### PR TITLE
fix: align custodyGroupCount type assertion with protobuf uint64

### DIFF
--- a/pkg/proto/libp2p/trace.go
+++ b/pkg/proto/libp2p/trace.go
@@ -613,8 +613,8 @@ func TraceEventToHandleMetadata(event *host.TraceEvent) (*HandleMetadata, error)
 		metadata.Direction = wrapperspb.String(direction)
 	}
 
-	if custodyGroupCount, ok := payload["CustodyGroupCount"].(uint8); ok {
-		metadata.Metadata.CustodyGroupCount = wrapperspb.UInt64(uint64(custodyGroupCount))
+	if custodyGroupCount, ok := payload["CustodyGroupCount"].(uint64); ok {
+		metadata.Metadata.CustodyGroupCount = wrapperspb.UInt64(custodyGroupCount)
 	}
 
 	return metadata, nil
@@ -651,11 +651,11 @@ func TraceEventToHandleStatus(event *host.TraceEvent) (*HandleStatus, error) {
 		}
 
 		status.Request = &Status{
-			ForkDigest:     wrapperspb.String(request.ForkDigest),
-			FinalizedRoot:  wrapperspb.String(request.FinalizedRoot),
-			FinalizedEpoch: wrapperspb.UInt64(request.FinalizedEpoch),
-			HeadRoot:       wrapperspb.String(request.HeadRoot),
-			HeadSlot:       wrapperspb.UInt64(request.HeadSlot),
+			ForkDigest:            wrapperspb.String(request.ForkDigest),
+			FinalizedRoot:         wrapperspb.String(request.FinalizedRoot),
+			FinalizedEpoch:        wrapperspb.UInt64(request.FinalizedEpoch),
+			HeadRoot:              wrapperspb.String(request.HeadRoot),
+			HeadSlot:              wrapperspb.UInt64(request.HeadSlot),
 			EarliestAvailableSlot: wrapperspb.UInt64(request.EarliestAvailableSlot),
 		}
 	}
@@ -667,11 +667,11 @@ func TraceEventToHandleStatus(event *host.TraceEvent) (*HandleStatus, error) {
 		}
 
 		status.Response = &Status{
-			ForkDigest:     wrapperspb.String(response.ForkDigest),
-			FinalizedRoot:  wrapperspb.String(response.FinalizedRoot),
-			FinalizedEpoch: wrapperspb.UInt64(response.FinalizedEpoch),
-			HeadRoot:       wrapperspb.String(response.HeadRoot),
-			HeadSlot:       wrapperspb.UInt64(response.HeadSlot),
+			ForkDigest:            wrapperspb.String(response.ForkDigest),
+			FinalizedRoot:         wrapperspb.String(response.FinalizedRoot),
+			FinalizedEpoch:        wrapperspb.UInt64(response.FinalizedEpoch),
+			HeadRoot:              wrapperspb.String(response.HeadRoot),
+			HeadSlot:              wrapperspb.UInt64(response.HeadSlot),
 			EarliestAvailableSlot: wrapperspb.UInt64(response.EarliestAvailableSlot),
 		}
 	}
@@ -684,11 +684,11 @@ func TraceEventToHandleStatus(event *host.TraceEvent) (*HandleStatus, error) {
 }
 
 type statusFields struct {
-	ForkDigest     string
-	FinalizedRoot  string
-	FinalizedEpoch uint64
-	HeadRoot       string
-	HeadSlot       uint64
+	ForkDigest            string
+	FinalizedRoot         string
+	FinalizedEpoch        uint64
+	HeadRoot              string
+	HeadSlot              uint64
 	EarliestAvailableSlot uint64
 }
 


### PR DESCRIPTION
tysm sends CustodyGroupCount as uint64 (from `metadata.CustodyGroupCount()` which returns uint64), xatu was expecting uint8 in the type assertion