### PR TITLE
feat(mempool_watcher): add configuration flags to enable/disable fetchers

### DIFF
--- a/pkg/sentry/execution/mempool_watcher.go
+++ b/pkg/sentry/execution/mempool_watcher.go
@@ -160,10 +160,14 @@ func (w *MempoolWatcher) Start(ctx context.Context) error {
 	}
 
 	// Start periodic fetching of txpool content.
-	w.startPeriodicFetcher()
+	if w.config.TxPoolContentEnabled {
+		w.startPeriodicFetcher()
+	}
 
 	// Start periodic fetching of eth_pendingTransactions.
-	w.startPendingTransactionsFetcher()
+	if w.config.EthPendingTxsEnabled {
+		w.startPendingTransactionsFetcher()
+	}
 
 	// Start periodic summary logging.
 	w.startSummaryLogger()

--- a/pkg/sentry/execution/types.go
+++ b/pkg/sentry/execution/types.go
@@ -24,6 +24,10 @@ const (
 type Config struct {
 	// Enabled is whether the execution client is enabled.
 	Enabled bool `yaml:"enabled" default:"false"`
+	// EthPendingTxsEnabled is whether we suppliment fetching tx's using eth_pendingTransactions periodically.
+	EthPendingTxsEnabled bool `yaml:"ethPendingTxsEnabled" default:"false"`
+	// TxPoolContentEnabled is whether we suppliment fetching tx's using txpool_content periodically.
+	TxPoolContentEnabled bool `yaml:"txPoolContentEnabled" default:"true"`
 	// WebsocketEnabled is whether the websocket is enabled.
 	WebsocketEnabled bool `yaml:"websocketEnabled" default:"false"`
 	// WSAddress is the WebSocket address of the execution client for subscriptions.


### PR DESCRIPTION
This commit introduces two new configuration flags, `EthPendingTxsEnabled` and `TxPoolContentEnabled`, to the `MempoolWatcher` configuration. These flags control whether the periodic fetching of `eth_pendingTransactions` and `txpool_content` is enabled, respectively.

Previously, both fetchers were always started when the `MempoolWatcher` was started. This change allows for more granular control over which methods are used to fetch pending transactions, enabling users to disable specific fetchers if they are not needed or causing issues.

A new test case `TestFetchersBasedOnConfig` has been added to verify that the fetcher goroutines are started or not based on the values of these configuration flags.