### PR TITLE
refactor(clmimicry): strip large meta data from root RPC events

### DIFF
--- a/pkg/clmimicry/event_libp2p.go
+++ b/pkg/clmimicry/event_libp2p.go
@@ -436,8 +436,16 @@ func (m *Mimicry) handleSendRPCEvent(
 		Meta: &xatu.Meta{
 			Client: metadata,
 		},
+		// The root level event will still contain all rpc meta level messages. With some events, these
+		// are really large, and will exceed msg limits at kafka/vector. Because we're splitting the meta
+		// events into multiple messages, we can remove the meta level messages from the root event.
 		Data: &xatu.DecoratedEvent_Libp2PTraceSendRpc{
-			Libp2PTraceSendRpc: data,
+			Libp2PTraceSendRpc: &libp2p.SendRPC{
+				PeerId: data.GetPeerId(),
+				Meta: &libp2p.RPCMeta{
+					PeerId: data.GetPeerId(),
+				},
+			},
 		},
 	}
 
@@ -543,8 +551,16 @@ func (m *Mimicry) handleRecvRPCEvent(
 		Meta: &xatu.Meta{
 			Client: metadata,
 		},
+		// The root level event will still contain all rpc meta level messages. With some events, these
+		// are really large, and will exceed msg limits at kafka/vector. Because we're splitting the meta
+		// events into multiple messages, we can remove the meta level messages from the root event.
 		Data: &xatu.DecoratedEvent_Libp2PTraceRecvRpc{
-			Libp2PTraceRecvRpc: data,
+			Libp2PTraceRecvRpc: &libp2p.RecvRPC{
+				PeerId: data.GetPeerId(),
+				Meta: &libp2p.RPCMeta{
+					PeerId: data.GetPeerId(),
+				},
+			},
 		},
 	}
 
@@ -614,8 +630,16 @@ func (m *Mimicry) handleDropRPCEvent(
 		Meta: &xatu.Meta{
 			Client: metadata,
 		},
+		// The root level event will still contain all rpc meta level messages. With some events, these
+		// are really large, and will exceed msg limits at kafka/vector. Because we're splitting the meta
+		// events into multiple messages, we can remove the meta level messages from the root event.
 		Data: &xatu.DecoratedEvent_Libp2PTraceDropRpc{
-			Libp2PTraceDropRpc: data,
+			Libp2PTraceDropRpc: &libp2p.DropRPC{
+				PeerId: data.GetPeerId(),
+				Meta: &libp2p.RPCMeta{
+					PeerId: data.GetPeerId(),
+				},
+			},
 		},
 	}
 

--- a/pkg/clmimicry/event_libp2p.go
+++ b/pkg/clmimicry/event_libp2p.go
@@ -470,6 +470,9 @@ func (m *Mimicry) handleSendRPCEvent(
 		if err := m.handleNewDecoratedEvents(ctx, decoratedEvents); err != nil {
 			return errors.Wrapf(err, "failed to handle decorated events")
 		}
+	} else {
+		// If we don't send the root level event, we need to add a metric for it.
+		m.metrics.AddSkippedMessage(xatu.Event_LIBP2P_TRACE_SEND_RPC.String(), getNetworkID(clientMeta))
 	}
 
 	return nil
@@ -664,6 +667,9 @@ func (m *Mimicry) handleDropRPCEvent(
 		if err := m.handleNewDecoratedEvents(ctx, decoratedEvents); err != nil {
 			return errors.Wrapf(err, "failed to handle decorated events")
 		}
+	} else {
+		// If we don't send the root level event, we need to add a metric for it.
+		m.metrics.AddSkippedMessage(xatu.Event_LIBP2P_TRACE_DROP_RPC.String(), getNetworkID(clientMeta))
 	}
 
 	return nil


### PR DESCRIPTION
The root level RPC events (SendRPC, RecvRPC, DropRPC) previously included the full RPC meta data payload. This payload can be very large, especially when containing many control messages, subscriptions, or messages. This can cause issues with message size limits downstream.

Since all detailed meta data is already being exploded into separate, individual events (e.g., RpcMetaControlIHave, RpcMetaSubscription, RpcMetaMessage), the full meta data is redundant in the root event.

This change modifies the root RPC event handlers to strip the large meta data fields (Control, Subscriptions, Messages) from the `Data` field of the root `DecoratedEvent`. The `Meta` field within the root event's data is also reduced to only include the `PeerId`.