### PR TITLE
fix(xatu): updates orderby in migration for validator block

### DIFF
--- a/deploy/migrations/clickhouse/053_validator_block.up.sql
+++ b/deploy/migrations/clickhouse/053_validator_block.up.sql
@@ -49,10 +49,10 @@ CREATE TABLE default.beacon_api_eth_v3_validator_block_local ON CLUSTER '{cluste
 ) PARTITION BY toStartOfMonth(slot_start_date_time)
 ORDER BY
 (
-    event_date_time,
     slot_start_date_time,
     meta_network_name,
-    meta_client_name
+    meta_client_name,
+    event_date_time
 )
 COMMENT 'Contains beacon API /eth/v3/validator/blocks/{slot} data from each sentry client attached to a beacon node.';
 
@@ -62,9 +62,9 @@ CREATE TABLE default.beacon_api_eth_v3_validator_block ON CLUSTER '{cluster}' AS
     default,
     beacon_api_eth_v3_validator_block_local,
     cityHash64(
-        event_date_time,
         slot_start_date_time,
         meta_network_name,
-        meta_client_name
+        meta_client_name,
+        event_date_time
     )
 );

--- a/deploy/migrations/clickhouse/053_validator_block.up.sql
+++ b/deploy/migrations/clickhouse/053_validator_block.up.sql
@@ -49,6 +49,7 @@ CREATE TABLE default.beacon_api_eth_v3_validator_block_local ON CLUSTER '{cluste
 ) PARTITION BY toStartOfMonth(slot_start_date_time)
 ORDER BY
 (
+    event_date_time,
     slot_start_date_time,
     meta_network_name,
     meta_client_name
@@ -61,6 +62,7 @@ CREATE TABLE default.beacon_api_eth_v3_validator_block ON CLUSTER '{cluster}' AS
     default,
     beacon_api_eth_v3_validator_block_local,
     cityHash64(
+        event_date_time,
         slot_start_date_time,
         meta_network_name,
         meta_client_name


### PR DESCRIPTION
Ensure clickhouse doesn't squash records by slot.