### PR TITLE
feat(proto): Remove EventFilter.Apply() method

### DIFF
--- a/pkg/proto/xatu/filter.go
+++ b/pkg/proto/xatu/filter.go
@@ -10,9 +10,6 @@ type EventFilter interface {
 	// EventNames returns the list of event names to filter on.
 	EventNames() []string
 
-	// Apply returns filtered events.
-	Apply(events []*DecoratedEvent) ([]*DecoratedEvent, error)
-
 	// ShouldBeDropped returns true if the event should be dropped.
 	ShouldBeDropped(event *DecoratedEvent) (bool, error)
 }

--- a/pkg/proto/xatu/filter_test.go
+++ b/pkg/proto/xatu/filter_test.go
@@ -47,11 +47,23 @@ func TestEventFilter_Apply(t *testing.T) {
 	testConfig := &EventFilterConfig{
 		EventNames: []string{Event_BEACON_API_ETH_V1_DEBUG_FORK_CHOICE.String()},
 	}
-	filter, _ := NewEventFilter(testConfig)
 
-	filteredEvents, err := filter.Apply(testEvents)
+	filter, err := NewEventFilter(testConfig)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	filteredEvents := []*DecoratedEvent{}
+
+	for _, event := range testEvents {
+		shouldBeDropped, err := filter.ShouldBeDropped(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !shouldBeDropped {
+			filteredEvents = append(filteredEvents, event)
+		}
 	}
 
 	assert.Len(t, filteredEvents, 1)
@@ -90,11 +102,23 @@ func TestEventFilter_AllowEverythingWhenEmpty(t *testing.T) {
 	}
 
 	emptyConfig := &EventFilterConfig{}
-	filter, _ := NewEventFilter(emptyConfig)
 
-	filteredEvents, err := filter.Apply(events)
+	filter, err := NewEventFilter(emptyConfig)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	filteredEvents := []*DecoratedEvent{}
+
+	for _, event := range events {
+		shouldBeDropped, err := filter.ShouldBeDropped(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !shouldBeDropped {
+			filteredEvents = append(filteredEvents, event)
+		}
 	}
 
 	assert.Equal(t, events, filteredEvents)


### PR DESCRIPTION
Backported from https://github.com/ethpandaops/xatu/pull/108

Removes the `EventFilter.Apply()` method to simplify error handling when filtering multiple events, forcing the user of the filter to decide for themselves.