### PR TITLE
fix(go.mod, go.sum): replace github.com/probe-lab/hermes with github.com/ethpandaops/hermes

### DIFF
--- a/example-cl-mimicry.yaml
+++ b/example-cl-mimicry.yaml
@@ -21,6 +21,7 @@ node:
   prysmHost: "127.0.0.1"
   prysmPortHttp: 5052
   prysmPortGrpc: 4000
+  prysmUseTLS: false
   maxPeers: 30
   dialConcurrency: 16
   dataStreamType: "callback"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24.0
 
 toolchain go1.24.1
 
+replace github.com/probe-lab/hermes => github.com/ethpandaops/hermes v0.0.4-0.20250408014407-f530d492b03b
+
 require (
 	github.com/IBM/sarama v1.45.1
 	github.com/attestantio/go-eth2-client v0.24.1
@@ -121,7 +123,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/ethpandaops/ethcore v0.0.0-20250317181755-3b229dede7c9 h1:W5S3gzJFhi3
 github.com/ethpandaops/ethcore v0.0.0-20250317181755-3b229dede7c9/go.mod h1:ZvKqL6CKxiraefdXPHeJurV2pDD/f2HF2uklDVdrry8=
 github.com/ethpandaops/ethwallclock v0.3.0 h1:xF5fwtBf+bHFHZKBnwiPFEuelW3sMM7SD3ZNFq1lJY4=
 github.com/ethpandaops/ethwallclock v0.3.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
+github.com/ethpandaops/hermes v0.0.4-0.20250408014407-f530d492b03b h1:u4yF+igKNyWJeLRA7rSoeyNZaQRxgvuToJ8S4xoozWc=
+github.com/ethpandaops/hermes v0.0.4-0.20250408014407-f530d492b03b/go.mod h1:jF1FslMW6Eg6cfTk2bvhAQeWZ7x5PTFgDeW0iiDsxDc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -305,8 +307,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -763,8 +765,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/probe-lab/hermes v0.0.0-20250328140724-f552d3382c38 h1:4bcB7jw06Jq/KvnhzLUKkJBIVQlAmTLtycNHdhsGvqk=
-github.com/probe-lab/hermes v0.0.0-20250328140724-f552d3382c38/go.mod h1:lzzFtjdyG3imvt18dSMU+EpDjInKkC7Hc3m1S+Aylqo=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=

--- a/pkg/clmimicry/config.go
+++ b/pkg/clmimicry/config.go
@@ -110,7 +110,7 @@ type NodeConfig struct {
 	PrysmHost     string `yaml:"prysmHost" default:"127.0.0.1"`
 	PrysmPortHTTP int    `yaml:"prysmPortHttp" default:"3500"`
 	PrysmPortGRPC int    `yaml:"prysmPortGrpc" default:"4000"`
-	PrysmUseTLS   bool   `yaml:"prysmUseTLS" default:"false"`
+	PrysmUseTLS   bool   `yaml:"prysmUseTls" default:"false"`
 
 	// The maximum number of peers our libp2p host can be connected to.
 	MaxPeers int `yaml:"maxPeers" default:"30"`

--- a/pkg/clmimicry/config.go
+++ b/pkg/clmimicry/config.go
@@ -110,6 +110,7 @@ type NodeConfig struct {
 	PrysmHost     string `yaml:"prysmHost" default:"127.0.0.1"`
 	PrysmPortHTTP int    `yaml:"prysmPortHttp" default:"3500"`
 	PrysmPortGRPC int    `yaml:"prysmPortGrpc" default:"4000"`
+	PrysmUseTLS   bool   `yaml:"prysmUseTLS" default:"false"`
 
 	// The maximum number of peers our libp2p host can be connected to.
 	MaxPeers int `yaml:"maxPeers" default:"30"`
@@ -138,6 +139,7 @@ func (h *NodeConfig) AsHermesConfig() *hermes.NodeConfig {
 		PrysmHost:       h.PrysmHost,
 		PrysmPortHTTP:   h.PrysmPortHTTP,
 		PrysmPortGRPC:   h.PrysmPortGRPC,
+		PrysmUseTLS:     h.PrysmUseTLS,
 		MaxPeers:        h.MaxPeers,
 		DialConcurrency: h.DialConcurrency,
 		DataStreamType:  host.DataStreamtypeFromStr(h.DataStreamType),


### PR DESCRIPTION
The hermes library was replaced to use the ethpandaops fork. 