### PR TITLE
ci(actions): bumps multiple actions versions

### DIFF
--- a/.github/workflows/alpha-releases.yaml
+++ b/.github/workflows/alpha-releases.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}

--- a/.github/workflows/cannon-smoke-test.yaml
+++ b/.github/workflows/cannon-smoke-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v3
     #   with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,10 +15,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -14,7 +14,7 @@ jobs:
       - size-l-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
@@ -36,10 +36,10 @@ jobs:
           echo "Release suffix: $RELEASE_SUFFIX"
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         name: Set up Node
         with:
           node-version: 18
@@ -50,18 +50,18 @@ jobs:
       - name: Install make
         run: sudo apt-get -y install make
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Context for Buildx
         shell: bash
         id: buildx-context
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/sentry-smoke-test.yaml
+++ b/.github/workflows/sentry-smoke-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build xatu image
       run: |
         docker build -t ethpandaops/xatu:local .

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.23'
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         name: Set up Node
         with:
           node-version: 18

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.23'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
         name: Set up Node
         with:
           node-version: 18
@@ -30,14 +30,14 @@ jobs:
       - name: Install make
         run: sudo apt-get -y install make
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Context for Buildx
         shell: bash
         id: buildx-context
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
       - name: Run GoReleaser in Docker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
         


### PR DESCRIPTION
- actions/checkout@v3 -> actions/checkout@v4
- actions/setup-go@v4 -> actions/setup-go@v5
- actions/setup-node@v3 -> actions/setup-node@v4
- docker/setup-qemu-action@v2 -> docker/setup-qemu-action@v3
- docker/setup-buildx-action@v2 -> docker/setup-buildx-action@v3
- docker/login-action@v2 -> docker/login-action@v3

Closes: https://github.com/ethpandaops/xatu/pull/389, https://github.com/ethpandaops/xatu/pull/361, https://github.com/ethpandaops/xatu/pull/263, https://github.com/ethpandaops/xatu/pull/249, https://github.com/ethpandaops/xatu/pull/233, https://github.com/ethpandaops/xatu/pull/232, https://github.com/ethpandaops/xatu/pull/231, https://github.com/ethpandaops/xatu/pull/230