### PR TITLE
build(docker-compose.yml): update vector image version from 0.34.1-alpine to 0.37.1-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -396,7 +396,7 @@ services:
   xatu-vector-http-kafka:
     profiles:
       - ""
-    image: timberio/vector:0.34.1-alpine
+    image: timberio/vector:0.37.1-alpine
     container_name: xatu-vector-http-kafka
     volumes:
       - ./deploy/local/docker-compose/vector-http-kafka.yaml:/etc/vector/vector.yaml


### PR DESCRIPTION
Bug with Vector `0.33.1` through `0.35.0`, occuring under high activity loads causing Vector to crash and restart in a loop.

See:  https://github.com/vectordotdev/vector/issues/19627

> It looks like `xatu-vector-kafka-clickhouse` and `xatu-vector-kafka-clickhouse-libp2p` were already on `0.37.1`, we were missing `xatu-vector-http-kafka`


```bash
thread 'vector-worker' panicked at 'called `Option::unwrap()` on a `None` value', /cargo/registry/src/index.crates.io-6f17d22bba15001f/lockfree-object-pool-0.1.4/src/linear_page.rs:48:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2025-06-18T03:00:13.906700Z ERROR sink{component_kind="sink" component_id=libp2p_trace_send_rpc_kafka component_type=kafka}: vector::topology: An error occurred that Vector couldn't handle: the task panicked and was aborted.
2025-06-18T03:00:13.907004Z  INFO vector: Vector has stopped.
2025-06-18T03:00:13.909404Z  INFO vector::topology::running: Shutting down... Waiting on running components. 
```