### PR TITLE
refactor(clmimicry): map event types to xatu event strings

### DIFF
--- a/pkg/clmimicry/metrics.go
+++ b/pkg/clmimicry/metrics.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type Metrics struct {
@@ -23,62 +22,72 @@ type Metrics struct {
 }
 
 func NewMetrics(namespace string) *Metrics {
-	return &Metrics{
+	m := &Metrics{
 		decoratedEvents: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Name:      "decorated_event_total",
 			Help:      "Total number of decorated events received",
 		}, []string{"type", "network_id"}),
-		samplingProcessed: promauto.NewCounterVec(
+		samplingProcessed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "sampling_processed_total",
 				Help:      "The number of messages processed after sampling",
 			},
-			[]string{"event_type", "network"},
+			[]string{"type", "network_id"},
 		),
-		samplingSkipped: promauto.NewCounterVec(
+		samplingSkipped: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "sampling_skipped_total",
 				Help:      "The number of messages skipped due to sampling",
 			},
-			[]string{"event_type", "network"},
+			[]string{"type", "network_id"},
 		),
-		shardDistribution: promauto.NewCounterVec(
+		shardDistribution: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "shard_distribution_total",
 				Help:      "The distribution of messages across shards",
 			},
-			[]string{"topic", "shard", "network"},
+			[]string{"topic", "shard", "network_id"},
 		),
-		shardProcessed: promauto.NewCounterVec(
+		shardProcessed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "shard_processed_total",
 				Help:      "The number of messages processed by shard",
 			},
-			[]string{"topic", "shard", "network"},
+			[]string{"topic", "shard", "network_id"},
 		),
-		shardSkipped: promauto.NewCounterVec(
+		shardSkipped: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
 				Name:      "shard_skipped_total",
 				Help:      "The number of messages skipped by shard",
 			},
-			[]string{"topic", "shard", "network"},
+			[]string{"topic", "shard", "network_id"},
 		),
-		shardDistributionHist: promauto.NewHistogramVec(
+		shardDistributionHist: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: namespace,
 				Name:      "shard_distribution_histogram",
 				Help:      "Histogram of shard distribution",
 				Buckets:   prometheus.LinearBuckets(0, 1, 64), // 64 buckets, one per potential shard
 			},
-			[]string{"topic", "network"},
+			[]string{"topic", "network_id"},
 		),
 	}
+
+	prometheus.MustRegister(m.decoratedEvents)
+	prometheus.MustRegister(m.samplingProcessed)
+	prometheus.MustRegister(m.samplingSkipped)
+	prometheus.MustRegister(m.shardDistribution)
+	prometheus.MustRegister(m.shardProcessed)
+	prometheus.MustRegister(m.shardSkipped)
+	prometheus.MustRegister(m.shardDistributionHist)
+
+	return m
 }
 
 func (m *Metrics) AddDecoratedEvent(count float64, eventType, network string) {

--- a/pkg/clmimicry/trace.go
+++ b/pkg/clmimicry/trace.go
@@ -1,7 +1,7 @@
 package clmimicry
 
 // ShouldTraceMessage determines whether a message with the given MsgID should be included
-// in the sample based on the configured sampling settings.
+// in the sample based on the configured trace settings.
 func (m *Mimicry) ShouldTraceMessage(msgID, eventType, network string) bool {
 	// If no msgID, we can't sample.
 	if msgID == "" {


### PR DESCRIPTION
This commit refactors the event handling logic in `clmimicry` to map incoming event types (from gossipsub, libp2p, and rpc) to their corresponding Xatu event string representations.

Previously, the code directly used the string representation of the incoming event type for metrics and sampling decisions. This made the code less readable and harder to maintain as the event types were scattered throughout the code.

By introducing dedicated mapping functions (`mapGossipSubEventToXatuEvent`, `mapLibp2pEventToXatuEvent`, `mapLibp2pCoreEventToXatuEvent`, and `mapRPCEventToXatuEvent`), we centralize the mapping logic and improve code clarity. The metrics and tracing functions now use the consistent Xatu event strings.

Additionally, the variable names related to sampling have been updated to reflect the concept of "tracing" or "sharding" messages, which is a more accurate description of the filtering mechanism used. This includes renaming variables and comments from "sampling" to "trace" or "sharding".

The Prometheus metrics have also been updated to use the Xatu event strings as labels, providing more consistent and meaningful metric names. The metric registration has been moved from `promauto` to explicit `prometheus.MustRegister` calls within the `NewMetrics` function for better control and clarity.