### PR TITLE
feat: remove deprecated Blockprint support from xatu-cannon

### DIFF
--- a/deploy/local/docker-compose/vector-http-kafka.yaml
+++ b/deploy/local/docker-compose/vector-http-kafka.yaml
@@ -17,7 +17,6 @@ transforms:
     inputs:
       - xatu_server_events_http
     route:
-      blockprint_block_classification: .event.name == "BLOCKPRINT_BLOCK_CLASSIFICATION"
       eth_v1_beacon_blob_sidecar: .event.name == "BEACON_API_ETH_V1_BEACON_BLOB_SIDECAR"
       eth_v1_beacon_committee: .event.name == "BEACON_API_ETH_V1_BEACON_COMMITTEE"
       eth_v1_debug_fork_choice_reorg_v2: .event.name == "BEACON_API_ETH_V1_DEBUG_FORK_CHOICE_REORG_V2"
@@ -651,22 +650,6 @@ sinks:
     bootstrap_servers: "${KAFKA_BROKERS}"
     key_field: "event.id"
     topic: beacon-api-eth-v2-beacon-block-withdrawal
-    compression: snappy
-    healthcheck:
-      enabled: true
-    encoding:
-      codec: json
-  blockprint_block_classification_kafka:
-    type: kafka
-    buffer:
-      max_events: 500000
-    batch:
-      timeout_secs: 0.5
-    inputs:
-      - xatu_server_events_router.blockprint_block_classification
-    bootstrap_servers: "${KAFKA_BROKERS}"
-    key_field: "event.id"
-    topic: blockprint-block-classification
     compression: snappy
     healthcheck:
       enabled: true

--- a/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
@@ -65,16 +65,6 @@ sources:
       - "^beacon-api-eth-v2-beacon-block.+"
     librdkafka_options:
       message.max.bytes: "10485760" # 10MB
-  blockprint_block_classification_events_kafka:
-    type: kafka
-    bootstrap_servers: "${KAFKA_BROKERS}"
-    group_id: xatu-vector-kafka-clickhouse-blockprint-block-classification-events
-    key_field: "event.id"
-    auto_offset_reset: earliest
-    decoding:
-      codec: json
-    topics:
-      - "blockprint-block-classification"
   beacon_api_eth_v1_beacon_blob_sidecar_kafka:
     type: kafka
     bootstrap_servers: "${KAFKA_BROKERS}"
@@ -156,7 +146,6 @@ transforms:
       - beacon_api_eth_v1_validator_kafka
       - mempool_transaction_events_kafka
       - beacon_api_eth_v2_beacon_block_events_kafka
-      - blockprint_block_classification_events_kafka
       - beacon_api_eth_v1_beacon_blob_sidecar_kafka
       - beacon_api_eth_v1_proposer_kafka
       - beacon_api_eth_v1_beacon_validators_kafka
@@ -343,7 +332,6 @@ transforms:
     inputs:
       - xatu_server_events_meta
     route:
-      blockprint_block_classification: .event.name == "BLOCKPRINT_BLOCK_CLASSIFICATION"
       canonical_beacon_blob_sidecar: .event.name == "BEACON_API_ETH_V1_BEACON_BLOB_SIDECAR"
       canonical_beacon_block_attester_slashing: .event.name == "BEACON_API_ETH_V2_BEACON_BLOCK_ATTESTER_SLASHING"
       canonical_beacon_block_elaborated_attestation: .event.name == "BEACON_API_ETH_V2_BEACON_BLOCK_ELABORATED_ATTESTATION"
@@ -390,7 +378,6 @@ transforms:
   xatu_server_events_router_matched:
     type: log_to_metric
     inputs:
-      - xatu_server_events_router.blockprint_block_classification
       - xatu_server_events_router.canonical_beacon_blob_sidecar
       - xatu_server_events_router.canonical_beacon_validators
       - xatu_server_events_router.canonical_beacon_block
@@ -1648,65 +1635,6 @@ transforms:
           })
       }
       . = events
-  blockprint_block_classification_formatted:
-    type: remap
-    inputs:
-      - xatu_server_events_router.blockprint_block_classification
-    source: |-
-      event_date_time, err = parse_timestamp(.event.date_time, format: "%+");
-      if err == null {
-        .event_date_time = to_unix_timestamp(event_date_time, unit: "milliseconds")
-      } else {
-        .error = err
-        .error_description = "failed to parse event date time"
-        log(., level: "error", rate_limit_secs: 60)
-      }
-      .slot = .data.slot
-      slot_start_date_time, err = parse_timestamp(.meta.client.additional_data.slot.start_date_time, format: "%+");
-      if err == null {
-        .slot_start_date_time = to_unix_timestamp(slot_start_date_time)
-      } else {
-        .error = err
-        .error_description = "failed to parse slot start date time"
-        log(., level: "error", rate_limit_secs: 60)
-      }
-      .epoch = .meta.client.additional_data.epoch.number
-      epoch_start_date_time, err = parse_timestamp(.meta.client.additional_data.epoch.start_date_time, format: "%+");
-      if err == null {
-        .epoch_start_date_time = to_unix_timestamp(epoch_start_date_time)
-      } else {
-        .error = err
-        .error_description = "failed to parse epoch start date time"
-        log(., level: "error", rate_limit_secs: 60)
-      }
-      best_guess_single, err = downcase(.data.best_guess_single)
-      if err != null {
-        .error = err
-        .error_description = "failed to downcase best_guess_single"
-        log(., level: "error", rate_limit_secs: 60)
-        best_guess_single = .data.best_guess_single
-      }
-      .best_guess_single = best_guess_single
-      best_guess_multi, err = downcase(.data.best_guess_multi)
-      if err != null {
-        .error = err
-        .error_description = "failed to downcase best_guess_multi"
-        log(., level: "error", rate_limit_secs: 60)
-        best_guess_multi = .data.best_guess_multi
-      }
-      .best_guess_multi = best_guess_multi
-      .client_probability_uncertain = .data.client_probability.uncertain
-      .client_probability_prysm = .data.client_probability.prysm
-      .client_probability_teku = .data.client_probability.teku
-      .client_probability_nimbus = .data.client_probability.nimbus
-      .client_probability_lodestar = .data.client_probability.lodestar
-      .client_probability_grandine = .data.client_probability.grandine
-      .client_probability_lighthouse = .data.client_probability.lighthouse
-      .proposer_index  = .data.proposer_index
-      .updated_date_time = to_unix_timestamp(now())
-      del(.event)
-      del(.meta)
-      del(.data)
   canonical_beacon_proposer_duty_formatted:
     type: remap
     inputs:
@@ -2964,26 +2892,6 @@ sinks:
     database: default
     endpoint: "${CLICKHOUSE_ENDPOINT}"
     table: canonical_beacon_blob_sidecar
-    auth:
-      strategy: basic
-      user: "${CLICKHOUSE_USER}"
-      password: "${CLICKHOUSE_PASSWORD}"
-    batch:
-      max_bytes: 52428800
-      max_events: 200000
-      timeout_secs: 1
-    buffer:
-      max_events: 200000
-    healthcheck:
-      enabled: true
-    skip_unknown_fields: false
-  blockprint_block_classification_clickhouse:
-    type: clickhouse
-    inputs:
-      - blockprint_block_classification_formatted
-    database: default
-    endpoint: "${CLICKHOUSE_ENDPOINT}"
-    table: beacon_block_classification
     auth:
       strategy: basic
       user: "${CLICKHOUSE_USER}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,7 +284,6 @@ services:
           "beacon-api-eth-v2-beacon-block-withdrawal"
           "beacon-api-eth-v2-beacon-block-elaborated-attestation"
           "beacon-p2p-attestation"
-          "blockprint-block-classification"
           "mempool-transaction"
           "mempool-transaction-v2"
           "libp2p-trace-connected"

--- a/pkg/cannon/cannon.go
+++ b/pkg/cannon/cannon.go
@@ -18,12 +18,10 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/beevik/ntp"
 	"github.com/ethpandaops/ethwallclock"
-	aBlockprint "github.com/ethpandaops/xatu/pkg/cannon/blockprint"
 	"github.com/ethpandaops/xatu/pkg/cannon/coordinator"
 	"github.com/ethpandaops/xatu/pkg/cannon/deriver"
 	v1 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v1"
 	v2 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v2"
-	"github.com/ethpandaops/xatu/pkg/cannon/deriver/blockprint"
 	"github.com/ethpandaops/xatu/pkg/cannon/ethereum"
 	"github.com/ethpandaops/xatu/pkg/cannon/iterator"
 	"github.com/ethpandaops/xatu/pkg/observability"
@@ -394,14 +392,7 @@ func (c *Cannon) startBeaconBlockProcessor(ctx context.Context) error {
 
 		backfillingCheckpointIteratorMetrics := iterator.NewBackfillingCheckpointMetrics("xatu_cannon")
 
-		blockprintIteratorMetrics := iterator.NewBlockprintMetrics("xatu_cannon")
-
 		finalizedCheckpoint := "finalized"
-
-		blockprintClient := aBlockprint.NewClient(
-			c.Config.Derivers.BlockClassificationConfig.Endpoint,
-			c.Config.Derivers.BlockClassificationConfig.Headers,
-		)
 
 		eventDerivers := []deriver.EventDeriver{
 			v2.NewAttesterSlashingDeriver(
@@ -555,22 +546,6 @@ func (c *Cannon) startBeaconBlockProcessor(ctx context.Context) error {
 				),
 				c.beacon,
 				clientMeta,
-			),
-			blockprint.NewBlockClassificationDeriver(
-				c.log,
-				&c.Config.Derivers.BlockClassificationConfig,
-				iterator.NewBlockprintIterator(
-					c.log,
-					networkName,
-					networkID,
-					xatu.CannonType_BLOCKPRINT_BLOCK_CLASSIFICATION,
-					c.coordinatorClient,
-					&blockprintIteratorMetrics,
-					blockprintClient,
-				),
-				c.beacon,
-				clientMeta,
-				blockprintClient,
 			),
 			v1.NewBeaconBlobDeriver(
 				c.log,

--- a/pkg/cannon/deriver/config.go
+++ b/pkg/cannon/deriver/config.go
@@ -3,31 +3,24 @@ package deriver
 import (
 	v1 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v1"
 	v2 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v2"
-	"github.com/ethpandaops/xatu/pkg/cannon/deriver/blockprint"
-	"github.com/pkg/errors"
 )
 
 type Config struct {
-	AttesterSlashingConfig      v2.AttesterSlashingDeriverConfig            `yaml:"attesterSlashing"`
-	BLSToExecutionConfig        v2.BLSToExecutionChangeDeriverConfig        `yaml:"blsToExecutionChange"`
-	DepositConfig               v2.DepositDeriverConfig                     `yaml:"deposit"`
-	ExecutionTransactionConfig  v2.ExecutionTransactionDeriverConfig        `yaml:"executionTransaction"`
-	ProposerSlashingConfig      v2.ProposerSlashingDeriverConfig            `yaml:"proposerSlashing"`
-	VoluntaryExitConfig         v2.VoluntaryExitDeriverConfig               `yaml:"voluntaryExit"`
-	WithdrawalConfig            v2.WithdrawalDeriverConfig                  `yaml:"withdrawal"`
-	BeaconBlockConfig           v2.BeaconBlockDeriverConfig                 `yaml:"beaconBlock"`
-	BlockClassificationConfig   blockprint.BlockClassificationDeriverConfig `yaml:"blockClassification"`
-	BeaconBlobSidecarConfig     v1.BeaconBlobDeriverConfig                  `yaml:"beaconBlobSidecar"`
-	ProposerDutyConfig          v1.ProposerDutyDeriverConfig                `yaml:"proposerDuty"`
-	ElaboratedAttestationConfig v2.ElaboratedAttestationDeriverConfig       `yaml:"elaboratedAttestation"`
-	BeaconValidatorsConfig      v1.BeaconValidatorsDeriverConfig            `yaml:"beaconValidators"`
-	BeaconCommitteeConfig       v1.BeaconCommitteeDeriverConfig             `yaml:"beaconCommittee"`
+	AttesterSlashingConfig      v2.AttesterSlashingDeriverConfig      `yaml:"attesterSlashing"`
+	BLSToExecutionConfig        v2.BLSToExecutionChangeDeriverConfig  `yaml:"blsToExecutionChange"`
+	DepositConfig               v2.DepositDeriverConfig               `yaml:"deposit"`
+	ExecutionTransactionConfig  v2.ExecutionTransactionDeriverConfig  `yaml:"executionTransaction"`
+	ProposerSlashingConfig      v2.ProposerSlashingDeriverConfig      `yaml:"proposerSlashing"`
+	VoluntaryExitConfig         v2.VoluntaryExitDeriverConfig         `yaml:"voluntaryExit"`
+	WithdrawalConfig            v2.WithdrawalDeriverConfig            `yaml:"withdrawal"`
+	BeaconBlockConfig           v2.BeaconBlockDeriverConfig           `yaml:"beaconBlock"`
+	BeaconBlobSidecarConfig     v1.BeaconBlobDeriverConfig            `yaml:"beaconBlobSidecar"`
+	ProposerDutyConfig          v1.ProposerDutyDeriverConfig          `yaml:"proposerDuty"`
+	ElaboratedAttestationConfig v2.ElaboratedAttestationDeriverConfig `yaml:"elaboratedAttestation"`
+	BeaconValidatorsConfig      v1.BeaconValidatorsDeriverConfig      `yaml:"beaconValidators"`
+	BeaconCommitteeConfig       v1.BeaconCommitteeDeriverConfig       `yaml:"beaconCommittee"`
 }
 
 func (c *Config) Validate() error {
-	if err := c.BlockClassificationConfig.Validate(); err != nil {
-		return errors.Wrap(err, "invalid block classification deriver config")
-	}
-
 	return nil
 }

--- a/pkg/cannon/deriver/event_deriver.go
+++ b/pkg/cannon/deriver/event_deriver.go
@@ -6,7 +6,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	v1 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v1"
 	v2 "github.com/ethpandaops/xatu/pkg/cannon/deriver/beacon/eth/v2"
-	"github.com/ethpandaops/xatu/pkg/cannon/deriver/blockprint"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -30,7 +29,6 @@ var _ EventDeriver = &v2.ExecutionTransactionDeriver{}
 var _ EventDeriver = &v2.BLSToExecutionChangeDeriver{}
 var _ EventDeriver = &v2.WithdrawalDeriver{}
 var _ EventDeriver = &v2.BeaconBlockDeriver{}
-var _ EventDeriver = &blockprint.BlockClassificationDeriver{}
 var _ EventDeriver = &v2.ElaboratedAttestationDeriver{}
 var _ EventDeriver = &v1.ProposerDutyDeriver{}
 var _ EventDeriver = &v1.BeaconBlobDeriver{}

--- a/pkg/proto/blockprint/block_classification.proto
+++ b/pkg/proto/blockprint/block_classification.proto
@@ -1,3 +1,4 @@
+// Deprecated: Blockprint is no longer supported
 syntax = "proto3";
 
 package xatu.blockprint;

--- a/pkg/proto/xatu/coordinator.proto
+++ b/pkg/proto/xatu/coordinator.proto
@@ -182,7 +182,7 @@ enum CannonType {
   BEACON_API_ETH_V2_BEACON_BLOCK_EXECUTION_TRANSACTION = 5;
   BEACON_API_ETH_V2_BEACON_BLOCK_WITHDRAWAL = 6;
   BEACON_API_ETH_V2_BEACON_BLOCK = 7;
-  BLOCKPRINT_BLOCK_CLASSIFICATION = 8;
+  BLOCKPRINT_BLOCK_CLASSIFICATION = 8; // Deprecated: Blockprint is no longer supported
   BEACON_API_ETH_V1_BEACON_BLOB_SIDECAR = 9;
   BEACON_API_ETH_V1_PROPOSER_DUTY = 10;
   BEACON_API_ETH_V2_BEACON_BLOCK_ELABORATED_ATTESTATION = 11;
@@ -235,6 +235,7 @@ message CannonLocationEthV2BeaconBlock {
   BackfillingCheckpointMarker backfilling_checkpoint_marker = 2;
 }
 
+// Deprecated: Blockprint is no longer supported
 message CannonLocationBlockprintBlockClassification {
   uint64 slot = 1;
   uint64 target_end_slot = 2;
@@ -287,6 +288,7 @@ message CannonLocation {
         [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK_WITHDRAWAL" ];
     CannonLocationEthV2BeaconBlock eth_v2_beacon_block = 10
         [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK" ];
+    // Deprecated: Blockprint is no longer supported
     CannonLocationBlockprintBlockClassification
         blockprint_block_classification = 11
         [ json_name = "BLOCKPRINT_BLOCK_CLASSIFICATION" ];

--- a/pkg/proto/xatu/event_ingester.proto
+++ b/pkg/proto/xatu/event_ingester.proto
@@ -665,6 +665,7 @@ message ClientMeta {
     BlockIdentifier block = 1;
   }
 
+  // Deprecated: Blockprint is no longer supported
   message AdditionalBlockprintBlockClassificationData {
     // Epoch contains the epoch information for the block classification.
     EpochV2 epoch = 1;
@@ -1361,6 +1362,7 @@ message ClientMeta {
     // eth v1 blob sidecar event.
     AdditionalEthV1EventsBlobSidecarData eth_v1_events_blob_sidecar = 42
         [ json_name = "BEACON_API_ETH_V1_EVENTS_BLOB_SIDECAR" ];
+    // Deprecated: Blockprint is no longer supported
     // AdditionalBlockprintBlockClassification contains additional data on
     // blockprint block classifications.
     AdditionalBlockprintBlockClassificationData
@@ -1603,7 +1605,7 @@ message Event {
     BEACON_API_ETH_V2_BEACON_BLOCK_EXECUTION_TRANSACTION = 30;
     BEACON_API_ETH_V2_BEACON_BLOCK_WITHDRAWAL = 31;
     BEACON_API_ETH_V1_EVENTS_BLOB_SIDECAR = 32;
-    BLOCKPRINT_BLOCK_CLASSIFICATION = 33;
+    BLOCKPRINT_BLOCK_CLASSIFICATION = 33; // Deprecated: Blockprint is no longer supported
     BEACON_API_ETH_V1_BEACON_BLOB_SIDECAR = 34;
     BEACON_P2P_ATTESTATION = 35;
     BEACON_API_ETH_V1_PROPOSER_DUTY = 36;
@@ -1745,6 +1747,7 @@ message DecoratedEvent {
         [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK_WITHDRAWAL" ];
     xatu.eth.v1.EventBlobSidecar eth_v1_events_blob_sidecar = 34
         [ json_name = "BEACON_API_ETH_V1_EVENTS_BLOB_SIDECAR" ];
+    // Deprecated: Blockprint is no longer supported
     xatu.blockprint.BlockClassification blockprint_block_classification = 35
         [ json_name = "BLOCKPRINT_BLOCK_CLASSIFICATION" ];
     xatu.eth.v1.BlobSidecar eth_v1_beacon_block_blob_sidecar = 36

--- a/pkg/server/service/event-ingester/event/event.go
+++ b/pkg/server/service/event-ingester/event/event.go
@@ -12,7 +12,6 @@ import (
 	v1 "github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/beacon/eth/v1"
 	v2 "github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/beacon/eth/v2"
 	v3 "github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/beacon/eth/v3"
-	"github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/blockprint"
 	"github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/libp2p"
 	"github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/mempool"
 	"github.com/ethpandaops/xatu/pkg/server/service/event-ingester/event/mevrelay"
@@ -56,7 +55,6 @@ var (
 	TypeBeaconEthV2BeaconExecutionTransaction   Type = v2.BeaconBlockExecutionTransactionType
 	TypeBeaconEthV2BeaconBLSToExecutionChange   Type = v2.BeaconBlockBLSToExecutionChangeType
 	TypeBeaconEthV2BeaconWithdrawal             Type = v2.BeaconBlockWithdrawalType
-	TypeBlockprintBlockClassification           Type = blockprint.BlockClassificationType
 	TypeBeaconETHV1EventsBlobSidecar            Type = v1.EventsBlobSidecarType
 	TypeBeaconETHV1EventsDataColumnSidecar      Type = v1.EventsDataColumnSidecarType
 	TypeBeaconETHV1BeaconBlobSidecar            Type = v1.BeaconBlobSidecarType
@@ -230,9 +228,6 @@ func NewEventRouter(log logrus.FieldLogger, cache store.Cache, geoipProvider geo
 	})
 	router.RegisterHandler(TypeBeaconEthV2BeaconWithdrawal, func(event *xatu.DecoratedEvent, router *EventRouter) (Event, error) {
 		return v2.NewBeaconBlockWithdrawal(router.log, event), nil
-	})
-	router.RegisterHandler(TypeBlockprintBlockClassification, func(event *xatu.DecoratedEvent, router *EventRouter) (Event, error) {
-		return blockprint.NewBlockClassification(router.log, event), nil
 	})
 	router.RegisterHandler(TypeBeaconETHV1EventsBlobSidecar, func(event *xatu.DecoratedEvent, router *EventRouter) (Event, error) {
 		return v1.NewEventsBlobSidecar(router.log, event), nil


### PR DESCRIPTION
Blockprint has been deprecated and is no longer supported. This commit removes all Blockprint-related code from xatu-cannon while maintaining proto backward compatibility.

Changes:
- Remove Blockprint deriver from xatu-cannon initialization
- Remove Blockprint configuration from deriver config
- Remove Blockprint event handler from xatu-server
- Remove Blockprint from Vector kafka/clickhouse configurations
- Remove Blockprint topic from docker-compose
- Add deprecation comments to proto files (keeping definitions for compatibility)
- ClickHouse tables remain unchanged (no data flow)

🤖 Generated with [Claude Code](https://claude.ai/code)