### PR TITLE
refactor(Makefile): improve proto generation script to iterate over dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,11 @@
 proto:
-	buf generate
+	@echo "Buf generate:" ; \
+	echo "-----------------" ; \
+	for f in pkg/proto/*/; do \
+		dir=$$(basename $$f); \
+		if [[ $$dir == .* ]]; then \
+			continue ; \
+		fi ; \
+		echo "	→ $$f" && buf generate --path "$$f"; \
+	done ; \
+	echo "-----------------" ;

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 proto:
 	@echo "Buf generate:" ; \
 	echo "-----------------" ; \
-	for f in pkg/proto/*/; do \
+	for f in $$(find pkg/proto -type d); do \
 		dir=$$(basename $$f); \
 		if [[ $$dir == .* ]]; then \
 			continue ; \


### PR DESCRIPTION
The introduction of `llm` docs throughout the repo has caused issues with proto generation, mainly around the use of symlinks. `buf` fails to follow symlinks and when traversing the project generating, it fails with...

`Failure: EvalSymlinks: too many links`

This PR updates the `Makefile` to traverse the `pkg/proto` directories only, and use the explicit `--path` parameter of `buf` which gets us around it.

---

```bash
make proto                   
                                                              
Buf generate:
-----------------
        → pkg/proto
        → pkg/proto/blockprint
        → pkg/proto/mevrelay
        → pkg/proto/eth
        → pkg/proto/eth/v1
        → pkg/proto/eth/v2
        → pkg/proto/xatu
        → pkg/proto/libp2p
        → pkg/proto/libp2p/gossipsub
-----------------
```