### PR TITLE
refactor(event_test.go): skip deprecated event types in tests

### DIFF
--- a/pkg/server/service/event-ingester/event/event_test.go
+++ b/pkg/server/service/event-ingester/event/event_test.go
@@ -12,20 +12,20 @@ func TestEventRouter_AllTypesHaveHandlers(t *testing.T) {
 	// Create a new EventRouter instance
 	router := event.NewEventRouter(nil, nil, nil)
 
+	// Event types that should be skipped (deprecated, unimplemented, or unknown types)
+	skippedEventTypes := map[string]string{
+		"BEACON_API_ETH_V1_EVENTS_UNKNOWN": "unknown event type",
+		"LIBP2P_TRACE_UNKNOWN":             "unknown event type",
+		"LIBP2P_TRACE_DROP_RPC":            "not implemented yet",
+		"BLOCKPRINT_BLOCK_CLASSIFICATION":  "deprecated: Blockprint support has been removed",
+	}
+
 	// List of all event types from event_ingester.proto
 	eventTypes := xatu.Event_Name_name
 
 	for _, eventType := range eventTypes {
-		if eventType == "BEACON_API_ETH_V1_EVENTS_UNKNOWN" {
-			continue
-		}
-
-		if eventType == "LIBP2P_TRACE_UNKNOWN" {
-			continue
-		}
-
-		if eventType == "LIBP2P_TRACE_DROP_RPC" {
-			// Not implemented yet
+		if reason, skip := skippedEventTypes[eventType]; skip {
+			t.Logf("Skipping event type %s: %s", eventType, reason)
 			continue
 		}
 


### PR DESCRIPTION
Blockprint support was removed here: https://github.com/ethpandaops/xatu/pull/628