### PR TITLE
refactor(clmimicry): rename decorated_events_total metric to decorated_event_total

### DIFF
--- a/pkg/clmimicry/metrics.go
+++ b/pkg/clmimicry/metrics.go
@@ -24,7 +24,7 @@ func NewMetrics(namespace string) *Metrics {
 		decoratedEvents: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: namespace,
-				Name:      "libp2p_decorated_events_total",
+				Name:      "decorated_event_total",
 				Help:      "Counts number of decorated events when we received them. Neither of the sharding layers have been applied.",
 			},
 			[]string{"type", "network_id"},


### PR DESCRIPTION
The metric name was plural, which is not consistent with the naming convention for Prometheus metrics. This change renames the metric to be singular.