### PR TITLE
refactor(migrations): clean up migration 077 and add column positioning

### DIFF
--- a/deploy/migrations/clickhouse/077_data_column_sidecar_kzg_commitments_count.down.sql
+++ b/deploy/migrations/clickhouse/077_data_column_sidecar_kzg_commitments_count.down.sql
@@ -1,15 +1,11 @@
--- Drop the distributed table first
 DROP TABLE IF EXISTS beacon_api_eth_v1_events_data_column_sidecar ON CLUSTER '{cluster}';
 
--- Alter the local table to drop kzg_commitments_count column
 ALTER TABLE beacon_api_eth_v1_events_data_column_sidecar_local ON CLUSTER '{cluster}'
     DROP COLUMN IF EXISTS kzg_commitments_count;
 
--- Alter the local table to add back kzg_commitments column
 ALTER TABLE beacon_api_eth_v1_events_data_column_sidecar_local ON CLUSTER '{cluster}'
-    ADD COLUMN kzg_commitments Array(FixedString(98)) COMMENT 'The KZG commitments in the beacon API event stream payload' CODEC(ZSTD(1));
+    ADD COLUMN kzg_commitments Array(FixedString(98)) COMMENT 'The KZG commitments in the beacon API event stream payload' CODEC(ZSTD(1)) AFTER column_index;
 
--- Recreate the distributed table
 CREATE TABLE default.beacon_api_eth_v1_events_data_column_sidecar ON CLUSTER '{cluster}' AS default.beacon_api_eth_v1_events_data_column_sidecar_local ENGINE = Distributed(
     '{cluster}',
     default,

--- a/deploy/migrations/clickhouse/077_data_column_sidecar_kzg_commitments_count.up.sql
+++ b/deploy/migrations/clickhouse/077_data_column_sidecar_kzg_commitments_count.up.sql
@@ -1,15 +1,11 @@
--- Drop the distributed table first
-DROP TABLE IF EXISTS beacon_api_eth_v1_events_data_column_sidecar ON CLUSTER '{cluster}';
+DROP TABLE IF EXISTS beacon_api_eth_v1_events_data_column_sidecar ON CLUSTER '{cluster}' SYNC;
 
--- Alter the local table to drop kzg_commitments column
 ALTER TABLE beacon_api_eth_v1_events_data_column_sidecar_local ON CLUSTER '{cluster}'
     DROP COLUMN IF EXISTS kzg_commitments;
 
--- Alter the local table to add kzg_commitments_count column
 ALTER TABLE beacon_api_eth_v1_events_data_column_sidecar_local ON CLUSTER '{cluster}'
-    ADD COLUMN kzg_commitments_count UInt32 COMMENT 'Number of KZG commitments associated with the record' CODEC(ZSTD(1));
+    ADD COLUMN kzg_commitments_count UInt32 COMMENT 'Number of KZG commitments associated with the record' CODEC(ZSTD(1)) AFTER column_index;
 
--- Recreate the distributed table
 CREATE TABLE default.beacon_api_eth_v1_events_data_column_sidecar ON CLUSTER '{cluster}' AS default.beacon_api_eth_v1_events_data_column_sidecar_local ENGINE = Distributed(
     '{cluster}',
     default,


### PR DESCRIPTION
- Remove redundant comments from migration files
- Add SYNC to DROP TABLE statement for safer execution
- Specify AFTER column_index for consistent column ordering