### PR TITLE
fix(clmimicry): handle map[string]any payloads in getMsgID

### DIFF
--- a/pkg/clmimicry/trace_shard_key.go
+++ b/pkg/clmimicry/trace_shard_key.go
@@ -113,6 +113,17 @@ func getMsgID(payload interface{}) string {
 		return ""
 	}
 
+	// Handle map[string]any payloads (used by deliver_message, duplicate_message, etc.)
+	if mapPayload, ok := payload.(map[string]any); ok {
+		if msgID, found := mapPayload["MsgID"]; found {
+			if msgIDStr, ok := msgID.(string); ok {
+				return msgIDStr
+			}
+		}
+
+		return ""
+	}
+
 	// Try to access the MsgID field using reflection.
 	v := reflect.ValueOf(payload)
 	if v.Kind() != reflect.Ptr || v.IsNil() {

--- a/pkg/clmimicry/trace_shard_key_test.go
+++ b/pkg/clmimicry/trace_shard_key_test.go
@@ -126,3 +126,68 @@ func TestGetShardingKey(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMsgID(t *testing.T) {
+	mockMsgID := "test-msg-id-12345"
+
+	testCases := []struct {
+		name        string
+		payload     interface{}
+		expectedKey string
+	}{
+		{
+			name:        "Struct pointer payload with MsgID",
+			payload:     &MockPayload{MsgID: mockMsgID},
+			expectedKey: mockMsgID,
+		},
+		{
+			name: "Map payload with MsgID (deliver_message/duplicate_message style)",
+			payload: map[string]any{
+				"MsgID":   mockMsgID,
+				"Topic":   "test-topic",
+				"PeerID":  "peer-123",
+				"Local":   true,
+				"MsgSize": 1024,
+			},
+			expectedKey: mockMsgID,
+		},
+		{
+			name:        "Nil payload returns empty string",
+			payload:     nil,
+			expectedKey: "",
+		},
+		{
+			name: "Map payload missing MsgID returns empty string",
+			payload: map[string]any{
+				"Topic":  "test-topic",
+				"PeerID": "peer-123",
+			},
+			expectedKey: "",
+		},
+		{
+			name: "Map payload with non-string MsgID returns empty string",
+			payload: map[string]any{
+				"MsgID": 12345, // Not a string
+				"Topic": "test-topic",
+			},
+			expectedKey: "",
+		},
+		{
+			name:        "Struct pointer with empty MsgID",
+			payload:     &MockPayload{MsgID: ""},
+			expectedKey: "",
+		},
+		{
+			name:        "Non-struct, non-map payload returns empty string",
+			payload:     []string{"not", "a", "struct", "or", "map"},
+			expectedKey: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getMsgID(tc.payload)
+			assert.Equal(t, tc.expectedKey, result)
+		})
+	}
+}


### PR DESCRIPTION
This change adds support for extracting the MsgID from payloads that are of type `map[string]any`. This is necessary because some message types, such as `deliver_message` and `duplicate_message`, use this format for their payload.

A new test case `TestGetMsgID` is also added to cover various scenarios, including map payloads with and without the MsgID field, and with different types for the MsgID value.