### PR TITLE
fix(sentry): Panic fix in wallclock

### DIFF
--- a/pkg/sentry/ethereum/services/duties.go
+++ b/pkg/sentry/ethereum/services/duties.go
@@ -104,17 +104,23 @@ func (m *DutiesService) Name() Name {
 	return "duties"
 }
 
-func (m *DutiesService) RequiredEpochDuties() []phase0.Epoch {
+func (m *DutiesService) RequiredEpochDuties(ctx context.Context) []phase0.Epoch {
 	now := m.metadata.Wallclock().Epochs().Current()
 
 	epochNumber := now.Number()
 
 	epochs := []phase0.Epoch{
-		phase0.Epoch(epochNumber - 3),
-		phase0.Epoch(epochNumber - 2),
-		phase0.Epoch(epochNumber - 1),
 		phase0.Epoch(epochNumber),
 		phase0.Epoch(epochNumber + 1),
+	}
+
+	// Lodestar does not support fetching beacon committees for older epochs.
+	if m.metadata.Client(ctx) != string(ClientLodestar) {
+		epochs = append(epochs,
+			phase0.Epoch(epochNumber-1),
+			phase0.Epoch(epochNumber-2),
+			phase0.Epoch(epochNumber-3),
+		)
 	}
 
 	final := map[phase0.Epoch]struct{}{}
@@ -133,7 +139,7 @@ func (m *DutiesService) RequiredEpochDuties() []phase0.Epoch {
 }
 
 func (m *DutiesService) Ready(ctx context.Context) error {
-	for _, epoch := range m.RequiredEpochDuties() {
+	for _, epoch := range m.RequiredEpochDuties(ctx) {
 		if duties := m.beaconCommittees.Get(epoch); duties == nil {
 			return fmt.Errorf("duties for epoch %d are not ready", epoch)
 		}
@@ -147,7 +153,7 @@ func (m *DutiesService) backFillEpochDuties(ctx context.Context) error {
 		return fmt.Errorf("metadata service is not ready")
 	}
 
-	for _, epoch := range m.RequiredEpochDuties() {
+	for _, epoch := range m.RequiredEpochDuties(ctx) {
 		if duties := m.beaconCommittees.Get(epoch); duties == nil {
 			if err := m.fetchBeaconCommittee(ctx, epoch); err != nil {
 				return err


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xfa8daa]

goroutine 55 [running]:
github.com/ethpandaops/ethwallclock.(*EthereumBeaconChain).OnEpochChanged(...)
	/home/runner/go/pkg/mod/github.com/ethpandaops/ethwallclock@v0.3.0/beacon_chain.go:92
github.com/ethpandaops/xatu/pkg/sentry/ethereum/services.(*DutiesService).Start(0xc000431960, {0x1775fe8?, 0xc000050018})
	/home/runner/work/xatu/xatu/pkg/sentry/ethereum/services/duties.go:78 +0x12a
github.com/ethpandaops/xatu/pkg/sentry/ethereum.(*BeaconNode).Start.func1()
	/home/runner/work/xatu/xatu/pkg/sentry/ethereum/beacon.go:77 +0x323
created by github.com/ethpandaops/xatu/pkg/sentry/ethereum.(*BeaconNode).Start
	/home/runner/work/xatu/xatu/pkg/sentry/ethereum/beacon.go:61 +0xf8
```