### PR TITLE
fix(observability): bump otel schema

### DIFF
--- a/pkg/observability/tracing.go
+++ b/pkg/observability/tracing.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	otrace "go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
**Fixes:** 

```
INFO[0000] Logger initialized                            fields.level=debug
...
INFO[0000] Tracing enabled                               module=sentry
FATA[0000] failed to create tracing resource: conflicting Schema URL: https://opentelemetry.io/schemas/1.26.0 and https://opentelemetry.io/schemas/1.24.0
exit status 1
```

Otel deps where bumped as part of https://github.com/ethpandaops/xatu/pull/410