### PR TITLE
feat(cl-mimicry): decouple parent/child event sharding

### DIFF
--- a/pkg/clmimicry/event_libp2p.go
+++ b/pkg/clmimicry/event_libp2p.go
@@ -477,25 +477,22 @@ func (p *Processor) handleSendRPCEvent(
 		return errors.Wrapf(err, "failed to parse rpc meta")
 	}
 
-	// Determine if parent event should be processed
-	var shouldProcessParent bool
+	// Only send events if there are child events to send
+	// The parent event is only sent alongside child events, not standalone
+	if len(rpcMetaDecoratedEvents) > 0 {
+		// Check if parent event should also be included
+		if p.events.SendRPCEnabled {
+			p.metrics.AddEvent(xatuEvent, networkStr)
 
-	if p.events.SendRPCEnabled {
-		p.metrics.AddEvent(xatuEvent, networkStr)
-		shouldProcessParent = p.ShouldTraceMessage(event, clientMeta, xatuEvent)
-	}
-
-	// Send events only if they should be processed
-	if len(rpcMetaDecoratedEvents) > 0 || shouldProcessParent {
-		if shouldProcessParent {
-			decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			if p.ShouldTraceMessage(event, clientMeta, xatuEvent) {
+				decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			}
 		}
+
 		decoratedEvents = append(decoratedEvents, rpcMetaDecoratedEvents...)
 
-		if len(decoratedEvents) > 0 {
-			if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
-				return errors.Wrapf(err, "failed to handle decorated events")
-			}
+		if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
+			return errors.Wrapf(err, "failed to handle decorated events")
 		}
 	}
 
@@ -606,25 +603,22 @@ func (p *Processor) handleRecvRPCEvent(
 		return errors.Wrapf(err, "failed to parse rpc meta")
 	}
 
-	// Determine if parent event should be processed
-	var shouldProcessParent bool
+	// Only send events if there are child events to send
+	// The parent event is only sent alongside child events, not standalone
+	if len(rpcMetaDecoratedEvents) > 0 {
+		// Check if parent event should also be included
+		if p.events.RecvRPCEnabled {
+			p.metrics.AddEvent(xatuEvent, networkStr)
 
-	if p.events.RecvRPCEnabled {
-		p.metrics.AddEvent(xatuEvent, networkStr)
-		shouldProcessParent = p.ShouldTraceMessage(event, clientMeta, xatuEvent)
-	}
-
-	// Send events only if they should be processed
-	if len(rpcMetaDecoratedEvents) > 0 || shouldProcessParent {
-		if shouldProcessParent {
-			decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			if p.ShouldTraceMessage(event, clientMeta, xatuEvent) {
+				decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			}
 		}
+
 		decoratedEvents = append(decoratedEvents, rpcMetaDecoratedEvents...)
 
-		if len(decoratedEvents) > 0 {
-			if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
-				return errors.Wrapf(err, "failed to handle decorated events")
-			}
+		if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
+			return errors.Wrapf(err, "failed to handle decorated events")
 		}
 	}
 
@@ -696,25 +690,22 @@ func (p *Processor) handleDropRPCEvent(
 		return errors.Wrapf(err, "failed to parse rpc meta")
 	}
 
-	// Determine if parent event should be processed
-	var shouldProcessParent bool
+	// Only send events if there are child events to send
+	// The parent event is only sent alongside child events, not standalone
+	if len(rpcMetaDecoratedEvents) > 0 {
+		// Check if parent event should also be included
+		if p.events.DropRPCEnabled {
+			p.metrics.AddEvent(xatuEvent, networkStr)
 
-	if p.events.DropRPCEnabled {
-		p.metrics.AddEvent(xatuEvent, networkStr)
-		shouldProcessParent = p.ShouldTraceMessage(event, clientMeta, xatuEvent)
-	}
-
-	// Send events only if they should be processed
-	if len(rpcMetaDecoratedEvents) > 0 || shouldProcessParent {
-		if shouldProcessParent {
-			decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			if p.ShouldTraceMessage(event, clientMeta, xatuEvent) {
+				decoratedEvents = append(decoratedEvents, rootRPCEvent)
+			}
 		}
+
 		decoratedEvents = append(decoratedEvents, rpcMetaDecoratedEvents...)
 
-		if len(decoratedEvents) > 0 {
-			if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
-				return errors.Wrapf(err, "failed to handle decorated events")
-			}
+		if err := p.output.HandleDecoratedEvents(ctx, decoratedEvents); err != nil {
+			return errors.Wrapf(err, "failed to handle decorated events")
 		}
 	}
 

--- a/pkg/clmimicry/event_libp2p_decoupled_test.go
+++ b/pkg/clmimicry/event_libp2p_decoupled_test.go
@@ -1,0 +1,479 @@
+package clmimicry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/xatu/pkg/output/mock"
+	"github.com/ethpandaops/xatu/pkg/proto/libp2p"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/probe-lab/hermes/host"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// TestDecoupledSharding tests that child events (like IHAVE) can be captured
+// independently of their parent events (SendRPC/RecvRPC/DropRPC)
+func TestDecoupledSharding(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *Config
+		parentEnabled bool
+		childEnabled  bool
+		expectParent  bool
+		expectChild   bool
+		description   string
+	}{
+		{
+			name: "parent_disabled_child_enabled_with_sharding",
+			config: &Config{
+				Events: EventConfig{
+					RecvRPCEnabled:             false, // Parent disabled
+					RpcMetaControlIHaveEnabled: true,  // Child enabled
+				},
+				Sharding: ShardingConfig{
+					Topics: map[string]*TopicShardingConfig{
+						".*attestation.*": {
+							TotalShards:  100,
+							ActiveShards: []uint64{0, 1, 2}, // Only capture 3% of messages
+						},
+					},
+				},
+			},
+			parentEnabled: false,
+			childEnabled:  true,
+			expectParent:  false, // Parent should not be sent
+			expectChild:   true,  // Child should be sent based on its own sharding
+			description:   "Parent disabled but child IHAVE events should still be captured based on sharding",
+		},
+		{
+			name: "parent_enabled_but_sharded_out_child_enabled",
+			config: &Config{
+				Events: EventConfig{
+					RecvRPCEnabled:             true, // Parent enabled
+					RpcMetaControlIHaveEnabled: true, // Child enabled
+				},
+				Sharding: ShardingConfig{
+					Topics: map[string]*TopicShardingConfig{
+						".*attestation.*": {
+							TotalShards:  100,
+							ActiveShards: []uint64{0}, // Only capture 1% of messages
+						},
+					},
+					NoShardingKeyEvents: &NoShardingKeyConfig{
+						Enabled: false, // Disable Group D events (like RECV_RPC without keys)
+					},
+				},
+			},
+			parentEnabled: true,
+			childEnabled:  true,
+			expectParent:  false, // Parent sharded out (Group D disabled)
+			expectChild:   true,  // Child should still be sent based on message ID sharding
+			description:   "Parent enabled but sharded out, child IHAVE should still be captured",
+		},
+		{
+			name: "both_enabled_and_pass_sharding",
+			config: &Config{
+				Events: EventConfig{
+					RecvRPCEnabled:             true, // Parent enabled
+					RpcMetaControlIHaveEnabled: true, // Child enabled
+				},
+				Sharding: ShardingConfig{
+					Topics: map[string]*TopicShardingConfig{
+						".*attestation.*": {
+							TotalShards:  100,
+							ActiveShards: []uint64{0}, // Capture 1%
+						},
+					},
+					NoShardingKeyEvents: &NoShardingKeyConfig{
+						Enabled: true, // Enable Group D events
+					},
+				},
+			},
+			parentEnabled: true,
+			childEnabled:  true,
+			expectParent:  true, // Parent passes (Group D enabled)
+			expectChild:   true, // Child passes based on sharding
+			description:   "Both parent and child enabled and pass sharding",
+		},
+		{
+			name: "parent_disabled_child_disabled",
+			config: &Config{
+				Events: EventConfig{
+					RecvRPCEnabled:             false, // Parent disabled
+					RpcMetaControlIHaveEnabled: false, // Child disabled
+				},
+			},
+			parentEnabled: false,
+			childEnabled:  false,
+			expectParent:  false, // Parent disabled
+			expectChild:   false, // Child disabled
+			description:   "Both parent and child disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockSink := mock.NewMockSink(ctrl)
+
+			// Setup expectations
+			expectedEventCount := 0
+			if tt.expectParent {
+				expectedEventCount++
+			}
+			if tt.expectChild {
+				expectedEventCount++
+			}
+
+			if expectedEventCount > 0 {
+				mockSink.EXPECT().HandleNewDecoratedEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, events []*xatu.DecoratedEvent) error {
+						// Verify we got the expected events
+						hasParent := false
+						hasChild := false
+
+						for _, event := range events {
+							switch event.Event.Name {
+							case xatu.Event_LIBP2P_TRACE_RECV_RPC:
+								hasParent = true
+							case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IHAVE:
+								hasChild = true
+							}
+						}
+
+						assert.Equal(t, tt.expectParent, hasParent, "Parent event presence mismatch")
+						assert.Equal(t, tt.expectChild, hasChild, "Child event presence mismatch")
+
+						return nil
+					},
+				).Times(1)
+			}
+
+			// Create mimicry with test configuration
+			mimicry := createTestMimicry(t, tt.config, mockSink)
+
+			// Create test event with IHAVE control message
+			peerID, err := peer.Decode(examplePeerID)
+			require.NoError(t, err)
+
+			event := &host.TraceEvent{
+				Type:      "RecvRPC",
+				PeerID:    peerID,
+				Timestamp: time.Now(),
+				Payload: &host.RpcMeta{
+					PeerID: peerID,
+					Control: &host.RpcMetaControl{
+						IHave: []host.RpcControlIHave{
+							{
+								TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+								MsgIDs: []string{
+									"msg_30", // This hashes to shard 0 (verified)
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Handle the event
+			clientMeta := createTestClientMeta()
+			traceMeta := &libp2p.TraceEventMetadata{
+				PeerId: wrapperspb.String(examplePeerID),
+			}
+
+			// Call the new handleRecvRPCEvent with the additional parameters
+			err = mimicry.GetProcessor().handleRecvRPCEvent(
+				context.Background(),
+				clientMeta,
+				traceMeta,
+				event,
+				xatu.Event_LIBP2P_TRACE_RECV_RPC.String(),
+				"1", // network ID
+			)
+
+			// Should not error
+			assert.NoError(t, err, tt.description)
+		})
+	}
+}
+
+// TestDecoupledShardingSendRPC tests decoupled sharding for SendRPC events
+func TestDecoupledShardingSendRPC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSink := mock.NewMockSink(ctrl)
+
+	// Configure to disable parent but enable child
+	config := &Config{
+		Events: EventConfig{
+			SendRPCEnabled:             false, // Parent disabled
+			RpcMetaControlIHaveEnabled: true,  // Child enabled
+		},
+		Sharding: ShardingConfig{
+			Topics: map[string]*TopicShardingConfig{
+				".*attestation.*": {
+					TotalShards:  100,
+					ActiveShards: []uint64{0}, // Capture 1%
+				},
+			},
+		},
+	}
+
+	// Expect only child event, not parent
+	mockSink.EXPECT().HandleNewDecoratedEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, events []*xatu.DecoratedEvent) error {
+			// Should only have IHAVE event, not SEND_RPC
+			assert.Len(t, events, 1)
+			assert.Equal(t, xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IHAVE, events[0].Event.Name)
+
+			return nil
+		},
+	).Times(1)
+
+	mimicry := createTestMimicry(t, config, mockSink)
+
+	// Create test event
+	peerID, err := peer.Decode(examplePeerID)
+	require.NoError(t, err)
+
+	event := &host.TraceEvent{
+		Type:      "SendRPC",
+		PeerID:    peerID,
+		Timestamp: time.Now(),
+		Payload: &host.RpcMeta{
+			PeerID: peerID,
+			Control: &host.RpcMetaControl{
+				IHave: []host.RpcControlIHave{
+					{
+						TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+						MsgIDs:  []string{"msg_30"},
+					},
+				},
+			},
+		},
+	}
+
+	clientMeta := createTestClientMeta()
+	traceMeta := &libp2p.TraceEventMetadata{
+		PeerId: wrapperspb.String(examplePeerID),
+	}
+
+	err = mimicry.GetProcessor().handleSendRPCEvent(
+		context.Background(),
+		clientMeta,
+		traceMeta,
+		event,
+		xatu.Event_LIBP2P_TRACE_SEND_RPC.String(),
+		"1",
+	)
+
+	assert.NoError(t, err)
+}
+
+// TestDecoupledShardingDropRPC tests decoupled sharding for DropRPC events
+func TestDecoupledShardingDropRPC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSink := mock.NewMockSink(ctrl)
+
+	// Configure to disable parent but enable child
+	config := &Config{
+		Events: EventConfig{
+			DropRPCEnabled:             false, // Parent disabled
+			RpcMetaControlIHaveEnabled: true,  // Child enabled
+		},
+		Sharding: ShardingConfig{
+			Topics: map[string]*TopicShardingConfig{
+				".*attestation.*": {
+					TotalShards:  100,
+					ActiveShards: []uint64{0}, // Capture 1%
+				},
+			},
+		},
+	}
+
+	// Expect only child event, not parent
+	mockSink.EXPECT().HandleNewDecoratedEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, events []*xatu.DecoratedEvent) error {
+			// Should only have IHAVE event, not DROP_RPC
+			assert.Len(t, events, 1)
+			assert.Equal(t, xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IHAVE, events[0].Event.Name)
+
+			return nil
+		},
+	).Times(1)
+
+	mimicry := createTestMimicry(t, config, mockSink)
+
+	// Create test event
+	peerID, err := peer.Decode(examplePeerID)
+	require.NoError(t, err)
+
+	event := &host.TraceEvent{
+		Type:      "DropRPC",
+		PeerID:    peerID,
+		Timestamp: time.Now(),
+		Payload: &host.RpcMeta{
+			PeerID: peerID,
+			Control: &host.RpcMetaControl{
+				IHave: []host.RpcControlIHave{
+					{
+						TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+						MsgIDs:  []string{"msg_30"},
+					},
+				},
+			},
+		},
+	}
+
+	clientMeta := createTestClientMeta()
+	traceMeta := &libp2p.TraceEventMetadata{
+		PeerId: wrapperspb.String(examplePeerID),
+	}
+
+	err = mimicry.GetProcessor().handleDropRPCEvent(
+		context.Background(),
+		clientMeta,
+		traceMeta,
+		event,
+		xatu.Event_LIBP2P_TRACE_DROP_RPC.String(),
+		"1",
+	)
+
+	assert.NoError(t, err)
+}
+
+// TestDecoupledShardingComplexScenario tests a complex scenario with multiple child event types
+func TestDecoupledShardingComplexScenario(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSink := mock.NewMockSink(ctrl)
+
+	// Configure with parent disabled but multiple child types enabled
+	config := &Config{
+		Events: EventConfig{
+			RecvRPCEnabled:                 false, // Parent disabled
+			RpcMetaControlIHaveEnabled:     true,  // Child enabled
+			RpcMetaControlIWantEnabled:     true,  // Child enabled
+			RpcMetaControlIDontWantEnabled: true,  // Child enabled
+			RpcMetaControlGraftEnabled:     true,  // Child enabled
+			RpcMetaControlPruneEnabled:     true,  // Child enabled
+		},
+		Sharding: ShardingConfig{
+			Topics: map[string]*TopicShardingConfig{
+				".*attestation.*": {
+					TotalShards:  100,
+					ActiveShards: []uint64{0}, // Capture 1%
+				},
+			},
+		},
+	}
+
+	// Expect multiple child events but no parent
+	mockSink.EXPECT().HandleNewDecoratedEvents(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, events []*xatu.DecoratedEvent) error {
+			// Should have multiple child events but no RECV_RPC
+			hasParent := false
+			hasIHave := false
+			hasIWant := false
+			hasIDontWant := false
+			hasGraft := false
+			hasPrune := false
+
+			for _, event := range events {
+				switch event.Event.Name {
+				case xatu.Event_LIBP2P_TRACE_RECV_RPC:
+					hasParent = true
+				case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IHAVE:
+					hasIHave = true
+				case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IWANT:
+					hasIWant = true
+				case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_IDONTWANT:
+					hasIDontWant = true
+				case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_GRAFT:
+					hasGraft = true
+				case xatu.Event_LIBP2P_TRACE_RPC_META_CONTROL_PRUNE:
+					hasPrune = true
+				}
+			}
+
+			assert.False(t, hasParent, "Should not have parent event")
+			assert.True(t, hasIHave, "Should have IHAVE event")
+			assert.True(t, hasIWant, "Should have IWANT event")
+			assert.True(t, hasIDontWant, "Should have IDONTWANT event")
+			assert.True(t, hasGraft, "Should have GRAFT event")
+			assert.True(t, hasPrune, "Should have PRUNE event")
+
+			return nil
+		},
+	).Times(1)
+
+	mimicry := createTestMimicry(t, config, mockSink)
+
+	// Create test event with multiple control messages
+	peerID, err := peer.Decode(examplePeerID)
+	require.NoError(t, err)
+
+	event := &host.TraceEvent{
+		Type:      "RecvRPC",
+		PeerID:    peerID,
+		Timestamp: time.Now(),
+		Payload: &host.RpcMeta{
+			PeerID: peerID,
+			Control: &host.RpcMetaControl{
+				IHave: []host.RpcControlIHave{
+					{
+						TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+						MsgIDs:  []string{"msg_30"},
+					},
+				},
+				IWant: []host.RpcControlIWant{
+					{
+						MsgIDs: []string{"msg_30"},
+					},
+				},
+				Idontwant: []host.RpcControlIdontWant{
+					{
+						MsgIDs: []string{"msg_30"},
+					},
+				},
+				Graft: []host.RpcControlGraft{
+					{
+						TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+					},
+				},
+				Prune: []host.RpcControlPrune{
+					{
+						TopicID: "/eth2/test/beacon_attestation_0/ssz_snappy",
+					},
+				},
+			},
+		},
+	}
+
+	clientMeta := createTestClientMeta()
+	traceMeta := &libp2p.TraceEventMetadata{
+		PeerId: wrapperspb.String(examplePeerID),
+	}
+
+	err = mimicry.GetProcessor().handleRecvRPCEvent(
+		context.Background(),
+		clientMeta,
+		traceMeta,
+		event,
+		xatu.Event_LIBP2P_TRACE_RECV_RPC.String(),
+		"1",
+	)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- Fixes issue where child events (like IHAVE) derived from SendRPC/RecvRPC were not captured when parent events were disabled or sharded out
- Allows child events to be captured at their configured sampling rate (e.g. 1% for IHAVE) even when parent RPC events are completely disabled
