### PR TITLE
feat(discovery): remove retry logic for consensus record addition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/creasty/defaults v1.8.0
 	github.com/ethereum/go-ethereum v1.15.11
-	github.com/ethpandaops/beacon v0.60.0
-	github.com/ethpandaops/ethcore v0.0.0-20250702014122-6069384d5e64
+	github.com/ethpandaops/beacon v0.61.0
+	github.com/ethpandaops/ethcore v0.0.0-20250703053009-1a87adc3340d
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ferranbt/fastssz v0.1.4
 	github.com/go-co-op/gocron/v2 v2.16.2

--- a/go.sum
+++ b/go.sum
@@ -242,11 +242,10 @@ github.com/ethereum/go-ethereum v1.15.11 h1:JK73WKeu0WC0O1eyX+mdQAVHUV+UR1a9VB/d
 github.com/ethereum/go-ethereum v1.15.11/go.mod h1:mf8YiHIb0GR4x4TipcvBUPxJLw1mFdmxzoDi11sDRoI=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/ethpandaops/beacon v0.60.0 h1:Qvq/aVlT8PxmmaAFjWDjLu/uW78rezhFd9zy2foTjos=
-github.com/ethpandaops/beacon v0.60.0/go.mod h1:T5HSrqxG8B28AT1zGFs+N/YDfDWMKBdYZX4Cxvjh2Zc=
-github.com/ethpandaops/ethcore v0.0.0-20250702005658-34f2999800a3/go.mod h1:Mkl9sl4s5o5HGtDcI0RiW21BhXKZf56rDVzkIYDHdq8=
-github.com/ethpandaops/ethcore v0.0.0-20250702014122-6069384d5e64 h1:U9YgVf6utG+Ve44Z5vKv+cf4NeSznktFpX9kenLtPZk=
-github.com/ethpandaops/ethcore v0.0.0-20250702014122-6069384d5e64/go.mod h1:Mkl9sl4s5o5HGtDcI0RiW21BhXKZf56rDVzkIYDHdq8=
+github.com/ethpandaops/beacon v0.61.0 h1:uDymnPAqDnu96bWEek0cHApj+yv2eGUIzLe94QQq+MQ=
+github.com/ethpandaops/beacon v0.61.0/go.mod h1:T5HSrqxG8B28AT1zGFs+N/YDfDWMKBdYZX4Cxvjh2Zc=
+github.com/ethpandaops/ethcore v0.0.0-20250703053009-1a87adc3340d h1:fYtQSf2IYLd54DDtrEt3F+ZTPqKAou3hI2FNOMCCD/o=
+github.com/ethpandaops/ethcore v0.0.0-20250703053009-1a87adc3340d/go.mod h1:QHrPSV5S/Y7N7Wec8br/qPzexybgzMUxxFGXnU5KBrU=
 github.com/ethpandaops/ethereum-package-go v0.4.0 h1:ItH40F7/TDGAtvSFU2oGUb0Cc95IWGSZLapw/2GFtxk=
 github.com/ethpandaops/ethereum-package-go v0.4.0/go.mod h1:cT6pzGeMN8QdrudoF7Crk7TdopX7FMhyzZfWACsW+GQ=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/pkg/discovery/p2p/consensus_crawler.go
+++ b/pkg/discovery/p2p/consensus_crawler.go
@@ -39,8 +39,8 @@ func NewConsensusCrawler(ctx context.Context, log logrus.FieldLogger, beaconNode
 		DialTimeout:      5 * time.Second,
 		CooloffDuration:  10 * time.Second,
 		UserAgent:        xatu.Full(),
-		MaxRetryAttempts: 3,
-		RetryBackoff:     10 * time.Second,
+		MaxRetryAttempts: 1,
+		RetryBackoff:     2 * time.Second,
 	}
 
 	manual := &discovery.Manual{}


### PR DESCRIPTION
The `ethcore` crawler has its own retry logic built it, we don't need retry logic here now, let the crawler handle it.
