### PR TITLE
fix: improve GeoIP database handling in Docker setup

### DIFF
--- a/deploy/local/docker-compose/xatu-server-entrypoint.sh
+++ b/deploy/local/docker-compose/xatu-server-entrypoint.sh
@@ -3,8 +3,8 @@
 # Copy the template config
 cp /etc/xatu-server/config-template.yaml /etc/xatu-server/config.yaml
 
-# Check if GeoIP databases exist
-if [ -f /geoip/GeoLite2-City.mmdb ] && [ -f /geoip/GeoLite2-ASN.mmdb ]; then
+# Check if GeoIP databases exist and are not empty
+if [ -s /geoip/GeoLite2-City.mmdb ] && [ -s /geoip/GeoLite2-ASN.mmdb ]; then
     echo "GeoIP databases found. Enabling GeoIP..."
     
     # Create a temporary file with the geoip configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,19 +169,9 @@ services:
     volumes:
       - ./deploy/local/docker-compose/xatu-server.yaml:/etc/xatu-server/config-template.yaml
       - ./deploy/local/docker-compose/xatu-server-entrypoint.sh:/xatu-server-entrypoint.sh:ro
-      # GeoIP databases - will be mounted if they exist
-      - type: bind
-        source: ./GeoLite2-City.mmdb
-        target: /geoip/GeoLite2-City.mmdb
-        read_only: true
-        bind:
-          create_host_path: false
-      - type: bind
-        source: ./GeoLite2-ASN.mmdb
-        target: /geoip/GeoLite2-ASN.mmdb
-        read_only: true
-        bind:
-          create_host_path: false
+      # GeoIP databases - create empty files if they don't exist
+      - ./GeoLite2-City.mmdb:/geoip/GeoLite2-City.mmdb:ro
+      - ./GeoLite2-ASN.mmdb:/geoip/GeoLite2-ASN.mmdb:ro
     networks:
       - xatu-net
 


### PR DESCRIPTION
- Change file existence check to non-empty check using -s flag
- Simplify volume mounts for GeoIP databases in docker-compose
- Remove complex bind mount configuration in favor of simpler syntax