### PR TITLE
feat(gloas): add BAL storage reads and touched accounts

### DIFF
--- a/pkg/cannon/deriver/beacon/eth/v2/block_access_list.go
+++ b/pkg/cannon/deriver/beacon/eth/v2/block_access_list.go
@@ -367,6 +367,27 @@ func (b *BlockAccessListDeriver) processSlot(
 
 			events = append(events, event)
 		}
+
+		// Emit a "touched" event for accounts with no state changes and no storage
+		// reads. These are accounts accessed via BALANCE, EXTCODESIZE, calls, etc.
+		// that had no state interactions. Valuable for parallel execution analysis.
+		if len(entry.GetStorageChanges()) == 0 &&
+			len(entry.GetStorageReads()) == 0 &&
+			len(entry.GetBalanceChanges()) == 0 &&
+			len(entry.GetNonceChanges()) == 0 &&
+			len(entry.GetCodeChanges()) == 0 {
+			change := &xatuethv1.BlockAccessListChange{
+				Address:    address,
+				ChangeType: "touched",
+			}
+
+			event, err := b.createEvent(ctx, change, blockIdentifier, execBlockNumber, execBlockHash)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create touched account event")
+			}
+
+			events = append(events, event)
+		}
 	}
 
 	return events, nil

--- a/pkg/proto/eth/v1/block_access_list.proto
+++ b/pkg/proto/eth/v1/block_access_list.proto
@@ -60,7 +60,7 @@ message BlockAccessList {
 // becomes one row.
 message BlockAccessListChange {
   google.protobuf.StringValue address = 1;
-  // change_type is one of: "storage", "balance", "nonce", "code", "storage_read"
+  // change_type is one of: "storage", "balance", "nonce", "code", "storage_read", "touched"
   string change_type = 2 [ json_name = "change_type" ];
   google.protobuf.UInt32Value block_access_index = 3
       [ json_name = "block_access_index" ];


### PR DESCRIPTION
[Spec](https://github.com/ethereum/execution-specs/blob/forks/amsterdam/src/ethereum/forks/amsterdam/block_access_lists.py#L529)

- Add `touched` change type for accounts accessed but not modified (e.g. `BALANCE`, `EXTCODESIZE`, calls)
