### PR TITLE
refactor(xatu): allow setting metrics addr via cli flag

### DIFF
--- a/cmd/cannon.go
+++ b/cmd/cannon.go
@@ -99,6 +99,15 @@ var CannonOverrides = []CannonOverride{
 			overrides.NetworkName.Value = val
 		},
 	}),
+	createCannonOverride(CannonOverrideConfig{
+		FlagName:    "metrics-addr",
+		EnvName:     "METRICS_ADDR",
+		Description: "sets the metrics address",
+		OverrideFunc: func(val string, overrides *cannon.Override) {
+			overrides.MetricsAddr.Enabled = true
+			overrides.MetricsAddr.Value = val
+		},
+	}),
 }
 
 // cannonCmd represents the cannon command
@@ -120,7 +129,6 @@ var cannonCmd = &cobra.Command{
 		log.WithField("location", cannonCfgFile).Info("Loaded config")
 
 		overrides := &cannon.Override{}
-
 		for _, override := range CannonOverrides {
 			if errr := override.Setter(cmd, overrides); errr != nil {
 				log.Fatal(errr)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@ var (
 
 	defaultLogLevel  = "info"
 	defaultLogFormat = "text"
+
+	metricsAddrFlag = "metrics-addr"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,6 +77,15 @@ var ServerOverrides = []ServerOverride{
 			overrides.CoordinatorAuth.AuthSecret = val
 		},
 	}),
+	createServerOverride(ServerOverrideConfig{
+		FlagName:    "metrics-addr",
+		EnvName:     "METRICS_ADDR",
+		Description: "sets the metrics address",
+		OverrideFunc: func(val string, overrides *server.Override) {
+			overrides.MetricsAddr.Enabled = true
+			overrides.MetricsAddr.Value = val
+		},
+	}),
 }
 
 // serverCmd represents the server command

--- a/pkg/cannon/config.go
+++ b/pkg/cannon/config.go
@@ -129,5 +129,11 @@ func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
 		c.Ethereum.OverrideNetworkName = o.NetworkName.Value
 	}
 
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
+	}
+
 	return nil
 }

--- a/pkg/cannon/overrides.go
+++ b/pkg/cannon/overrides.go
@@ -1,6 +1,10 @@
 package cannon
 
 type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
 	BeaconNodeURL struct {
 		Enabled bool
 		Value   string

--- a/pkg/clmimicry/config.go
+++ b/pkg/clmimicry/config.go
@@ -154,3 +154,18 @@ type EventConfig struct {
 func (e *EventConfig) Validate() error {
 	return nil
 }
+
+// ApplyOverrides applies any overrides to the config.
+func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
+	if o == nil {
+		return nil
+	}
+
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
+	}
+
+	return nil
+}

--- a/pkg/clmimicry/mimicry.go
+++ b/pkg/clmimicry/mimicry.go
@@ -55,13 +55,19 @@ type Mimicry struct {
 	ethereum *ethereum.BeaconNode
 }
 
-func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*Mimicry, error) {
+func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides *Override) (*Mimicry, error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
 
 	if err := config.Validate(); err != nil {
 		return nil, err
+	}
+
+	if overrides != nil {
+		if err := config.ApplyOverrides(overrides, log); err != nil {
+			return nil, fmt.Errorf("failed to apply overrides: %w", err)
+		}
 	}
 
 	sinks, err := config.CreateSinks(log)

--- a/pkg/clmimicry/overrides.go
+++ b/pkg/clmimicry/overrides.go
@@ -1,0 +1,9 @@
+package clmimicry
+
+// Override is the set of overrides for the cl-mimicry command.
+type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
+}

--- a/pkg/discovery/config.go
+++ b/pkg/discovery/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethpandaops/xatu/pkg/discovery/coordinator"
 	"github.com/ethpandaops/xatu/pkg/discovery/p2p"
+	"github.com/sirupsen/logrus"
 )
 
 type Config struct {
@@ -26,6 +27,21 @@ func (c *Config) Validate() error {
 
 	if err := c.Coordinator.Validate(); err != nil {
 		return fmt.Errorf("coordinator config error: %w", err)
+	}
+
+	return nil
+}
+
+// ApplyOverrides applies any overrides to the config.
+func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
+	if o == nil {
+		return nil
+	}
+
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
 	}
 
 	return nil

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -42,13 +42,19 @@ type Discovery struct {
 	metrics *Metrics
 }
 
-func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*Discovery, error) {
+func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides *Override) (*Discovery, error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
 
 	if err := config.Validate(); err != nil {
 		return nil, err
+	}
+
+	if overrides != nil {
+		if err := config.ApplyOverrides(overrides, log); err != nil {
+			return nil, fmt.Errorf("failed to apply overrides: %w", err)
+		}
 	}
 
 	client, err := coordinator.New(&config.Coordinator, log)

--- a/pkg/discovery/overrides.go
+++ b/pkg/discovery/overrides.go
@@ -1,0 +1,9 @@
+package discovery
+
+// Override is the set of overrides for the discovery command.
+type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
+}

--- a/pkg/mimicry/config.go
+++ b/pkg/mimicry/config.go
@@ -80,3 +80,18 @@ func (c *Config) CreateSinks(log logrus.FieldLogger) ([]output.Sink, error) {
 
 	return sinks, nil
 }
+
+// ApplyOverrides applies any overrides to the config.
+func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
+	if o == nil {
+		return nil
+	}
+
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
+	}
+
+	return nil
+}

--- a/pkg/mimicry/mimicry.go
+++ b/pkg/mimicry/mimicry.go
@@ -43,13 +43,19 @@ type Mimicry struct {
 	startupTime time.Time
 }
 
-func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*Mimicry, error) {
+func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides *Override) (*Mimicry, error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
 
 	if err := config.Validate(); err != nil {
 		return nil, err
+	}
+
+	if overrides != nil {
+		if err := config.ApplyOverrides(overrides, log); err != nil {
+			return nil, fmt.Errorf("failed to apply overrides: %w", err)
+		}
 	}
 
 	sinks, err := config.CreateSinks(log)

--- a/pkg/mimicry/overrides.go
+++ b/pkg/mimicry/overrides.go
@@ -1,0 +1,9 @@
+package mimicry
+
+// Override is the set of overrides for the mimicry command.
+type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
+}

--- a/pkg/relaymonitor/config.go
+++ b/pkg/relaymonitor/config.go
@@ -107,3 +107,18 @@ func (c *Config) CreateSinks(log logrus.FieldLogger) ([]output.Sink, error) {
 
 	return sinks, nil
 }
+
+// ApplyOverrides applies any overrides to the config.
+func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
+	if o == nil {
+		return nil
+	}
+
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
+	}
+
+	return nil
+}

--- a/pkg/relaymonitor/overrides.go
+++ b/pkg/relaymonitor/overrides.go
@@ -1,0 +1,9 @@
+package relaymonitor
+
+// Override is the set of overrides for the relay monitor command.
+type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
+}

--- a/pkg/relaymonitor/relay_monitor.go
+++ b/pkg/relaymonitor/relay_monitor.go
@@ -51,13 +51,19 @@ const (
 	namespace = "xatu_relay_monitor"
 )
 
-func New(ctx context.Context, log logrus.FieldLogger, config *Config) (*RelayMonitor, error) {
+func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides *Override) (*RelayMonitor, error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
 
 	if err := config.Validate(); err != nil {
 		return nil, err
+	}
+
+	if overrides != nil {
+		if err := config.ApplyOverrides(overrides, log); err != nil {
+			return nil, fmt.Errorf("failed to apply overrides: %w", err)
+		}
 	}
 
 	sinks, err := config.CreateSinks(log)

--- a/pkg/sentry/overrides.go
+++ b/pkg/sentry/overrides.go
@@ -1,6 +1,10 @@
 package sentry
 
 type Override struct {
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
 	BeaconNodeURL struct {
 		Enabled bool
 		Value   string

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
 	//nolint:gosec // only exposed if pprofAddr config is set
 	_ "net/http/pprof"
 	"os"
@@ -106,6 +107,13 @@ func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides 
 		log.Info("Overriding beacon node URL")
 
 		config.Ethereum.BeaconNodeAddress = overrides.BeaconNodeURL.Value
+	}
+
+	// If the metrics address override is set, use it
+	if overrides.MetricsAddr.Enabled {
+		log.WithField("address", overrides.MetricsAddr.Value).Info("Overriding metrics address")
+
+		config.MetricsAddr = overrides.MetricsAddr.Value
 	}
 
 	if err := config.Validate(); err != nil {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -111,5 +111,11 @@ func (c *Config) ApplyOverrides(o *Override, log logrus.FieldLogger) error {
 		c.Services.Coordinator.Auth.Secret = o.CoordinatorAuth.AuthSecret
 	}
 
+	if o.MetricsAddr.Enabled {
+		log.WithField("address", o.MetricsAddr.Value).Info("Overriding metrics address")
+
+		c.MetricsAddr = o.MetricsAddr.Value
+	}
+
 	return nil
 }

--- a/pkg/server/overrides.go
+++ b/pkg/server/overrides.go
@@ -1,6 +1,11 @@
 package server
 
 type Override struct {
+	// MetricsAddr configures the metrics address.
+	MetricsAddr struct {
+		Enabled bool
+		Value   string
+	}
 	// EventIngesterBasicAuth configures basic authentication for the event ingester.
 	EventIngesterBasicAuth struct {
 		Username string


### PR DESCRIPTION
Allows setting `--metrics-addr=:XXXX` via cli flag for the following Xatu pkgs...

- `cannon`
- `cl-mimicry`
- `discovery`
- `mimicry`
- `relay-monitor`
- `sentry`
- `server`

Takes precedence over any `metricsAddr` set in config.

<details>
  <summary>Example (without flag)</summary>
  
  ```bash
go run main.go sentry                                                                                                                                                            
...
INFO[0000] Serving metrics at :9090                      module=sentry
  ```

</details>

<details>
  <summary>Example (with flag)</summary>
  
  ```bash
go run main.go sentry --metrics-addr=:8765                                                                                                                                                            
...
INFO[0000] Overriding metrics address                    address=":8765" module=sentry
INFO[0000] Serving metrics at :8765                      module=sentry
  ```

</details>