### PR TITLE
fix(cannon): Prevent checkpoint iterators going beyond head of chain

### DIFF
--- a/pkg/cannon/iterator/checkpoint_iterator.go
+++ b/pkg/cannon/iterator/checkpoint_iterator.go
@@ -82,7 +82,7 @@ func (c *CheckpointIterator) Next(ctx context.Context) (next *xatu.CannonLocatio
 
 		c.metrics.SetTrailingEpochs(c.cannonType.String(), c.networkName, c.checkpointName, float64(checkpoint.Epoch-locationEpoch))
 
-		if locationEpoch == checkpoint.Epoch {
+		if locationEpoch >= checkpoint.Epoch {
 			// Sleep until the next epoch
 			epoch := c.wallclock.Epochs().Current()
 


### PR DESCRIPTION
Fixes an issue where the slot default for a cannon type is greater than the finalized epoch. For example, Holesky starts Withdrawals/BLS changes at epoch 256, but epoch 256 hasn't been hit yet.