### PR TITLE
feat(clmimicry): add support for range syntax in active shards config

### DIFF
--- a/example-cl-mimicry.yaml
+++ b/example-cl-mimicry.yaml
@@ -43,17 +43,17 @@ outputs:
 #   topics:
 #     "(?i).*add_peer.*":
 #       shardingKey: "PeerID"
-#       totalShards: 64
-#       activeShards: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+#       totalShards: 512
+#       activeShards: ["0-255"] # Range syntax - expands to shards 0 through 255
 #     "(?i).*beacon_attestation.*":
 #       shardingKey: "MsgID"
-#       totalShards: 64
-#       activeShards: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+#       totalShards: 512
+#       activeShards: [0, "10-20", 50] # Mix of individual shards and ranges
 #     # RPC meta control events are depending on recv_rpc, send_rpc or drop_rpc events
 #     "(?i).*rpc_meta_control_ihave.*":
 #       shardingKey: "MsgID"
 #       totalShards: 1
-#       activeShards: [0]
+#       activeShards: [0, 1, 2, 3, 4]
 #     "(?i).*rpc_meta_control_iwant.*":
 #       shardingKey: "MsgID"
 #       totalShards: 1

--- a/pkg/clmimicry/event.go
+++ b/pkg/clmimicry/event.go
@@ -32,6 +32,7 @@ var (
 	UnshardableEventTypes = []string{
 		xatu.Event_LIBP2P_TRACE_JOIN.String(),
 		xatu.Event_LIBP2P_TRACE_LEAVE.String(),
+		xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_GRAFT.String(),
 	}
 )
 

--- a/pkg/clmimicry/trace_config.go
+++ b/pkg/clmimicry/trace_config.go
@@ -5,8 +5,13 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
+
+// ActiveShardsConfig represents a list of active shards that can be specified
+// as individual numbers or ranges (e.g., "0-255").
+type ActiveShardsConfig []interface{}
 
 // TracesConfig represents the new trace-based configuration.
 type TracesConfig struct {
@@ -25,8 +30,10 @@ type TracesConfig struct {
 type TopicConfig struct {
 	// Total number of shards for this topic.
 	TotalShards uint64 `yaml:"totalShards" default:"64"`
-	// List of active shards to process.
-	ActiveShards []uint64 `yaml:"activeShards"`
+	// List of active shards to process. Supports individual numbers and ranges (e.g., "0-255").
+	ActiveShardsRaw ActiveShardsConfig `yaml:"activeShards"`
+	// Processed active shards (populated during validation).
+	ActiveShards []uint64 `yaml:"-"`
 	// Key to use for sharding (MsgID, PeerID, etc).
 	ShardingKey string `yaml:"shardingKey" default:"MsgID"`
 }
@@ -151,6 +158,82 @@ func (e *TracesConfig) LogSummary() string {
 	return summary
 }
 
+// ToUint64Slice converts the ActiveShardsConfig to a slice of uint64.
+// It expands any ranges found in the configuration.
+func (a ActiveShardsConfig) ToUint64Slice() ([]uint64, error) {
+	var (
+		result = make([]uint64, 0)
+		seen   = make(map[uint64]bool) // To avoid duplicates.
+	)
+
+	for _, item := range a {
+		switch v := item.(type) {
+		case int:
+			shard := uint64(v) //nolint:gosec // conversion fine.
+
+			if !seen[shard] {
+				result = append(result, shard)
+				seen[shard] = true
+			}
+		case uint64:
+			if !seen[v] {
+				result = append(result, v)
+				seen[v] = true
+			}
+		case string:
+			// Handle range syntax like "0-255".
+			if strings.Contains(v, "-") {
+				parts := strings.Split(v, "-")
+				if len(parts) != 2 {
+					return nil, fmt.Errorf("invalid range format '%s', expected 'start-end'", v)
+				}
+
+				start, err := strconv.ParseUint(strings.TrimSpace(parts[0]), 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("invalid range start '%s': %w", parts[0], err)
+				}
+
+				end, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("invalid range end '%s': %w", parts[1], err)
+				}
+
+				if start > end {
+					return nil, fmt.Errorf("invalid range '%s': start (%d) is greater than end (%d)", v, start, end)
+				}
+
+				// Add all numbers in the range.
+				for i := start; i <= end; i++ {
+					if !seen[i] {
+						result = append(result, i)
+						seen[i] = true
+					}
+				}
+			} else {
+				// Handle single number as string.
+				shard, err := strconv.ParseUint(v, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("invalid shard number '%s': %w", v, err)
+				}
+
+				if !seen[shard] {
+					result = append(result, shard)
+					seen[shard] = true
+				}
+			}
+		default:
+			return nil, fmt.Errorf("unsupported type for active shard: %T", v)
+		}
+	}
+
+	// Sort the result for consistency.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i] < result[j]
+	})
+
+	return result, nil
+}
+
 func validateTracesConfig(config *TracesConfig) error {
 	if len(config.Topics) == 0 {
 		return errors.New("no topics configured")
@@ -167,12 +250,22 @@ func validateTracesConfig(config *TracesConfig) error {
 			return fmt.Errorf("total_shards must be greater than 0 for pattern '%s'", pattern)
 		}
 
-		// Validate active shards.
-		if len(topicConfig.ActiveShards) == 0 {
+		// Process raw active shards (expand ranges).
+		if len(topicConfig.ActiveShardsRaw) == 0 {
 			return fmt.Errorf("active_shards cannot be empty for pattern '%s'", pattern)
 		}
 
-		for _, shard := range topicConfig.ActiveShards {
+		activeShards, err := topicConfig.ActiveShardsRaw.ToUint64Slice()
+		if err != nil {
+			return fmt.Errorf("invalid active_shards for pattern '%s': %w", pattern, err)
+		}
+
+		if len(activeShards) == 0 {
+			return fmt.Errorf("active_shards cannot be empty for pattern '%s'", pattern)
+		}
+
+		// Validate that all active shards are within range.
+		for _, shard := range activeShards {
 			if shard >= topicConfig.TotalShards {
 				return fmt.Errorf(
 					"active shard %d is out of range (0-%d) for pattern '%s'",
@@ -182,6 +275,11 @@ func validateTracesConfig(config *TracesConfig) error {
 				)
 			}
 		}
+
+		// Update the topic config with processed active shards.
+		updatedConfig := topicConfig
+		updatedConfig.ActiveShards = activeShards
+		config.Topics[pattern] = updatedConfig
 
 		// Validate sharding key, if provided (if empty, will default to MsgID).
 		switch ShardingKeyType(topicConfig.ShardingKey) {


### PR DESCRIPTION
This change allows users to specify ranges of active shards in the `activeShards` configuration using the format "start-end". This simplifies the configuration for topics with a large number of active shards.

For example:

```yaml
# Range syntax - expands to shards 0 through 255
activeShards: ["0-255"]

# Mix individual shards and ranges  
activeShards: [0, "10-20", 50]  # Expands to: [0,10,11,12,13,14,15,16,17,18,19,20,50]

# Continue to support individual shards
activeShards: [0, 1, 2, 3, 4]
```