### PR TITLE
feat: add beacon_block_root field to blob and data column sidecars

### DIFF
--- a/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse-libp2p.yaml
@@ -309,7 +309,7 @@ transforms:
         .error = "No peer_id field found"
         log(., level: "error", rate_limit_secs: 60)
       }
-      
+
       key, err = .peer_id + .meta_network_name
       if err != null {
         .error = err
@@ -1284,6 +1284,7 @@ transforms:
       .blob_index = .data.index
       .state_root = .data.state_root
       .parent_root = .data.parent_root
+      .beacon_block_root = .data.block_root
 
       peer_id_key, err = .meta.client.additional_data.metadata.peer_id + .meta_network_name
       if err != null {
@@ -1379,6 +1380,7 @@ transforms:
       .kzg_commitments_count = .data.kzg_commitments_count
       .state_root = .data.state_root
       .parent_root = .data.parent_root
+      .beacon_block_root = .data.block_root
 
       peer_id_key, err = .meta.client.additional_data.metadata.peer_id + .meta_network_name
       if err != null {

--- a/pkg/clmimicry/gossipsub_blob_sidecar.go
+++ b/pkg/clmimicry/gossipsub_blob_sidecar.go
@@ -34,6 +34,7 @@ func (p *Processor) handleGossipBlobSidecar(
 		ProposerIndex: wrapperspb.UInt64(uint64(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetProposerIndex())),
 		StateRoot:     wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetStateRoot())),
 		ParentRoot:    wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetParentRoot())),
+		BlockRoot:     wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetBodyRoot())),
 	}
 
 	metadata, ok := proto.Clone(clientMeta).(*xatu.ClientMeta)

--- a/pkg/clmimicry/gossipsub_blob_sidecar.go
+++ b/pkg/clmimicry/gossipsub_blob_sidecar.go
@@ -28,13 +28,20 @@ func (p *Processor) handleGossipBlobSidecar(
 		return fmt.Errorf("handleGossipBlobSidecar() called with nil blob sidecar")
 	}
 
+	header := payload.BlobSidecar.GetSignedBlockHeader().GetHeader()
+
+	blockRoot, err := header.HashTreeRoot()
+	if err != nil {
+		return fmt.Errorf("failed to calculate block header hash tree root: %w", err)
+	}
+
 	data := &gossipsub.BlobSidecar{
 		Index:         wrapperspb.UInt64(payload.BlobSidecar.GetIndex()),
-		Slot:          wrapperspb.UInt64(uint64(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetSlot())),
-		ProposerIndex: wrapperspb.UInt64(uint64(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetProposerIndex())),
-		StateRoot:     wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetStateRoot())),
-		ParentRoot:    wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetParentRoot())),
-		BlockRoot:     wrapperspb.String(hex.EncodeToString(payload.BlobSidecar.GetSignedBlockHeader().GetHeader().GetBodyRoot())),
+		Slot:          wrapperspb.UInt64(uint64(header.GetSlot())),
+		ProposerIndex: wrapperspb.UInt64(uint64(header.GetProposerIndex())),
+		StateRoot:     wrapperspb.String(hex.EncodeToString(header.GetStateRoot())),
+		ParentRoot:    wrapperspb.String(hex.EncodeToString(header.GetParentRoot())),
+		BlockRoot:     wrapperspb.String(hex.EncodeToString(blockRoot[:])),
 	}
 
 	metadata, ok := proto.Clone(clientMeta).(*xatu.ClientMeta)

--- a/pkg/clmimicry/gossipsub_data_column_sidecar.go
+++ b/pkg/clmimicry/gossipsub_data_column_sidecar.go
@@ -28,13 +28,20 @@ func (p *Processor) handleGossipDataColumnSidecar(
 		return fmt.Errorf("handleGossipDataColumnSidecar() called with nil data column sidecar")
 	}
 
+	header := payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader()
+
+	blockRoot, err := header.HashTreeRoot()
+	if err != nil {
+		return fmt.Errorf("failed to calculate block header hash tree root: %w", err)
+	}
+
 	data := &gossipsub.DataColumnSidecar{
 		Index:               wrapperspb.UInt64(payload.DataColumnSidecar.GetIndex()),
-		Slot:                wrapperspb.UInt64(uint64(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetSlot())),
-		ProposerIndex:       wrapperspb.UInt64(uint64(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetProposerIndex())),
-		StateRoot:           wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetStateRoot())),
-		ParentRoot:          wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetParentRoot())),
-		BlockRoot:           wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetBodyRoot())),
+		Slot:                wrapperspb.UInt64(uint64(header.GetSlot())),
+		ProposerIndex:       wrapperspb.UInt64(uint64(header.GetProposerIndex())),
+		StateRoot:           wrapperspb.String(hex.EncodeToString(header.GetStateRoot())),
+		ParentRoot:          wrapperspb.String(hex.EncodeToString(header.GetParentRoot())),
+		BlockRoot:           wrapperspb.String(hex.EncodeToString(blockRoot[:])),
 		KzgCommitmentsCount: wrapperspb.UInt32(uint32(len(payload.DataColumnSidecar.GetKzgCommitments()))), //nolint:gosec // conversion fine.
 	}
 

--- a/pkg/clmimicry/gossipsub_data_column_sidecar.go
+++ b/pkg/clmimicry/gossipsub_data_column_sidecar.go
@@ -34,6 +34,7 @@ func (p *Processor) handleGossipDataColumnSidecar(
 		ProposerIndex:       wrapperspb.UInt64(uint64(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetProposerIndex())),
 		StateRoot:           wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetStateRoot())),
 		ParentRoot:          wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetParentRoot())),
+		BlockRoot:           wrapperspb.String(hex.EncodeToString(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetBodyRoot())),
 		KzgCommitmentsCount: wrapperspb.UInt32(uint32(len(payload.DataColumnSidecar.GetKzgCommitments()))), //nolint:gosec // conversion fine.
 	}
 

--- a/pkg/clmimicry/gossipsub_data_column_sidecar_test.go
+++ b/pkg/clmimicry/gossipsub_data_column_sidecar_test.go
@@ -47,6 +47,7 @@ func TestDataColumnSidecarIntegration(t *testing.T) {
 
 	stateRoot := [32]byte{10, 20, 30, 40}
 	parentRoot := [32]byte{50, 60, 70, 80}
+	bodyRoot := [32]byte{90, 100, 110, 120}
 
 	// Create multiple data column sidecars with different indices
 	sidecars := []struct {
@@ -349,9 +350,10 @@ func Test_handleGossipDataColumnSidecar(t *testing.T) {
 	peerID, err := peer.Decode(examplePeerID)
 	require.NoError(t, err)
 
-	// Create sample state and parent roots
+	// Create sample state, parent, and body roots
 	stateRoot := [32]byte{1, 2, 3, 4}
 	parentRoot := [32]byte{5, 6, 7, 8}
+	bodyRoot := [32]byte{9, 10, 11, 12}
 
 	tests := []struct {
 		name           string
@@ -396,6 +398,7 @@ func Test_handleGossipDataColumnSidecar(t *testing.T) {
 							ProposerIndex: primitives.ValidatorIndex(42),
 							StateRoot:     stateRoot[:],
 							ParentRoot:    parentRoot[:],
+							BodyRoot:      bodyRoot[:],
 						},
 					},
 				},


### PR DESCRIPTION
Adds `block_root` (`body_root`) to both blob and data column sidecar events so downstream consumers can correlate sidecars with their originating beacon block.

<img width="1875" height="297" alt="Screenshot 2025-09-24 at 11 20 31 am" src="https://github.com/user-attachments/assets/39366c7d-46d4-41c9-901c-6cd8ab38c6f4" />
