### PR TITLE
feat(ci): add nimbus unstable image to sentry smoke test workflow

### DIFF
--- a/.github/workflows/sentry-smoke-test.yaml
+++ b/.github/workflows/sentry-smoke-test.yaml
@@ -34,6 +34,7 @@ jobs:
               cl_type: lodestar
             - el_type: ethereumjs
               cl_type: nimbus
+              cl_image: ethpandaops/nimbus-eth2:unstable
           additional_services: []
           network_params:
             genesis_delay: 180


### PR DESCRIPTION
My OCD kicking in.

Until a mainline fulu release, use unstable which contains addition of `block_gossip` event in nimbus.

![Screenshot 2025-05-19 at 13 32 55](https://github.com/user-attachments/assets/a3a216a0-f0cd-4cc7-8a62-6e51f2097f6c)
