### PR TITLE
refactor(xatu): bumps cenkalti/backoff to v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.out
 sentry.yaml
 server.yaml
 discovery.yaml

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/attestantio/go-eth2-client v0.24.0
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/beevik/ntp v1.3.1
-	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/creasty/defaults v1.7.0
 	github.com/ethereum/go-ethereum v1.15.0
@@ -67,6 +67,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/consensys/bavard v0.1.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v1.1.1 h1:nCb6ZLdB7NRaqsm91JtQTAme2SKJzXVsdPIPkyJr1MU=
 github.com/cespare/cp v1.1.1/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=

--- a/pkg/cannon/deriver/beacon/eth/v1/beacon_blob.go
+++ b/pkg/cannon/deriver/beacon/eth/v1/beacon_blob.go
@@ -10,7 +10,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -108,7 +108,7 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := tracer.Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -122,7 +122,7 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 				if err := b.beacon.Synced(ctx); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				span.AddEvent("Grabbing next location")
@@ -132,7 +132,7 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 				if err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -142,7 +142,7 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Send the events
@@ -150,7 +150,7 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 					if err := fn(ctx, events); err != nil {
 						span.SetStatus(codes.Error, err.Error())
 
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
@@ -158,17 +158,22 @@ func (b *BeaconBlobDeriver) run(rctx context.Context) {
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v1/beacon_committee.go
+++ b/pkg/cannon/deriver/beacon/eth/v1/beacon_committee.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -106,7 +106,7 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := tracer.Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -118,7 +118,7 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 				if err := b.beacon.Synced(ctx); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Get the next position.
@@ -126,7 +126,7 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 				if err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -135,7 +135,7 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 					b.log.WithError(err).Error("Failed to process epoch")
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -146,7 +146,7 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 					if err := fn(ctx, events); err != nil {
 						span.SetStatus(codes.Error, err.Error())
 
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
@@ -154,17 +154,22 @@ func (b *BeaconCommitteeDeriver) run(rctx context.Context) {
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v1/proposer_duty.go
+++ b/pkg/cannon/deriver/beacon/eth/v1/proposer_duty.go
@@ -9,7 +9,7 @@ import (
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -107,7 +107,7 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := tracer.Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -119,7 +119,7 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 				if err := b.beacon.Synced(ctx); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Get the next position.
@@ -127,7 +127,7 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 				if err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -137,7 +137,7 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -148,7 +148,7 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 					if err := fn(ctx, events); err != nil {
 						span.SetStatus(codes.Error, err.Error())
 
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
@@ -156,17 +156,22 @@ func (b *ProposerDutyDeriver) run(rctx context.Context) {
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/bls_to_execution_change.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/bls_to_execution_change.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -104,7 +104,7 @@ func (b *BLSToExecutionChangeDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := observability.Tracer().Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -114,13 +114,13 @@ func (b *BLSToExecutionChangeDeriver) run(rctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 
 				if err := b.beacon.Synced(ctx); err != nil {
-					return err
+					return "", err
 				}
 
 				// Get the next position
 				position, err := b.iterator.Next(ctx)
 				if err != nil {
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -128,7 +128,7 @@ func (b *BLSToExecutionChangeDeriver) run(rctx context.Context) {
 				if err != nil {
 					b.log.WithError(err).Error("Failed to process epoch")
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -137,23 +137,28 @@ func (b *BLSToExecutionChangeDeriver) run(rctx context.Context) {
 				// Send the events
 				for _, fn := range b.onEventsCallbacks {
 					if err := fn(ctx, events); err != nil {
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
 				// Update our location
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/deposit.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/deposit.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -102,7 +102,7 @@ func (b *DepositDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := observability.Tracer().Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -112,13 +112,13 @@ func (b *DepositDeriver) run(rctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 
 				if err := b.beacon.Synced(ctx); err != nil {
-					return err
+					return "", err
 				}
 
 				// Get the next position
 				position, err := b.iterator.Next(ctx)
 				if err != nil {
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -126,7 +126,7 @@ func (b *DepositDeriver) run(rctx context.Context) {
 				if err != nil {
 					b.log.WithError(err).Error("Failed to process epoch")
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -135,23 +135,28 @@ func (b *DepositDeriver) run(rctx context.Context) {
 				// Send the events
 				for _, fn := range b.onEventsCallbacks {
 					if err := fn(ctx, events); err != nil {
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
 				// Update our location
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/elaborated_attestation.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/elaborated_attestation.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -105,7 +105,7 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := tracer.Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -117,7 +117,7 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 				if err := b.beacon.Synced(ctx); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Get the next position.
@@ -125,7 +125,7 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 				if err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -135,7 +135,7 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -146,7 +146,7 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 					if err := fn(ctx, events); err != nil {
 						span.SetStatus(codes.Error, err.Error())
 
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
@@ -154,17 +154,22 @@ func (b *ElaboratedAttestationDeriver) run(rctx context.Context) {
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
 					span.SetStatus(codes.Error, err.Error())
 
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/execution_transaction.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/execution_transaction.go
@@ -11,7 +11,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
@@ -107,7 +107,7 @@ func (b *ExecutionTransactionDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := observability.Tracer().Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -117,13 +117,13 @@ func (b *ExecutionTransactionDeriver) run(rctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 
 				if err := b.beacon.Synced(ctx); err != nil {
-					return err
+					return "", err
 				}
 
 				// Get the next position
 				position, err := b.iterator.Next(ctx)
 				if err != nil {
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -131,7 +131,7 @@ func (b *ExecutionTransactionDeriver) run(rctx context.Context) {
 				if err != nil {
 					b.log.WithError(err).Error("Failed to process epoch")
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -140,23 +140,28 @@ func (b *ExecutionTransactionDeriver) run(rctx context.Context) {
 				// Send the events
 				for _, fn := range b.onEventsCallbacks {
 					if err := fn(ctx, events); err != nil {
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
 				// Update our location
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/voluntary_exit.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/voluntary_exit.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -102,7 +102,7 @@ func (b *VoluntaryExitDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := observability.Tracer().Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -112,13 +112,13 @@ func (b *VoluntaryExitDeriver) run(rctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 
 				if err := b.beacon.Synced(ctx); err != nil {
-					return err
+					return "", err
 				}
 
 				// Get the next position
 				position, err := b.iterator.Next(ctx)
 				if err != nil {
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -126,7 +126,7 @@ func (b *VoluntaryExitDeriver) run(rctx context.Context) {
 				if err != nil {
 					b.log.WithError(err).Error("Failed to process epoch")
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -135,23 +135,27 @@ func (b *VoluntaryExitDeriver) run(rctx context.Context) {
 				// Send the events
 				for _, fn := range b.onEventsCallbacks {
 					if err := fn(ctx, events); err != nil {
-						return errors.Wrap(err, "failed to send events")
+						return "", errors.Wrap(err, "failed to send events")
 					}
 				}
 
 				// Update our location
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/deriver/beacon/eth/v2/withdrawal.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/withdrawal.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -102,7 +102,7 @@ func (b *WithdrawalDeriver) run(rctx context.Context) {
 		case <-rctx.Done():
 			return
 		default:
-			operation := func() error {
+			operation := func() (string, error) {
 				ctx, span := observability.Tracer().Start(rctx, fmt.Sprintf("Derive %s", b.Name()),
 					trace.WithAttributes(
 						attribute.String("network", string(b.beacon.Metadata().Network.Name))),
@@ -112,13 +112,13 @@ func (b *WithdrawalDeriver) run(rctx context.Context) {
 				time.Sleep(100 * time.Millisecond)
 
 				if err := b.beacon.Synced(ctx); err != nil {
-					return err
+					return "", err
 				}
 
 				// Get the next position
 				position, err := b.iterator.Next(ctx)
 				if err != nil {
-					return err
+					return "", err
 				}
 
 				// Process the epoch
@@ -126,7 +126,7 @@ func (b *WithdrawalDeriver) run(rctx context.Context) {
 				if err != nil {
 					b.log.WithError(err).Error("Failed to process epoch")
 
-					return err
+					return "", err
 				}
 
 				// Look ahead
@@ -134,23 +134,28 @@ func (b *WithdrawalDeriver) run(rctx context.Context) {
 
 				for _, fn := range b.onEventsCallbacks {
 					if errr := fn(ctx, events); errr != nil {
-						return errors.Wrapf(errr, "failed to send events")
+						return "", errors.Wrapf(errr, "failed to send events")
 					}
 				}
 
 				// Update our location
 				if err := b.iterator.UpdateLocation(ctx, position.Next, position.Direction); err != nil {
-					return err
+					return "", err
 				}
 
 				bo.Reset()
 
-				return nil
+				return "", nil
 			}
 
-			if err := backoff.RetryNotify(operation, bo, func(err error, timer time.Duration) {
-				b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
-			}); err != nil {
+			retryOpts := []backoff.RetryOption{
+				backoff.WithBackOff(bo),
+				backoff.WithNotify(func(err error, timer time.Duration) {
+					b.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to process")
+				}),
+			}
+
+			if _, err := backoff.Retry(rctx, operation, retryOpts...); err != nil {
 				b.log.WithError(err).Warn("Failed to process")
 			}
 		}

--- a/pkg/cannon/ethereum/services/metadata.go
+++ b/pkg/cannon/ethereum/services/metadata.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/beacon/pkg/beacon"
 	"github.com/ethpandaops/beacon/pkg/beacon/state"
 	"github.com/ethpandaops/ethwallclock"
@@ -53,19 +53,26 @@ func (m *MetadataService) OverrideNetworkName(name string) {
 
 func (m *MetadataService) Start(ctx context.Context) error {
 	go func() {
-		operation := func() error {
+		operation := func() (string, error) {
 			if err := m.RefreshAll(ctx); err != nil {
-				return err
+				return "", err
 			}
 
 			if err := m.Ready(ctx); err != nil {
-				return err
+				return "", err
 			}
 
-			return nil
+			return "", nil
 		}
 
-		if err := backoff.Retry(operation, backoff.NewExponentialBackOff()); err != nil {
+		retryOpts := []backoff.RetryOption{
+			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithNotify(func(err error, timer time.Duration) {
+				m.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to refresh metadata")
+			}),
+		}
+
+		if _, err := backoff.Retry(ctx, operation, retryOpts...); err != nil {
 			m.log.WithError(err).Warn("Failed to refresh metadata")
 		}
 

--- a/pkg/clmimicry/ethereum/services/duties.go
+++ b/pkg/clmimicry/ethereum/services/duties.go
@@ -8,7 +8,7 @@ import (
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	backoff "github.com/cenkalti/backoff/v4"
+	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/ethpandaops/beacon/pkg/beacon"
 	"github.com/ethpandaops/ethwallclock"
 	"github.com/jellydator/ttlcache/v3"
@@ -65,28 +65,35 @@ func NewDutiesService(log logrus.FieldLogger, sbeacon beacon.Node, metadata *Met
 
 func (m *DutiesService) Start(ctx context.Context) error {
 	go func() {
-		operation := func() error {
+		operation := func() (string, error) {
 			if err := m.fetchRequiredEpochDuties(ctx, false); err != nil {
-				return err
+				return "", err
 			}
 
 			epoch := m.metadata.Wallclock().Epochs().Current()
 
 			if err := m.fetchProposerDuties(ctx, phase0.Epoch(epoch.Number())); err != nil {
-				return err
+				return "", err
 			}
 
 			//nolint:errcheck // We don't care about the error here
 			m.fetchNiceToHaveEpochDuties(ctx)
 
 			if err := m.Ready(ctx); err != nil {
-				return err
+				return "", err
 			}
 
-			return nil
+			return "", nil
 		}
 
-		if err := backoff.Retry(operation, backoff.NewExponentialBackOff()); err != nil {
+		retryOpts := []backoff.RetryOption{
+			backoff.WithBackOff(backoff.NewExponentialBackOff()),
+			backoff.WithNotify(func(err error, timer time.Duration) {
+				m.log.WithError(err).WithField("next_attempt", timer).Warn("Failed to fetch epoch duties")
+			}),
+		}
+
+		if _, err := backoff.Retry(ctx, operation, retryOpts...); err != nil {
 			m.log.WithError(err).Warn("Failed to fetch epoch duties")
 		}
 


### PR DESCRIPTION
Bumps `cenkalti/backoff/v4` to `cenkalti/backoff/v5`.

- `RetryNotify` was removed, in favor of a single `Retry` method.
- `Retry` now takes `ctx`.
- Operation, now returns a result of `any` type.

See full change-log: https://github.com/cenkalti/backoff/blob/v5/CHANGELOG.md

![Screenshot 2025-02-17 at 12 23 20](https://github.com/user-attachments/assets/b2b03947-3032-427a-8217-0df70b9f2972)

Closes: https://github.com/ethpandaops/xatu/pull/432