### PR TITLE
fix: downgrade actions/checkout to v4.2.2 to fix node24 error

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -14,7 +14,7 @@ jobs:
       - size-l-x64
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}


### PR DESCRIPTION
The v5.0.0 release uses node24 which is not supported by GitHub Actions runners yet

🤖 Generated with [Claude Code](https://claude.ai/code)