### PR TITLE
feat(clmimicry): add gossipsub subnet configuration

### DIFF
--- a/example-cl-mimicry.yaml
+++ b/example-cl-mimicry.yaml
@@ -24,7 +24,13 @@ node:
   maxPeers: 30
   dialConcurrency: 16
   dataStreamType: "callback"
-
+  subnets:
+    beacon_attestation:
+      type: "all"
+    sync_committee:
+      type: "all"
+    blob_sidecar:
+      type: "all"
 outputs:
 - name: log
   type: stdout

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.24.0
 
 toolchain go1.24.1
 
-replace github.com/probe-lab/hermes => github.com/ethpandaops/hermes v0.0.4-0.20250318101859-b1565d551e36
-
 require (
 	github.com/IBM/sarama v1.45.1
 	github.com/attestantio/go-eth2-client v0.24.1
@@ -35,7 +33,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.15.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/pkg/errors v0.9.1
-	github.com/probe-lab/hermes v0.0.0-20241128085322-a39cba499cb1
+	github.com/probe-lab/hermes v0.0.0-20250326124220-bbe750ac3b1d
 	github.com/prometheus/client_golang v1.21.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prysmaticlabs/prysm/v5 v5.3.2-0.20250317054927-5c24978702e0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ github.com/ethpandaops/ethcore v0.0.0-20250317181755-3b229dede7c9 h1:W5S3gzJFhi3
 github.com/ethpandaops/ethcore v0.0.0-20250317181755-3b229dede7c9/go.mod h1:ZvKqL6CKxiraefdXPHeJurV2pDD/f2HF2uklDVdrry8=
 github.com/ethpandaops/ethwallclock v0.3.0 h1:xF5fwtBf+bHFHZKBnwiPFEuelW3sMM7SD3ZNFq1lJY4=
 github.com/ethpandaops/ethwallclock v0.3.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/hermes v0.0.4-0.20250318101859-b1565d551e36 h1:GouLNPChGttWtq9hn69RFAFSeAhN84EOBMjAdL9HwoE=
-github.com/ethpandaops/hermes v0.0.4-0.20250318101859-b1565d551e36/go.mod h1:LgkbbePReT9kEZFqoHFbuKdDe9yGUgh74x6XuHvGNt4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -761,6 +759,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/probe-lab/hermes v0.0.0-20250326124220-bbe750ac3b1d h1:DF+X943ojKJbff9ONCyxUQvT4YGKcyyZam4BAVorp6o=
+github.com/probe-lab/hermes v0.0.0-20250326124220-bbe750ac3b1d/go.mod h1:LgkbbePReT9kEZFqoHFbuKdDe9yGUgh74x6XuHvGNt4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/pkg/clmimicry/config.go
+++ b/pkg/clmimicry/config.go
@@ -122,6 +122,9 @@ type NodeConfig struct {
 
 	// DataStreamType is the type of data stream to use for the node (e.g. kinesis, callback, etc).
 	DataStreamType string `yaml:"dataStreamType" default:"callback"`
+
+	// Subnets is the configuration for gossipsub subnets.
+	Subnets map[string]*hermes.SubnetConfig `yaml:"subnets"`
 }
 
 func (h *NodeConfig) AsHermesConfig() *hermes.NodeConfig {
@@ -138,6 +141,7 @@ func (h *NodeConfig) AsHermesConfig() *hermes.NodeConfig {
 		MaxPeers:        h.MaxPeers,
 		DialConcurrency: h.DialConcurrency,
 		DataStreamType:  host.DataStreamtypeFromStr(h.DataStreamType),
+		SubnetConfigs:   h.Subnets,
 	}
 }
 

--- a/pkg/clmimicry/mimicry.go
+++ b/pkg/clmimicry/mimicry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
 	//nolint:gosec // only exposed if pprofAddr config is set
 	_ "net/http/pprof"
 	"os"
@@ -233,7 +234,7 @@ func (m *Mimicry) Start(ctx context.Context) error {
 		m.log.Info("Ethereum client is ready. Starting Hermes..")
 
 		if err := m.startHermes(ctx); err != nil {
-			m.log.Fatal("failed to start hermes: %w", err)
+			m.log.Fatalf("failed to start hermes: %v", err)
 		}
 
 		return nil


### PR DESCRIPTION
This commit introduces the ability to configure gossipsub subnets within the clmimicry application. This allows for more granular control over the pubsub network and enables the creation of specialized subnets for different types of data.

The following changes were made:

- Added a `Subnets` field to the `NodeConfig` struct in `pkg/clmimicry/config.go` to store the subnet configurations.
- Passed the `SubnetConfigs` to the hermes config in `pkg/clmimicry/config.go`.
- Updated the `AsHermesConfig` method in `pkg/clmimicry/config.go` to include the subnet configurations when creating the Hermes node configuration.
- Fixed a logging error in `pkg/clmimicry/mimicry.go`.

Depends on https://github.com/probe-lab/hermes/pull/51