### PR TITLE
refactor(cannon): Lookahead 1 epoch

### DIFF
--- a/pkg/cannon/iterator/checkpoint_iterator.go
+++ b/pkg/cannon/iterator/checkpoint_iterator.go
@@ -129,7 +129,7 @@ func (c *CheckpointIterator) getLookAheads(ctx context.Context, location *xatu.C
 
 	lookAheads := make([]*xatu.CannonLocation, 0)
 
-	for _, i := range []int{1, 2, 3} {
+	for _, i := range []int{1} {
 		lookAheadEpoch := epoch + phase0.Epoch(i)
 
 		if lookAheadEpoch > latestCheckpoint.Epoch {


### PR DESCRIPTION
Doing this to reduce contention, will need a more well-thought-out solution longer term.