### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/cannon/deriver/blockprint/block_classification.go
+++ b/pkg/cannon/deriver/blockprint/block_classification.go
@@ -130,10 +130,7 @@ func (b *BlockClassificationDeriver) run(rctx context.Context) {
 				targetEndSlot := phase0.Slot(data.TargetEndSlot)
 
 				// Fetch the range from blockprint using our batch size
-				end := currentSlot + phase0.Slot(b.cfg.BatchSize)
-				if end > targetEndSlot {
-					end = targetEndSlot
-				}
+				end := min(currentSlot+phase0.Slot(b.cfg.BatchSize), targetEndSlot)
 
 				if currentSlot >= end {
 					return "", errors.New("current slot is equal or larger than end slot")

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -132,11 +132,7 @@ func NewBatchItemProcessor[T any](exporter ItemExporter[T], name string, log log
 	maxExportBatchSize := DefaultMaxExportBatchSize
 
 	if maxExportBatchSize > maxQueueSize {
-		if DefaultMaxExportBatchSize > maxQueueSize {
-			maxExportBatchSize = maxQueueSize
-		} else {
-			maxExportBatchSize = DefaultMaxExportBatchSize
-		}
+		maxExportBatchSize = min(DefaultMaxExportBatchSize, maxQueueSize)
 	}
 
 	o := BatchItemProcessorOptions{
@@ -230,10 +226,7 @@ func (bvp *BatchItemProcessor[T]) Write(ctx context.Context, s []*T) error {
 	// batch.
 	batchSize := bvp.o.Workers * bvp.o.MaxExportBatchSize
 	for start := 0; start < len(s); start += batchSize {
-		end := start + batchSize
-		if end > len(s) {
-			end = len(s)
-		}
+		end := min(start+batchSize, len(s))
 
 		prepared := []*TraceableItem[T]{}
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.
