### PR TITLE
fix(vector-kafka-clickhouse.yaml): use length! to fail fast when kzg_commitments is missing

### DIFF
--- a/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
+++ b/deploy/local/docker-compose/vector-kafka-clickhouse.yaml
@@ -598,7 +598,7 @@ transforms:
       # Handle backward compatibility: if kzg_commitments is present, calculate count
       # Otherwise use kzg_commitments_count directly. Abort if neither exists.
       if exists(.data.kzg_commitments) && .data.kzg_commitments != null {
-        .kzg_commitments_count = length(.data.kzg_commitments)
+        .kzg_commitments_count = length!(.data.kzg_commitments)
       } else if exists(.data.kzg_commitments_count) && .data.kzg_commitments_count != null {
         .kzg_commitments_count = .data.kzg_commitments_count
       } else {


### PR DESCRIPTION
<img width="813" height="456" alt="Screenshot 2025-09-30 at 2 47 57 pm" src="https://github.com/user-attachments/assets/a32916b8-ca4f-40e9-b56f-fcc5ac526d57" />
