### PR TITLE
fix(vector): use `split!` instead of `split` to parse capabilities st…

### DIFF
--- a/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
@@ -2198,7 +2198,7 @@ transforms:
       .name = .data.name
       # Parse capabilities string into array
       if exists(.data.capabilities) && .data.capabilities != null {
-        .capabilities = split(.data.capabilities, ",")
+        .capabilities = split!(.data.capabilities, ",")
       } else {
         .capabilities = []
       }


### PR DESCRIPTION
![Screenshot 2025-07-08 at 16 48 33](https://github.com/user-attachments/assets/96b15f77-0ea7-4c91-9c89-11c1d2f9a790)
