### PR TITLE
fix(server): maxmind geoip country

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ server.yaml
 discovery.yaml
 mimicry.yaml
 dist
+GeoLite2-ASN.mmdb
+GeoLite2-City.mmdb

--- a/pkg/server/geoip/maxmind/database/city.go
+++ b/pkg/server/geoip/maxmind/database/city.go
@@ -16,12 +16,12 @@ type City struct {
 }
 
 type LookupCity struct {
-	RegisteredCountry struct {
+	Country struct {
 		ISOCode string `maxminddb:"iso_code"`
 		Names   struct {
 			EN string `maxminddb:"en"`
 		} `maxminddb:"names"`
-	} `maxminddb:"registered_country"`
+	} `maxminddb:"country"`
 	Continent struct {
 		Code string `maxminddb:"code"`
 	} `maxminddb:"continent"`

--- a/pkg/server/geoip/maxmind/maxmind.go
+++ b/pkg/server/geoip/maxmind/maxmind.go
@@ -83,8 +83,8 @@ func (m *Maxmind) LookupIP(ctx context.Context, ip net.IP) (*lookup.Result, erro
 
 		if city != nil {
 			result.CityName = city.City.Names.EN
-			result.CountryName = city.RegisteredCountry.Names.EN
-			result.CountryCode = city.RegisteredCountry.ISOCode
+			result.CountryName = city.Country.Names.EN
+			result.CountryCode = city.Country.ISOCode
 			result.ContinentCode = city.Continent.Code
 			result.Latitude = city.Location.Latitude
 			result.Longitude = city.Location.Longitude


### PR DESCRIPTION
Fix incorrect usage of `RegisteredCountry` over `Country` field https://dev.maxmind.com/geoip/whats-new-in-geoip2?lang=en#country-registered-country-and-represented-country