### PR TITLE
fix(sentry): Beacon commitee duties cache overriding

### DIFF
--- a/pkg/sentry/ethereum/services/duties.go
+++ b/pkg/sentry/ethereum/services/duties.go
@@ -99,6 +99,21 @@ func (m *DutiesService) Start(ctx context.Context) error {
 		return nil
 	})
 
+	m.beacon.OnSyncStatus(ctx, func(ctx context.Context, ev *beacon.SyncStatusEvent) error {
+		if ev.State.IsSyncing != m.lastSyncState {
+			if err := m.fetchRequiredEpochDuties(ctx, true); err != nil {
+				m.log.
+					WithError(err).
+					WithField("is_syncing", ev.State.IsSyncing).
+					Warn("Failed to fetch required epoch duties after a sync status change")
+			}
+		}
+
+		m.lastSyncState = ev.State.IsSyncing
+
+		return nil
+	})
+
 	go m.beaconCommittees.Start()
 
 	return nil

--- a/pkg/sentry/ethereum/services/duties.go
+++ b/pkg/sentry/ethereum/services/duties.go
@@ -202,7 +202,6 @@ func (m *DutiesService) fetchRequiredEpochDuties(ctx context.Context, overrideCa
 	}
 
 	for _, epoch := range m.RequiredEpochDuties(ctx) {
-		m.log.WithField("epoch", epoch).WithField("override_cache", overrideCache).Debug("Fetching required beacon committee")
 		if duties := m.beaconCommittees.Get(epoch); duties == nil || len(overrideCache) != 0 && overrideCache[0] {
 			if err := m.fetchBeaconCommittee(ctx, epoch, overrideCache...); err != nil {
 				return err
@@ -246,6 +245,8 @@ func (m *DutiesService) fetchBeaconCommittee(ctx context.Context, epoch phase0.E
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	m.log.WithField("epoch", epoch).WithField("override_cache", overrideCache).Debug("Fetching beacon committee")
 
 	committees, err := m.beacon.FetchBeaconCommittees(ctx, "head", epoch)
 	if err != nil {

--- a/pkg/sentry/ethereum/services/metadata.go
+++ b/pkg/sentry/ethereum/services/metadata.go
@@ -110,6 +110,10 @@ func (m *MetadataService) Ready(ctx context.Context) error {
 		return errors.New("network name is not available")
 	}
 
+	if m.wallclock == nil {
+		return errors.New("wallclock is not available")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Forcefully refreshes the "required" tier of beacon duties any time:
- a reorg happens
- the sync status of the beacon node changes
- a new epoch starts.