### PR TITLE
fix(sentry): allow sentry to start without mempool watcher

### DIFF
--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -606,7 +606,11 @@ func (s *Sentry) Start(ctx context.Context) error {
 		}
 
 		if err := s.startMempoolTransactionWatcher(ctx); err != nil {
-			return err
+			// If we can't reach the execution node, we can't start the mempool transaction watcher.
+			// Instead of preventing the sentry from starting, we'll log an error and continue.
+			s.log.WithError(err).Error("failed to start mempool transaction watcher")
+
+			return nil
 		}
 
 		return nil


### PR DESCRIPTION
The sentry should be able to start even if the execution node is unavailable. This change allows the sentry to start without the mempool watcher, logging an error instead of returning an error. This prevents the sentry from failing to start when the execution node is unavailable.