### PR TITLE
fix(processor): Fix panic from nil items

### DIFF
--- a/pkg/mimicry/p2p/execution/event_transaction.go
+++ b/pkg/mimicry/p2p/execution/event_transaction.go
@@ -164,6 +164,7 @@ func (p *Peer) ExportTransactions(ctx context.Context, items []*TransactionHashI
 			if item == nil {
 				continue
 			}
+
 			exists := p.sharedCache.Transaction.Get(item.Hash.String())
 			if exists == nil {
 				hashes = append(hashes, item.Hash)

--- a/pkg/mimicry/p2p/execution/event_transaction.go
+++ b/pkg/mimicry/p2p/execution/event_transaction.go
@@ -158,6 +158,7 @@ func (p *Peer) ExportTransactions(ctx context.Context, items []*TransactionHashI
 
 	go func() {
 		var hashes []common.Hash
+
 		seenMap := make(map[common.Hash]time.Time, len(items))
 
 		for _, item := range items {

--- a/pkg/mimicry/p2p/execution/execution.go
+++ b/pkg/mimicry/p2p/execution/execution.go
@@ -119,6 +119,7 @@ func (p *Peer) Start(ctx context.Context) (<-chan error, error) {
 		// I think we can get away with much higher as long as it doesn't go above the
 		// max client message size.
 		processor.WithMaxExportBatchSize(50000),
+		processor.WithWorkers(1),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -234,6 +234,14 @@ func (bvp *BatchItemProcessor[T]) Write(ctx context.Context, s []*T) error {
 		prepared := []*TraceableItem[T]{}
 
 		for _, i := range s[start:end] {
+			if i == nil {
+				bvp.metrics.IncItemsDroppedBy(bvp.name, float64(1))
+
+				bvp.log.Warnf("Attempted to write a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
+
+				continue
+			}
+
 			item := &TraceableItem[T]{
 				item: i,
 			}
@@ -284,8 +292,18 @@ func (bvp *BatchItemProcessor[T]) exportWithTimeout(ctx context.Context, itemsBa
 		defer cancel()
 	}
 
+	// Since the batch processor filters out nil items upstream,
+	// we can optimize by pre-allocating the full slice size.
+	// Worst case is a few wasted allocations if any nil items slip through.
 	items := make([]*T, len(itemsBatch))
+
 	for i, item := range itemsBatch {
+		if item == nil {
+			bvp.log.Warnf("Attempted to export a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
+
+			continue
+		}
+
 		items[i] = item.item
 	}
 
@@ -298,10 +316,10 @@ func (bvp *BatchItemProcessor[T]) exportWithTimeout(ctx context.Context, itemsBa
 	bvp.metrics.ObserveExportDuration(bvp.name, duration)
 
 	if err != nil {
-		bvp.metrics.IncItemsFailedBy(bvp.name, float64(len(itemsBatch)))
+		bvp.metrics.IncItemsFailedBy(bvp.name, float64(len(items)))
 	} else {
-		bvp.metrics.IncItemsExportedBy(bvp.name, float64(len(itemsBatch)))
-		bvp.metrics.ObserveBatchSize(bvp.name, float64(len(itemsBatch)))
+		bvp.metrics.IncItemsExportedBy(bvp.name, float64(len(items)))
+		bvp.metrics.ObserveBatchSize(bvp.name, float64(len(items)))
 	}
 
 	for _, item := range itemsBatch {
@@ -427,6 +445,14 @@ func (bvp *BatchItemProcessor[T]) batchBuilder(ctx context.Context) {
 
 			return
 		case item := <-bvp.queue:
+			if item == nil {
+				bvp.metrics.IncItemsDroppedBy(bvp.name, float64(1))
+
+				bvp.log.Warnf("Attempted to build a batch with a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
+
+				continue
+			}
+
 			batch = append(batch, item)
 
 			if len(batch) >= bvp.o.MaxExportBatchSize {

--- a/pkg/processor/batch_test.go
+++ b/pkg/processor/batch_test.go
@@ -190,9 +190,11 @@ func TestAsyncNewBatchItemProcessorWithOptions(t *testing.T) {
 					time.Sleep(10 * time.Millisecond)
 				}
 
-				if err := ssp.Write(context.Background(), []*TestItem{{
-					name: "test",
-				}}); err != nil {
+				item := TestItem{
+					name: "test" + strconv.Itoa(i),
+				}
+
+				if err := ssp.Write(context.Background(), []*TestItem{&item}); err != nil {
 					t.Errorf("%s: Error writing to BatchItemProcessor", option.name)
 				}
 			}
@@ -788,7 +790,6 @@ func TestBatchItemProcessorQueueSize(t *testing.T) {
 func TestBatchItemProcessorNilItem(t *testing.T) {
 	te := testBatchExporter[TestItem]{}
 
-	metrics := NewMetrics("test")
 	bsp, err := NewBatchItemProcessor[TestItem](
 		&te,
 		"processor",
@@ -798,7 +799,6 @@ func TestBatchItemProcessorNilItem(t *testing.T) {
 		WithMaxExportBatchSize(5),
 		WithWorkers(1),
 		WithShippingMethod(ShippingMethodSync),
-		WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
@@ -821,7 +821,6 @@ func TestBatchItemProcessorNilItem(t *testing.T) {
 }
 
 func TestBatchItemProcessorNilExporter(t *testing.T) {
-	metrics := NewMetrics("test")
 	bsp, err := NewBatchItemProcessor[TestItem](
 		nil,
 		"processor",
@@ -831,7 +830,6 @@ func TestBatchItemProcessorNilExporter(t *testing.T) {
 		WithMaxExportBatchSize(5),
 		WithWorkers(1),
 		WithShippingMethod(ShippingMethodSync),
-		WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
@@ -843,7 +841,6 @@ func TestBatchItemProcessorNilExporter(t *testing.T) {
 }
 
 func TestBatchItemProcessorNilExporterAfterProcessing(t *testing.T) {
-	metrics := NewMetrics("test")
 	exporter := &testBatchExporter[TestItem]{}
 	bsp, err := NewBatchItemProcessor[TestItem](
 		exporter,
@@ -854,7 +851,6 @@ func TestBatchItemProcessorNilExporterAfterProcessing(t *testing.T) {
 		WithMaxExportBatchSize(5),
 		WithWorkers(1),
 		WithShippingMethod(ShippingMethodAsync),
-		WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 
@@ -882,7 +878,6 @@ func TestBatchItemProcessorNilExporterAfterProcessing(t *testing.T) {
 }
 
 func TestBatchItemProcessorNilItemAfterQueue(t *testing.T) {
-	metrics := NewMetrics("test")
 	exporter := &testBatchExporter[TestItem]{}
 	bsp, err := NewBatchItemProcessor[TestItem](
 		exporter,
@@ -893,7 +888,6 @@ func TestBatchItemProcessorNilItemAfterQueue(t *testing.T) {
 		WithMaxExportBatchSize(5),
 		WithWorkers(1),
 		WithShippingMethod(ShippingMethodAsync),
-		WithMetrics(metrics),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1c796c1]

goroutine 11986827 [running]:
github.com/ethpandaops/xatu/pkg/processor.(*BatchItemProcessor[...]).exportWithTimeout(0x2d54940, {0x2d22720, 0x43ecfe0}, {0xc006974000, 0xc350, 0x0})
	/workspace/pkg/processor/batch.go:289 +0x4a1
github.com/ethpandaops/xatu/pkg/processor.(*BatchItemProcessor[...]).worker(0x2d54940, {0x2d22720, 0x43ecfe0}, 0x2)
	/workspace/pkg/processor/batch.go:468 +0x154
github.com/ethpandaops/xatu/pkg/processor.(*BatchItemProcessor[...]).Start.func1()
	/workspace/pkg/processor/batch.go:200 +0x6c
created by github.com/ethpandaops/xatu/pkg/processor.(*BatchItemProcessor[...]).Start in goroutine 11857871
	/workspace/pkg/processor/batch.go:198 +0x134