### PR TITLE
feat: add Caplin client to supported Ethereum clients

### DIFF
--- a/pkg/cannon/ethereum/services/client.go
+++ b/pkg/cannon/ethereum/services/client.go
@@ -14,6 +14,7 @@ const (
 	ClientPrysm      Client = "prysm"
 	ClientLodestar   Client = "lodestar"
 	ClientGrandine   Client = "grandine"
+	ClientCaplin     Client = "caplin"
 )
 
 var AllClients = []Client{
@@ -24,6 +25,7 @@ var AllClients = []Client{
 	ClientPrysm,
 	ClientLodestar,
 	ClientGrandine,
+	ClientCaplin,
 }
 
 func ClientFromString(client string) Client {
@@ -51,6 +53,10 @@ func ClientFromString(client string) Client {
 
 	if strings.Contains(asLower, "grandine") {
 		return ClientGrandine
+	}
+
+	if strings.Contains(asLower, "caplin") {
+		return ClientCaplin
 	}
 
 	return ClientUnknown

--- a/pkg/ethereum/client.go
+++ b/pkg/ethereum/client.go
@@ -14,6 +14,7 @@ const (
 	ClientPrysm      Client = "prysm"
 	ClientLodestar   Client = "lodestar"
 	ClientGrandine   Client = "grandine"
+	ClientCaplin     Client = "caplin"
 )
 
 var AllClients = []Client{
@@ -24,6 +25,7 @@ var AllClients = []Client{
 	ClientPrysm,
 	ClientLodestar,
 	ClientGrandine,
+	ClientCaplin,
 }
 
 func ClientFromString(client string) Client {
@@ -51,6 +53,10 @@ func ClientFromString(client string) Client {
 
 	if strings.Contains(asLower, "grandine") {
 		return ClientGrandine
+	}
+
+	if strings.Contains(asLower, "caplin") {
+		return ClientCaplin
 	}
 
 	return ClientUnknown

--- a/pkg/sentry/ethereum/services/client.go
+++ b/pkg/sentry/ethereum/services/client.go
@@ -14,6 +14,7 @@ const (
 	ClientPrysm      Client = "prysm"
 	ClientLodestar   Client = "lodestar"
 	ClientGrandine   Client = "grandine"
+	ClientCaplin     Client = "caplin"
 )
 
 var AllClients = []Client{
@@ -24,6 +25,7 @@ var AllClients = []Client{
 	ClientPrysm,
 	ClientLodestar,
 	ClientGrandine,
+	ClientCaplin,
 }
 
 func ClientFromString(client string) Client {
@@ -51,6 +53,10 @@ func ClientFromString(client string) Client {
 
 	if strings.Contains(asLower, "grandine") {
 		return ClientGrandine
+	}
+
+	if strings.Contains(asLower, "caplin") {
+		return ClientCaplin
 	}
 
 	return ClientUnknown


### PR DESCRIPTION
This commit introduces support for the Caplin Ethereum client. The changes include:

- Adding `ClientCaplin` constant to the `Client` enum in `pkg/cannon/ethereum/services/client.go`, `pkg/ethereum/client.go`, and `pkg/sentry/ethereum/services/client.go`.
- Adding `ClientCaplin` to the `AllClients` array in the same files.
- Updating the `ClientFromString` function to recognize "caplin" as a valid client string and return `ClientCaplin`.

These changes allow the system to correctly identify and interact with Ethereum nodes running the Caplin client.