### PR TITLE
refactor(processor): improve batch processor shutdown and channel handling

### DIFF
--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -448,7 +448,8 @@ func (bvp *BatchItemProcessor[T]) batchBuilder(ctx context.Context) {
 			return
 		case item, ok := <-bvp.queue:
 			if !ok {
-				// Channel is closed
+				// Channel is closed, send any remaining items in the batch for processing
+				// before shutting down.
 				if len(batch) > 0 {
 					bvp.sendBatch(batch, "shutdown")
 				}
@@ -458,7 +459,7 @@ func (bvp *BatchItemProcessor[T]) batchBuilder(ctx context.Context) {
 
 			if item == nil {
 				bvp.metrics.IncItemsDroppedBy(bvp.name, float64(1))
-				bvp.log.Warnf("Attempted to build a batch with a nil item...")
+				bvp.log.Warnf("Attempted to build a batch with a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
 				continue
 			}
 
@@ -516,6 +517,8 @@ func (bvp *BatchItemProcessor[T]) drainQueue() {
 	for len(bvp.queue) > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
+
+	bvp.log.Info("Draining queue: waiting for workers to finish processing batches")
 
 	// Then wait for any in-flight batches
 	for len(bvp.batchCh) > 0 {

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -439,21 +439,26 @@ func (bvp *BatchItemProcessor[T]) waitForBatchCompletion(ctx context.Context, it
 
 func (bvp *BatchItemProcessor[T]) batchBuilder(ctx context.Context) {
 	log := bvp.log.WithField("module", "batch_builder")
-
 	var batch []*TraceableItem[T]
 
 	for {
 		select {
 		case <-bvp.stopWorkersCh:
 			log.Info("Stopping batch builder")
-
 			return
-		case item := <-bvp.queue:
+		case item, ok := <-bvp.queue:
+			if !ok {
+				// Channel is closed
+				if len(batch) > 0 {
+					bvp.sendBatch(batch, "shutdown")
+				}
+
+				return
+			}
+
 			if item == nil {
 				bvp.metrics.IncItemsDroppedBy(bvp.name, float64(1))
-
-				bvp.log.Warnf("Attempted to build a batch with a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
-
+				bvp.log.Warnf("Attempted to build a batch with a nil item...")
 				continue
 			}
 
@@ -505,19 +510,19 @@ func (bvp *BatchItemProcessor[T]) worker(ctx context.Context, number int) {
 }
 
 func (bvp *BatchItemProcessor[T]) drainQueue() {
-	bvp.log.Info("Draining queue: waiting for the batch builder to pull all the items from the queue")
+	bvp.log.Info("Draining queue: waiting for the batch builder to process remaining items")
 
+	// First wait for queue to be processed
 	for len(bvp.queue) > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	bvp.log.Info("Draining queue: waiting for workers to finish processing batches")
-
-	for len(bvp.queue) > 0 {
-		<-bvp.queue
+	// Then wait for any in-flight batches
+	for len(bvp.batchCh) > 0 {
+		time.Sleep(10 * time.Millisecond)
 	}
 
-	bvp.log.Info("Draining queue: all batches finished")
+	bvp.log.Info("Draining queue: all items processed")
 
 	close(bvp.queue)
 }


### PR DESCRIPTION
In an attempt to resolve `nil` items being run through the batch processor...

```
WARN[0250] Attempted to build a batch with a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.  node_record="enode://xx@xx:xx"
```

... this PR:

- Refactors channel closure in the batch builder to handle shutdown gracefully
- Improve queue draining sequence to prevent race conditions during shutdown
- Wait for in-flight batches to complete before closing channels
