### PR TITLE
Add NewEventFilter and related tests for event filtering

### DIFF
--- a/pkg/proto/xatu/filter.go
+++ b/pkg/proto/xatu/filter.go
@@ -10,7 +10,7 @@ type EventFilter interface {
 	// EventNames returns the list of event names to filter on.
 	EventNames() []string
 
-	// Apply returns true if the event should be filtered.
+	// Apply returns filtered events.
 	Apply(events []*DecoratedEvent) ([]*DecoratedEvent, error)
 
 	// ShouldBeDropped returns true if the event should be dropped.

--- a/pkg/proto/xatu/filter.go
+++ b/pkg/proto/xatu/filter.go
@@ -1,0 +1,81 @@
+package xatu
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type EventFilter interface {
+	// EventNames returns the list of event names to filter on.
+	EventNames() []string
+
+	// Apply returns true if the event should be filtered.
+	Apply(events []*DecoratedEvent) ([]*DecoratedEvent, error)
+
+	// ShouldBeDropped returns true if the event should be dropped.
+	ShouldBeDropped(event *DecoratedEvent) (bool, error)
+}
+
+type EventFilterConfig struct {
+	EventNames []string `yaml:"eventNames"`
+}
+
+func (f *EventFilterConfig) Validate() error {
+	for _, eventName := range f.EventNames {
+		if _, ok := Event_Name_value[eventName]; !ok {
+			return fmt.Errorf("invalid event name: %s", eventName)
+		}
+	}
+
+	return nil
+}
+
+func NewEventFilter(config *EventFilterConfig) (EventFilter, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid event filter config")
+	}
+
+	eventNames := make(map[string]struct{}, len(config.EventNames))
+
+	for _, eventName := range config.EventNames {
+		eventNames[eventName] = struct{}{}
+	}
+
+	return &eventFilter{
+		eventNames: eventNames,
+	}, nil
+}
+
+type eventFilter struct {
+	config *EventFilterConfig
+
+	eventNames map[string]struct{}
+}
+
+func (f *eventFilter) EventNames() []string {
+	return f.config.EventNames
+}
+
+func (f *eventFilter) Apply(events []*DecoratedEvent) ([]*DecoratedEvent, error) {
+	filteredEvents := make([]*DecoratedEvent, 0, len(events))
+
+	for _, event := range events {
+		shouldBeDropped, err := f.ShouldBeDropped(event)
+		if err != nil {
+			return nil, err
+		}
+
+		if !shouldBeDropped {
+			filteredEvents = append(filteredEvents, event)
+		}
+	}
+
+	return filteredEvents, nil
+}
+
+func (f *eventFilter) ShouldBeDropped(event *DecoratedEvent) (bool, error) {
+	_, ok := f.eventNames[event.Event.Name.String()]
+
+	return !ok, nil
+}

--- a/pkg/proto/xatu/filter_test.go
+++ b/pkg/proto/xatu/filter_test.go
@@ -1,0 +1,79 @@
+package xatu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEventFilter(t *testing.T) {
+	testConfig := &EventFilterConfig{
+		EventNames: []string{},
+	}
+
+	filter, err := NewEventFilter(testConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotNil(t, filter)
+}
+
+func TestNewEventFilter_InvalidName(t *testing.T) {
+	testConfig := &EventFilterConfig{
+		EventNames: []string{"InvalidEventName"},
+	}
+
+	_, err := NewEventFilter(testConfig)
+
+	assert.Error(t, err)
+}
+
+func TestEventFilter_Apply(t *testing.T) {
+	testEvents := []*DecoratedEvent{{
+		Event: &Event{
+			Name: Event_BEACON_API_ETH_V1_DEBUG_FORK_CHOICE,
+		},
+	}, {
+		Event: &Event{
+			Name: Event_BEACON_API_ETH_V1_EVENTS_ATTESTATION,
+		},
+	}, {
+		Event: &Event{
+			Name: Event_BEACON_API_ETH_V1_EVENTS_BLOCK,
+		},
+	}}
+
+	testConfig := &EventFilterConfig{
+		EventNames: []string{Event_BEACON_API_ETH_V1_DEBUG_FORK_CHOICE.String()},
+	}
+	filter, _ := NewEventFilter(testConfig)
+
+	filteredEvents, err := filter.Apply(testEvents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, filteredEvents, 1)
+	assert.Equal(t, testEvents[0], filteredEvents[0])
+}
+
+func TestEventFilter_ShouldBeDropped(t *testing.T) {
+	testEvent := &DecoratedEvent{
+		Event: &Event{
+			Name: Event_BEACON_API_ETH_V1_DEBUG_FORK_CHOICE,
+		},
+	}
+
+	testConfig := &EventFilterConfig{
+		EventNames: []string{Event_BEACON_API_ETH_V1_EVENTS_FINALIZED_CHECKPOINT.String()},
+	}
+	filter, _ := NewEventFilter(testConfig)
+
+	shouldBeDropped, err := filter.ShouldBeDropped(testEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, shouldBeDropped)
+}


### PR DESCRIPTION
Adds an `EventFilter` interface, which can be used by our `outputs` to filter out events they don't care about.