### PR TITLE
fix(migrations): extend ENR column size and improve consensus migrati…

### DIFF
--- a/migrations/postgres/006_consensus.down.sql
+++ b/migrations/postgres/006_consensus.down.sql
@@ -1,1 +1,16 @@
+-- Drop indexes first
+DROP INDEX IF EXISTS node_record_consensus_create_time_network_id_fork_digest_idx;
+DROP INDEX IF EXISTS node_record_consensus_network_id_fork_digest_create_time_idx;
+DROP INDEX IF EXISTS node_record_consensus_network_id_create_time_idx;
+
+-- Drop the table
 DROP TABLE IF EXISTS node_record_consensus;
+
+-- Remove added columns from node_record
+ALTER TABLE node_record DROP COLUMN IF EXISTS next_fork_digest;
+ALTER TABLE node_record DROP COLUMN IF EXISTS cgc;
+
+-- Revert ENR column type changes
+ALTER TABLE node_record_activity ALTER COLUMN enr TYPE VARCHAR(304);
+ALTER TABLE node_record_execution ALTER COLUMN enr TYPE VARCHAR(304);
+ALTER TABLE node_record ALTER COLUMN enr TYPE VARCHAR(304);

--- a/migrations/postgres/006_consensus.up.sql
+++ b/migrations/postgres/006_consensus.up.sql
@@ -26,3 +26,7 @@ CREATE TABLE node_record_consensus (
 CREATE INDEX node_record_consensus_network_id_create_time_idx ON node_record_consensus (network_id, create_time DESC);
 CREATE INDEX node_record_consensus_network_id_fork_digest_create_time_idx ON node_record_consensus (network_id, fork_digest, create_time DESC);
 CREATE INDEX node_record_consensus_create_time_network_id_fork_digest_idx ON node_record_consensus (create_time, network_id, fork_digest);
+
+ALTER TABLE node_record ALTER COLUMN enr TYPE VARCHAR(1000);
+ALTER TABLE node_record_execution ALTER COLUMN enr TYPE VARCHAR(1000);
+ALTER TABLE node_record_activity ALTER COLUMN enr TYPE VARCHAR(1000);


### PR DESCRIPTION
…on rollback

- Increase ENR column size from VARCHAR(304) to VARCHAR(1000) for node_record tables
- Add comprehensive rollback logic in down migration including index cleanup
- Ensure proper column type reversion during rollback