### PR TITLE
feat(docker-compose): migrate Kafka setup from Zookeeper to Kraft mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -324,6 +324,31 @@ services:
     networks:
       - xatu-net
 
+  xatu-kafka-storage-format:
+    profiles:
+      - ""
+    image: confluentinc/cp-kafka:latest
+    container_name: xatu-kafka-storage-format
+    environment:
+      CLUSTER_ID: WySlHi0zTAmp0tJmzXHSNQ
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@xatu-kafka:29093
+      KAFKA_LISTENERS: PLAINTEXT://xatu-kafka:29092,CONTROLLER://xatu-kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://xatu-kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    command: >
+      bash -c "
+        kafka-storage format -t $$CLUSTER_ID -c /etc/kafka/kraft/server.properties || true
+      "
+    networks:
+      - xatu-net
+
   xatu-kafka:
     profiles:
       - ""
@@ -331,10 +356,16 @@ services:
     hostname: xatu-kafka
     container_name: xatu-kafka
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: xatu-kafka-zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@xatu-kafka:29093
+      KAFKA_LISTENERS: PLAINTEXT://xatu-kafka:29092,CONTROLLER://xatu-kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://xatu-kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: WySlHi0zTAmp0tJmzXHSNQ
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -343,44 +374,24 @@ services:
     ports:
       - "${KAFKA_ADDRESS:-127.0.0.1}:${KAFKA_PORT:-29092}:29092"
       - "${KAFKA_BROKER_ADDRESS:-127.0.0.1}:${KAFKA_BROKER_PORT:-9092}:9092"
+      - "${KAFKA_CONTROLLER_ADDRESS:-127.0.0.1}:${KAFKA_CONTROLLER_PORT:-29093}:29093"
     networks:
       - xatu-net
     volumes:
       - kafka-data:/var/lib/kafka/data
+    depends_on:
+      xatu-kafka-storage-format:
+        condition: service_completed_successfully
     healthcheck:
       test:
         [
-          "CMD",
-          "kafka-broker-api-versions",
-          "--bootstrap-server=localhost:9092",
+          "CMD-SHELL",
+          "kafka-broker-api-versions --bootstrap-server=localhost:9092 || exit 1",
         ]
       interval: 30s
       timeout: 10s
-      retries: 5
-      start_period: 5s
-    depends_on:
-      xatu-kafka-zookeeper:
-        condition: service_healthy
-  xatu-kafka-zookeeper:
-    profiles:
-      - ""
-    image: zookeeper
-    container_name: xatu-kafka-zookeeper
-    environment:
-      ZOO_LOG4J_PROP: "ERROR,CONSOLE"
-    ports:
-      - "${KAFKA_ZOOKEEPER_ADDRESS:-127.0.0.1}:${KAFKA_ZOOKEEPER_PORT:-2181}:2181"
-    networks:
-      - xatu-net
-    volumes:
-      - kafka-zookeeper-data:/data
-      - kafka-zookeeper-datalog:/datalog
-    healthcheck:
-      test: ["CMD", "./bin/zkServer.sh", "status"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 5s
+      retries: 10
+      start_period: 30s
 
   xatu-vector-http-kafka:
     profiles:
@@ -609,10 +620,6 @@ volumes:
   clickhouse-zookeeper-03-datalog:
     driver: local
   kafka-data:
-    driver: local
-  kafka-zookeeper-data:
-    driver: local
-  kafka-zookeeper-datalog:
     driver: local
   prometheus-data:
     driver: local


### PR DESCRIPTION
Confluent Platform 7.9 is the last version supporting ZooKeeper - so our existing compose setup using `confluentinc/cp-kafka:latest` is failing. 

This PR migrates the local Docker Compose setup from ZooKeeper-based Kafka to KRaft mode, eliminating ZooKeeper dependency for Kafka.

We now have:

  1. xatu-kafka-storage-format → formats KRaft storage directory
  2. xatu-kafka → starts Kafka broker (depends on storage format)
  3. xatu-init-kafka → creates topics (depends on Kafka healthy)
