### PR TITLE
feat(sentry): Derive network dynamically

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.47.3
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.3
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -32,7 +32,7 @@ jobs:
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.3
+          go-version: 1.18
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/cmd/sentry.go
+++ b/cmd/sentry.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethpandaops/xatu/pkg/sentry"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
+github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/pkg/sentry/ethereum/networks/network.go
+++ b/pkg/sentry/ethereum/networks/network.go
@@ -1,0 +1,63 @@
+package networks
+
+import "github.com/attestantio/go-eth2-client/spec/phase0"
+
+type NetworkName string
+
+var (
+	NetworkNameNone    NetworkName = "none"
+	NetworkNameUnknown NetworkName = "unknown"
+	NetworkNameMainnet NetworkName = "mainnet"
+	NetworkNameSepolia NetworkName = "sepolia"
+	NetworkNameGoerli  NetworkName = "goerli"
+)
+
+type NetworkIdentifierSlot struct {
+	NetworkName NetworkName
+	Slot        phase0.Slot
+	BlockRoot   string
+}
+
+var NetworkSlotBlockRoots = []NetworkIdentifierSlot{
+	{
+		NetworkName: NetworkNameMainnet,
+		Slot:        phase0.Slot(50),
+		BlockRoot:   "0x68937f266e8f339e3d605b00424446f8db835a4f2548636a906095babc5fb308",
+	},
+	{
+		NetworkName: NetworkNameSepolia,
+		Slot:        phase0.Slot(50),
+		BlockRoot:   "0x79bed901a63e22bb4dbed9330372bc399ea4d5faec87de916a80410135f3475c",
+	},
+	{
+		NetworkName: NetworkNameGoerli,
+		Slot:        phase0.Slot(50),
+		BlockRoot:   "0x93379731ee4c8e438a2c74c850e80fa7b2ccab4d9e25e6dc5567d3a33059b4d4",
+	},
+}
+
+func AllNetworkIdentifierSlots() []phase0.Slot {
+	// Deduplicate the slots.
+	slots := map[phase0.Slot]struct{}{}
+
+	for _, networkSlotBlockRoot := range NetworkSlotBlockRoots {
+		slots[networkSlotBlockRoot.Slot] = struct{}{}
+	}
+
+	slotsSlice := make([]phase0.Slot, 0, len(slots))
+	for slot, _ := range slots {
+		slotsSlice = append(slotsSlice, slot)
+	}
+
+	return slotsSlice
+}
+
+func DeriveNetworkName(slot phase0.Slot, blockRoot string) NetworkName {
+	for _, networkSlotBlockRoot := range NetworkSlotBlockRoots {
+		if networkSlotBlockRoot.Slot == slot && networkSlotBlockRoot.BlockRoot == blockRoot {
+			return networkSlotBlockRoot.NetworkName
+		}
+	}
+
+	return NetworkNameUnknown
+}

--- a/pkg/sentry/ethereum/networks/network.go
+++ b/pkg/sentry/ethereum/networks/network.go
@@ -45,7 +45,7 @@ func AllNetworkIdentifierSlots() []phase0.Slot {
 	}
 
 	slotsSlice := make([]phase0.Slot, 0, len(slots))
-	for slot, _ := range slots {
+	for slot := range slots {
 		slotsSlice = append(slotsSlice, slot)
 	}
 

--- a/pkg/sentry/ethereum/networks/network_test.go
+++ b/pkg/sentry/ethereum/networks/network_test.go
@@ -1,0 +1,37 @@
+package networks
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+func TestDeriveNetwork(t *testing.T) {
+	tests := []struct {
+		slot uint64
+		root string
+		want NetworkName
+	}{
+		{
+			slot: 50,
+			root: "0x68937f266e8f339e3d605b00424446f8db835a4f2548636a906095babc5fb308",
+			want: NetworkNameMainnet,
+		},
+		{
+			slot: 50,
+			root: "0x79bed901a63e22bb4dbed9330372bc399ea4d5faec87de916a80410135f3475c",
+			want: NetworkNameSepolia,
+		},
+		{
+			slot: 50,
+			root: "0x93379731ee4c8e438a2c74c850e80fa7b2ccab4d9e25e6dc5567d3a33059b4d4",
+			want: NetworkNameGoerli,
+		},
+	}
+
+	for _, test := range tests {
+		if got := DeriveNetworkName(phase0.Slot(test.slot), test.root); got != test.want {
+			t.Errorf("DeriveNetworkName(%d, %s) = %s, want %s", test.slot, test.root, got, test.want)
+		}
+	}
+}

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -141,10 +141,7 @@ func (s *Sentry) ServeMetrics(ctx context.Context) error {
 }
 
 func (s *Sentry) createNewClientMeta(ctx context.Context, topic xatu.ClientMeta_Event_Name) (*xatu.ClientMeta, error) {
-	network, err := s.beacon.Metadata().NetworkName()
-	if err != nil {
-		return nil, err
-	}
+	network := s.beacon.Metadata().NetworkName
 
 	return &xatu.ClientMeta{
 		Name:           s.Config.Name,
@@ -160,7 +157,7 @@ func (s *Sentry) createNewClientMeta(ctx context.Context, topic xatu.ClientMeta_
 
 		Ethereum: &xatu.ClientMeta_Ethereum{
 			Network: &xatu.ClientMeta_Ethereum_Network{
-				Name: network,
+				Name: string(network),
 				Id:   999, // TODO(sam.calder-mason): Derive dynamically
 			},
 			Execution: &xatu.ClientMeta_Ethereum_Execution{


### PR DESCRIPTION
Derives the network by using a hardcoded map of `slot -> block_root`. This obviously doesn't scale to testnets (those networks will be considered `unknown`), but it significantly improves the reliability of the network name. Previous we were using `spec.CONFIG_NAME`, but some clients don't provide this value, and others have inconsistent naming (i.e. Goerli/Prater is the same network with 2 configs now that they've merged).