### PR TITLE
fix(clmimicry): iterate over events slice to add metrics for each event

### DIFF
--- a/pkg/clmimicry/mimicry.go
+++ b/pkg/clmimicry/mimicry.go
@@ -437,12 +437,14 @@ func (m *Mimicry) handleNewDecoratedEvents(ctx context.Context, events []*xatu.D
 		networkStr = unknown
 	}
 
-	eventType := event.GetEvent().GetName().String()
-	if eventType == "" {
-		eventType = unknown
-	}
+	for _, event := range events {
+		eventType := event.GetEvent().GetName().String()
+		if eventType == "" {
+			eventType = unknown
+		}
 
-	m.metrics.AddDecoratedEvent(float64(len(events)), eventType, networkStr)
+		m.metrics.AddDecoratedEvent(float64(len(events)), eventType, networkStr)
+	}
 
 	for _, sink := range m.sinks {
 		if err := sink.HandleNewDecoratedEvents(ctx, events); err != nil {

--- a/pkg/clmimicry/mimicry.go
+++ b/pkg/clmimicry/mimicry.go
@@ -443,7 +443,7 @@ func (m *Mimicry) handleNewDecoratedEvents(ctx context.Context, events []*xatu.D
 			eventType = unknown
 		}
 
-		m.metrics.AddDecoratedEvent(float64(len(events)), eventType, networkStr)
+		m.metrics.AddDecoratedEvent(1, eventType, networkStr)
 	}
 
 	for _, sink := range m.sinks {


### PR DESCRIPTION
The previous implementation was adding metrics for the entire slice of events, not for each individual event within the slice. This change iterates over the slice and adds metrics for each event.