### PR TITLE
build(.goreleaser.yaml): remove go generate from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,6 @@ project_name: xatu
 before:
   hooks:
     - go mod tidy
-    - go generate ./...
 builds:
   - id: linux-amd64
     env:


### PR DESCRIPTION
This change removes the go generate command from the goreleaser configuration. This is because go generate is not needed for the release process and can be run separately.