### PR TITLE
feat: prepare epbs types

### DIFF
--- a/pkg/proto/eth/v1/builder.proto
+++ b/pkg/proto/eth/v1/builder.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+// EIP-7732: ePBS Builder type
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#builder
+
+package xatu.eth.v1;
+
+option go_package = "github.com/ethpandaops/xatu/pkg/proto/eth/v1";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
+
+// Builder represents an enshrined builder in the beacon state.
+message Builder {
+  string pubkey = 1;
+
+  // uint8 in the spec; proto3 has no uint8, so we use UInt32Value.
+  google.protobuf.UInt32Value version = 2;
+
+  string execution_address = 3 [ json_name = "execution_address" ];
+
+  google.protobuf.UInt64Value balance = 4;
+
+  google.protobuf.UInt64Value deposit_epoch = 5
+      [ json_name = "deposit_epoch" ];
+
+  google.protobuf.UInt64Value withdrawable_epoch = 6
+      [ json_name = "withdrawable_epoch" ];
+}

--- a/pkg/proto/eth/v1/execution_payload_bid.proto
+++ b/pkg/proto/eth/v1/execution_payload_bid.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+// EIP-7732: ePBS Execution Payload Bid types
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#executionpayloadbid
+
+package xatu.eth.v1;
+
+option go_package = "github.com/ethpandaops/xatu/pkg/proto/eth/v1";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
+
+// ExecutionPayloadBid is the builder's bid included in the beacon block body.
+message ExecutionPayloadBid {
+  string parent_block_hash = 1 [ json_name = "parent_block_hash" ];
+
+  string parent_block_root = 2 [ json_name = "parent_block_root" ];
+
+  string block_hash = 3 [ json_name = "block_hash" ];
+
+  string prev_randao = 4 [ json_name = "prev_randao" ];
+
+  string fee_recipient = 5 [ json_name = "fee_recipient" ];
+
+  google.protobuf.UInt64Value gas_limit = 6 [ json_name = "gas_limit" ];
+
+  google.protobuf.UInt64Value builder_index = 7
+      [ json_name = "builder_index" ];
+
+  google.protobuf.UInt64Value slot = 8 [ json_name = "slot" ];
+
+  google.protobuf.UInt64Value value = 9 [ json_name = "value" ];
+
+  google.protobuf.UInt64Value execution_payment = 10
+      [ json_name = "execution_payment" ];
+
+  repeated string blob_kzg_commitments = 11
+      [ json_name = "blob_kzg_commitments" ];
+}
+
+// SignedExecutionPayloadBid wraps ExecutionPayloadBid with the builder's signature.
+message SignedExecutionPayloadBid {
+  ExecutionPayloadBid message = 1;
+
+  string signature = 2;
+}

--- a/pkg/proto/eth/v1/execution_payload_envelope.proto
+++ b/pkg/proto/eth/v1/execution_payload_envelope.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+// EIP-7732: ePBS Execution Payload Envelope types
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#executionpayloadenvelope
+
+package xatu.eth.v1;
+
+option go_package = "github.com/ethpandaops/xatu/pkg/proto/eth/v1";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
+import "pkg/proto/eth/v1/execution_engine.proto";
+import "pkg/proto/eth/v1/execution_requests.proto";
+
+// ExecutionPayloadEnvelope is the container delivered by the builder
+// separately from the beacon block (~2s after block).
+message ExecutionPayloadEnvelope {
+  ExecutionPayloadGloas payload = 1;
+
+  ElectraExecutionRequests execution_requests = 2
+      [ json_name = "execution_requests" ];
+
+  google.protobuf.UInt64Value builder_index = 3
+      [ json_name = "builder_index" ];
+
+  string beacon_block_root = 4 [ json_name = "beacon_block_root" ];
+
+  google.protobuf.UInt64Value slot = 5 [ json_name = "slot" ];
+
+  string state_root = 6 [ json_name = "state_root" ];
+}
+
+// SignedExecutionPayloadEnvelope wraps ExecutionPayloadEnvelope with the
+// builder's signature.
+message SignedExecutionPayloadEnvelope {
+  ExecutionPayloadEnvelope message = 1;
+
+  string signature = 2;
+}

--- a/pkg/proto/eth/v1/payload_attestation.proto
+++ b/pkg/proto/eth/v1/payload_attestation.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+// EIP-7732: ePBS Payload Attestation types
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#payloadattestationdata
+
+package xatu.eth.v1;
+
+option go_package = "github.com/ethpandaops/xatu/pkg/proto/eth/v1";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
+
+// PayloadAttestationData is the data that PTC validators attest to.
+message PayloadAttestationData {
+  string beacon_block_root = 1 [ json_name = "beacon_block_root" ];
+
+  google.protobuf.UInt64Value slot = 2 [ json_name = "slot" ];
+
+  bool payload_present = 3 [ json_name = "payload_present" ];
+
+  bool blob_data_available = 4 [ json_name = "blob_data_available" ];
+}
+
+// PayloadAttestationMessage is an individual PTC validator's attestation.
+// ~512 of these are produced per slot.
+message PayloadAttestationMessage {
+  google.protobuf.UInt64Value validator_index = 1
+      [ json_name = "validator_index" ];
+
+  PayloadAttestationData data = 2;
+
+  string signature = 3;
+}
+
+// PayloadAttestation is the aggregated PTC attestation included in the block body.
+// Max MAX_PAYLOAD_ATTESTATIONS (4) per block.
+message PayloadAttestation {
+  // Bitvector[PTC_SIZE] (512 bits) as hex string
+  string aggregation_bits = 1 [ json_name = "aggregation_bits" ];
+
+  PayloadAttestationData data = 2;
+
+  string signature = 3;
+}
+
+// IndexedPayloadAttestation is a PayloadAttestation with attesting indices
+// expanded from the aggregation bits.
+message IndexedPayloadAttestation {
+  repeated google.protobuf.UInt64Value attesting_indices = 1
+      [ json_name = "attesting_indices" ];
+
+  PayloadAttestationData data = 2;
+
+  string signature = 3;
+}

--- a/pkg/proto/eth/v1/proposer_preferences.proto
+++ b/pkg/proto/eth/v1/proposer_preferences.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+// EIP-7732: ePBS Proposer Preferences types
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#new-proposerpreferences
+
+package xatu.eth.v1;
+
+option go_package = "github.com/ethpandaops/xatu/pkg/proto/eth/v1";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
+
+// ProposerPreferences signals the proposer's preferences for their upcoming
+// slot (fee recipient, gas limit). Gossiped on P2P.
+message ProposerPreferences {
+  google.protobuf.UInt64Value proposal_slot = 1
+      [ json_name = "proposal_slot" ];
+
+  google.protobuf.UInt64Value validator_index = 2
+      [ json_name = "validator_index" ];
+
+  string fee_recipient = 3 [ json_name = "fee_recipient" ];
+
+  google.protobuf.UInt64Value gas_limit = 4 [ json_name = "gas_limit" ];
+}
+
+// SignedProposerPreferences wraps ProposerPreferences with the proposer's
+// signature.
+message SignedProposerPreferences {
+  ProposerPreferences message = 1;
+
+  string signature = 2;
+}

--- a/pkg/proto/eth/v2/beacon_block.proto
+++ b/pkg/proto/eth/v2/beacon_block.proto
@@ -12,6 +12,8 @@ import "google/protobuf/descriptor.proto";
 import "pkg/proto/eth/v1/attestation.proto";
 import "pkg/proto/eth/v1/beacon_block.proto";
 import "pkg/proto/eth/v1/execution_engine.proto";
+import "pkg/proto/eth/v1/execution_payload_bid.proto";
+import "pkg/proto/eth/v1/payload_attestation.proto";
 import "pkg/proto/eth/v2/withdrawals.proto";
 import "pkg/proto/eth/v1/execution_requests.proto";
 
@@ -560,16 +562,21 @@ message BeaconBlockBodyGloas {
 
   v1.SyncAggregate sync_aggregate = 9 [ json_name = "sync_aggregate" ];
 
-  v1.ExecutionPayloadGloas execution_payload = 10
-      [ json_name = "execution_payload" ];
+  // EIP-7732: execution_payload, blob_kzg_commitments, and
+  // execution_requests moved to ExecutionPayloadEnvelope.
+  reserved 10, 12, 13;
+  reserved "execution_payload", "blob_kzg_commitments", "execution_requests";
 
   repeated SignedBLSToExecutionChange bls_to_execution_changes = 11
       [ json_name = "bls_to_execution_changes" ];
 
-  repeated string blob_kzg_commitments = 12
-      [ json_name = "blob_kzg_commitments" ];
+  // EIP-7732: Builder's bid replaces inline execution payload.
+  v1.SignedExecutionPayloadBid signed_execution_payload_bid = 14
+      [ json_name = "signed_execution_payload_bid" ];
 
-  v1.ElectraExecutionRequests execution_requests = 13 [ json_name = "execution_requests" ];
+  // EIP-7732: Aggregated PTC attestations (max 4 per block).
+  repeated v1.PayloadAttestation payload_attestations = 15
+      [ json_name = "payload_attestations" ];
 }
 
 message BlindedBeaconBlockBodyCapella {

--- a/pkg/proto/xatu/event_ingester.proto
+++ b/pkg/proto/xatu/event_ingester.proto
@@ -20,6 +20,10 @@ import "pkg/proto/eth/v1/execution_engine.proto";
 import "pkg/proto/eth/v1/validator.proto";
 import "pkg/proto/eth/v1/sync_committee.proto";
 import "pkg/proto/eth/v1/block_access_list.proto";
+import "pkg/proto/eth/v1/payload_attestation.proto";
+import "pkg/proto/eth/v1/execution_payload_bid.proto";
+import "pkg/proto/eth/v1/execution_payload_envelope.proto";
+import "pkg/proto/eth/v1/proposer_preferences.proto";
 
 import "pkg/proto/mevrelay/bids.proto";
 import "pkg/proto/mevrelay/relay.proto";
@@ -1999,6 +2003,22 @@ message Event {
     EXECUTION_BLOCK_METRICS = 87;
     LIBP2P_TRACE_IDENTIFY = 88;
     BEACON_API_ETH_V2_BEACON_BLOCK_ACCESS_LIST = 89;
+
+    // EIP-7732 ePBS: Sentry SSE events
+    BEACON_API_ETH_V1_EVENTS_EXECUTION_PAYLOAD = 90;
+    BEACON_API_ETH_V1_EVENTS_PAYLOAD_ATTESTATION = 91;
+    BEACON_API_ETH_V1_EVENTS_EXECUTION_PAYLOAD_BID = 92;
+    BEACON_API_ETH_V1_EVENTS_PROPOSER_PREFERENCES = 93;
+
+    // EIP-7732 ePBS: Cannon derived events
+    BEACON_API_ETH_V2_BEACON_BLOCK_PAYLOAD_ATTESTATION = 94;
+    BEACON_API_ETH_V2_BEACON_BLOCK_EXECUTION_PAYLOAD_BID = 95;
+
+    // EIP-7732 ePBS: P2P gossip events
+    LIBP2P_TRACE_GOSSIPSUB_EXECUTION_PAYLOAD_ENVELOPE = 96;
+    LIBP2P_TRACE_GOSSIPSUB_EXECUTION_PAYLOAD_BID = 97;
+    LIBP2P_TRACE_GOSSIPSUB_PAYLOAD_ATTESTATION_MESSAGE = 98;
+    LIBP2P_TRACE_GOSSIPSUB_PROPOSER_PREFERENCES = 99;
   }
   // Name is the name of the event.
   Name name = 1;
@@ -2308,6 +2328,32 @@ message DecoratedEvent {
         [ json_name = "EXECUTION_BLOCK_METRICS" ];
     xatu.eth.v1.BlockAccessListChange eth_v2_beacon_block_access_list = 210
         [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK_ACCESS_LIST" ];
+
+    // EIP-7732 ePBS: Sentry SSE events
+    xatu.eth.v1.SignedExecutionPayloadEnvelope eth_v1_events_execution_payload = 211
+        [ json_name = "BEACON_API_ETH_V1_EVENTS_EXECUTION_PAYLOAD" ];
+    xatu.eth.v1.PayloadAttestationMessage eth_v1_events_payload_attestation = 212
+        [ json_name = "BEACON_API_ETH_V1_EVENTS_PAYLOAD_ATTESTATION" ];
+    xatu.eth.v1.SignedExecutionPayloadBid eth_v1_events_execution_payload_bid = 213
+        [ json_name = "BEACON_API_ETH_V1_EVENTS_EXECUTION_PAYLOAD_BID" ];
+    xatu.eth.v1.SignedProposerPreferences eth_v1_events_proposer_preferences = 214
+        [ json_name = "BEACON_API_ETH_V1_EVENTS_PROPOSER_PREFERENCES" ];
+
+    // EIP-7732 ePBS: Cannon derived events
+    xatu.eth.v1.PayloadAttestation eth_v2_beacon_block_payload_attestation = 215
+        [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK_PAYLOAD_ATTESTATION" ];
+    xatu.eth.v1.SignedExecutionPayloadBid eth_v2_beacon_block_execution_payload_bid = 216
+        [ json_name = "BEACON_API_ETH_V2_BEACON_BLOCK_EXECUTION_PAYLOAD_BID" ];
+
+    // EIP-7732 ePBS: P2P gossip events
+    xatu.eth.v1.SignedExecutionPayloadEnvelope libp2p_trace_gossipsub_execution_payload_envelope = 217
+        [ json_name = "LIBP2P_TRACE_GOSSIPSUB_EXECUTION_PAYLOAD_ENVELOPE" ];
+    xatu.eth.v1.SignedExecutionPayloadBid libp2p_trace_gossipsub_execution_payload_bid = 218
+        [ json_name = "LIBP2P_TRACE_GOSSIPSUB_EXECUTION_PAYLOAD_BID" ];
+    xatu.eth.v1.PayloadAttestationMessage libp2p_trace_gossipsub_payload_attestation_message = 219
+        [ json_name = "LIBP2P_TRACE_GOSSIPSUB_PAYLOAD_ATTESTATION_MESSAGE" ];
+    xatu.eth.v1.SignedProposerPreferences libp2p_trace_gossipsub_proposer_preferences = 220
+        [ json_name = "LIBP2P_TRACE_GOSSIPSUB_PROPOSER_PREFERENCES" ];
   };
 }
 


### PR DESCRIPTION
- Define all ePBS protobuf types for the glammy fork
- Add 10 new event type IDs for ePBS sentry, cannon, and P2P events
- Update `BeaconBlockBodyGloas` to reflect ePBS block structure (bid + payload attestations replace inline execution payload)