### PR TITLE
build(lint): update deprecated cfg + replace exportloopref w/ copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,8 @@ linters-settings:
       - performance
       - style
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   nolintlint:
     require-explanation: true
     require-specific: true
@@ -29,7 +30,7 @@ linters:
     - durationcheck
     - errcheck
     - errname
-    - exportloopref
+    - copyloopvar
     - goconst
     - gocritic
     - gocyclo


### PR DESCRIPTION
- `govet.check-shadowing` has been deprecated, in favour of [`enable.shadow`](https://golangci-lint.run/usage/linters/#govet). 
- `exportloopref` is a non-problem in Go 1.22 ([See docs](https://go.dev/blog/loopvar-preview)), adds [`copyloopvar`](https://golangci-lint.run/usage/linters/#copyloopvar) instead.