### PR TITLE
feat(mimicry.go): add TLS support for Prysm connection

### DIFF
--- a/pkg/clmimicry/mimicry.go
+++ b/pkg/clmimicry/mimicry.go
@@ -79,8 +79,12 @@ func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides 
 
 	addr := fmt.Sprintf("%s:%d", config.Node.PrysmHost, config.Node.PrysmPortHTTP)
 
-	if !strings.HasPrefix(addr, "http") {
-		addr = "http://" + addr
+	if !strings.HasPrefix(addr, "http") && !strings.HasPrefix(addr, "https") {
+		if config.Node.PrysmUseTLS {
+			addr = "https://" + addr
+		} else {
+			addr = "http://" + addr
+		}
 	}
 
 	client, err := ethereum.NewBeaconNode(ctx,


### PR DESCRIPTION
This commit adds support for TLS when connecting to the Prysm beacon node. The code now checks the `PrysmUseTLS` configuration option and prefixes the address with "https://" if it is enabled. This allows the mimicry service to securely connect to Prysm nodes that require TLS.