### PR TITLE
consumoor: remove kzg_commitments array from data column sidecar

### DIFF
--- a/deploy/migrations/clickhouse/001_init.up.sql
+++ b/deploy/migrations/clickhouse/001_init.up.sql
@@ -332,7 +332,6 @@ CREATE TABLE IF NOT EXISTS default.beacon_api_eth_v1_events_data_column_sidecar_
     `block_root` FixedString(66) COMMENT 'The beacon block root hash in the beacon API event stream payload' CODEC(ZSTD(1)),
     `column_index` UInt64 COMMENT 'The index of column in the beacon API event stream payload' CODEC(ZSTD(1)),
     `kzg_commitments_count` UInt32 COMMENT 'Number of KZG commitments associated with the record' CODEC(ZSTD(1)),
-    `kzg_commitments` Array(FixedString(98)) COMMENT 'The KZG commitments in the beacon API event stream payload' CODEC(ZSTD(1)),
     `meta_client_name` LowCardinality(String) COMMENT 'Name of the client that generated the event',
     `meta_client_version` LowCardinality(String) COMMENT 'Version of the client that generated the event',
     `meta_client_implementation` LowCardinality(String) COMMENT 'Implementation of the client that generated the event',

--- a/pkg/consumoor/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.gen.go
+++ b/pkg/consumoor/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.gen.go
@@ -23,7 +23,6 @@ type beaconApiEthV1EventsDataColumnSidecarBatch struct {
 	BlockRoot                                 route.SafeColFixedStr
 	ColumnIndex                               proto.ColUInt64
 	KzgCommitmentsCount                       proto.ColUInt32
-	KzgCommitments                            *proto.ColArr[[]byte]
 	MetaClientName                            proto.ColStr
 	MetaClientVersion                         proto.ColStr
 	MetaClientImplementation                  proto.ColStr
@@ -48,13 +47,8 @@ type beaconApiEthV1EventsDataColumnSidecarBatch struct {
 
 func newbeaconApiEthV1EventsDataColumnSidecarBatch() *beaconApiEthV1EventsDataColumnSidecarBatch {
 	return &beaconApiEthV1EventsDataColumnSidecarBatch{
-		EventDateTime: func() proto.ColDateTime64 { var c proto.ColDateTime64; c.WithPrecision(proto.Precision(3)); return c }(),
-		BlockRoot:     func() route.SafeColFixedStr { var c route.SafeColFixedStr; c.SetSize(66); return c }(),
-		KzgCommitments: func() *proto.ColArr[[]byte] {
-			var fs route.SafeColFixedStr
-			fs.SetSize(98)
-			return proto.NewArray[[]byte](&fs)
-		}(),
+		EventDateTime:                             func() proto.ColDateTime64 { var c proto.ColDateTime64; c.WithPrecision(proto.Precision(3)); return c }(),
+		BlockRoot:                                 func() route.SafeColFixedStr { var c route.SafeColFixedStr; c.SetSize(66); return c }(),
 		MetaClientIP:                              new(proto.ColIPv6).Nullable(),
 		MetaClientGeoLongitude:                    new(proto.ColFloat64).Nullable(),
 		MetaClientGeoLatitude:                     new(proto.ColFloat64).Nullable(),
@@ -125,7 +119,6 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) Input() proto.Input {
 		{Name: "block_root", Data: &b.BlockRoot},
 		{Name: "column_index", Data: &b.ColumnIndex},
 		{Name: "kzg_commitments_count", Data: &b.KzgCommitmentsCount},
-		{Name: "kzg_commitments", Data: b.KzgCommitments},
 		{Name: "meta_client_name", Data: &b.MetaClientName},
 		{Name: "meta_client_version", Data: &b.MetaClientVersion},
 		{Name: "meta_client_implementation", Data: &b.MetaClientImplementation},
@@ -159,7 +152,6 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) Reset() {
 	b.BlockRoot.Reset()
 	b.ColumnIndex.Reset()
 	b.KzgCommitmentsCount.Reset()
-	b.KzgCommitments.Reset()
 	b.MetaClientName.Reset()
 	b.MetaClientVersion.Reset()
 	b.MetaClientImplementation.Reset()
@@ -187,7 +179,7 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) Snapshot() []map[string]any
 	out := make([]map[string]any, n)
 
 	for i := 0; i < n; i++ {
-		row := make(map[string]any, 30)
+		row := make(map[string]any, 29)
 		row["updated_date_time"] = b.UpdatedDateTime.Row(i).Unix()
 		row["event_date_time"] = b.EventDateTime.Row(i).UnixMilli()
 		row["slot"] = b.Slot.Row(i)
@@ -198,7 +190,6 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) Snapshot() []map[string]any
 		row["block_root"] = string(b.BlockRoot.Row(i))
 		row["column_index"] = b.ColumnIndex.Row(i)
 		row["kzg_commitments_count"] = b.KzgCommitmentsCount.Row(i)
-		row["kzg_commitments"] = route.ByteSlicesToStrings(b.KzgCommitments.Row(i))
 		row["meta_client_name"] = b.MetaClientName.Row(i)
 		row["meta_client_version"] = b.MetaClientVersion.Row(i)
 		row["meta_client_implementation"] = b.MetaClientImplementation.Row(i)

--- a/pkg/consumoor/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.go
+++ b/pkg/consumoor/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.go
@@ -104,15 +104,6 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) appendPayload(event *xatu.D
 	} else {
 		b.KzgCommitmentsCount.Append(0)
 	}
-
-	commitments := sidecar.GetKzgCommitments() //nolint:staticcheck // deprecated but still populated
-	byteSlices := make([][]byte, len(commitments))
-
-	for i, c := range commitments {
-		byteSlices[i] = []byte(c)
-	}
-
-	b.KzgCommitments.Append(byteSlices)
 }
 
 func (b *beaconApiEthV1EventsDataColumnSidecarBatch) appendAdditionalData(


### PR DESCRIPTION
## Summary

- Removes the `kzg_commitments Array(FixedString(98))` column from the `beacon_api_eth_v1_events_data_column_sidecar_local` ClickHouse migration, as the data is redundant with the existing `kzg_commitments_count` field
- Updates the consumoor beacon route (`beacon_api_eth_v1_events_data_column_sidecar.gen.go`) to remove the `KzgCommitments` struct field, constructor initialization, `Input()` entry, `Reset()` call, `Snapshot()` row, and adjusts the map capacity from 30 to 29
- Removes the `GetKzgCommitments()` append logic from `beacon_api_eth_v1_events_data_column_sidecar.go` that serialized the commitments array into the batch

The libp2p `gossipsub_data_column_sidecar` route was already correct — it only had `KzgCommitmentsCount`, no array field.

**Note:** `deploy/local/docker-compose/vector-kafka-clickhouse.yaml:657` still references `.kzg_commitments` in the `beacon_api_eth_v1_events_blob_sidecar_formatted` sink (which also takes data_column_sidecar input). This may need a separate update if that sink feeds the same table.

## Test plan

- [ ] Verify `go build ./pkg/consumoor/...` compiles cleanly
- [ ] Verify `golangci-lint` passes on changed files
- [ ] Confirm ClickHouse migration applies without errors on a fresh instance
- [ ] Validate data column sidecar events are ingested correctly without the `kzg_commitments` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)