### PR TITLE
fix: resolve libp2p peer_id parsing and expand peer table population

### DIFF
--- a/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
@@ -1537,7 +1537,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1610,7 +1612,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1666,7 +1670,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1722,7 +1728,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1793,7 +1801,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1873,7 +1883,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
@@ -1945,7 +1957,9 @@ transforms:
 
       # Extract peer_id from protobuf wrapper format if present
       if starts_with(string!(.data.peer_id), "value:") {
-        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+        # Remove the 'value:"' prefix and the trailing '"'
+        peer_id_temp = replace(string!(.data.peer_id), "value:\"", "")
+        .data.peer_id = replace(peer_id_temp, "\"", "")
       }
 
       peer_id_key, err = .data.peer_id + .meta_network_name

--- a/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
@@ -290,9 +290,25 @@ transforms:
     inputs:
       - xatu_server_events_router.libp2p_trace_connected
       - xatu_server_events_router.libp2p_trace_disconnected
+      - xatu_server_events_router.libp2p_trace_add_peer
+      - xatu_server_events_router.libp2p_trace_remove_peer
+      - xatu_server_events_router.libp2p_trace_recv_rpc
+      - xatu_server_events_router.libp2p_trace_send_rpc
+      - xatu_server_events_router.libp2p_trace_drop_rpc
+      - xatu_server_events_router.libp2p_trace_graft
+      - xatu_server_events_router.libp2p_trace_prune
     source: |-
-      .peer_id = .data.remote_peer
-      key, err = .data.remote_peer + .meta_network_name
+      # Handle different peer_id field names
+      if exists(.data.remote_peer) {
+        .peer_id = .data.remote_peer
+      } else if exists(.data.peer_id) {
+        .peer_id = .data.peer_id
+      } else {
+        .error = "No peer_id field found"
+        log(., level: "error", rate_limit_secs: 60)
+      }
+      
+      key, err = .peer_id + .meta_network_name
       if err != null {
         .error = err
         .error_description = "failed to generate unique key"
@@ -1519,6 +1535,11 @@ transforms:
       }
       .rpc_meta_unique_key = rootEventKey
 
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
+
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
         .error = err
@@ -1587,6 +1608,11 @@ transforms:
       }
       .rpc_meta_unique_key = rootEventKey
 
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
+
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
         .error = err
@@ -1638,6 +1664,11 @@ transforms:
       }
       .rpc_meta_unique_key = rootEventKey
 
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
+
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
         .error = err
@@ -1688,6 +1719,11 @@ transforms:
         log(., level: "error", rate_limit_secs: 60)
       }
       .rpc_meta_unique_key = rootEventKey
+
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
@@ -1754,6 +1790,11 @@ transforms:
         log(., level: "error", rate_limit_secs: 60)
       }
       .rpc_meta_unique_key = rootEventKey
+
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
@@ -1830,6 +1871,11 @@ transforms:
       }
       .rpc_meta_unique_key = rootEventKey
 
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
+
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {
         .error = err
@@ -1896,6 +1942,11 @@ transforms:
         log(., level: "error", rate_limit_secs: 60)
       }
       .rpc_meta_unique_key = rootEventKey
+
+      # Extract peer_id from protobuf wrapper format if present
+      if starts_with(string!(.data.peer_id), "value:") {
+        .data.peer_id = parse_regex!(string!(.data.peer_id), r'value:"([^"]+)"').captures[0]
+      }
 
       peer_id_key, err = .data.peer_id + .meta_network_name
       if err != null {

--- a/pkg/clmimicry/event_libp2p.go
+++ b/pkg/clmimicry/event_libp2p.go
@@ -495,7 +495,7 @@ func (p *Processor) handleSendRPCEvent(
 	// 2. RPC meta level messages.
 	rpcMetaDecoratedEvents, err := p.parseRPCMeta(
 		rootEventID,
-		data.GetPeerId().String(),
+		data.GetPeerId().GetValue(),
 		clientMeta,
 		traceMeta,
 		event,
@@ -612,7 +612,7 @@ func (p *Processor) handleRecvRPCEvent(
 	// 2. RPC meta level messages.
 	rpcMetaDecoratedEvents, err := p.parseRPCMeta(
 		rootEventID,
-		data.GetPeerId().String(),
+		data.GetPeerId().GetValue(),
 		clientMeta,
 		traceMeta,
 		event,
@@ -690,7 +690,7 @@ func (p *Processor) handleDropRPCEvent(
 	// 2. RPC meta level messages.
 	rpcMetaDecoratedEvents, err := p.parseRPCMeta(
 		rootEventID,
-		data.GetPeerId().String(),
+		data.GetPeerId().GetValue(),
 		clientMeta,
 		traceMeta,
 		event,


### PR DESCRIPTION
- Add peer_id extraction from protobuf wrapper format in 7 RPC meta control transforms
- Expand libp2p_peer table inputs to include all peer-related events (add_peer, remove_peer, recv_rpc, send_rpc, drop_rpc, graft, prune)
- Update peer_id field handling to support both remote_peer and peer_id field names
- Ensures libp2p_connected and libp2p_rpc_meta_control_* tables are properly joinable

These changes fix malformed peer_id values that were preventing proper table joins and ensure the libp2p_peer table contains all peers, not just connected/disconnected ones.

🤖 Generated with [Claude Code](https://claude.ai/code)