### PR TITLE
feat(local): add docker container log collection to ch

### DIFF
--- a/deploy/local/docker-compose/grafana/datasources/datasources.yaml
+++ b/deploy/local/docker-compose/grafana/datasources/datasources.yaml
@@ -27,6 +27,30 @@ datasources:
       user: readonly
     secureJsonData:
       password: $CLICKHOUSE_USER_READONLY_PASSWORD
+  - name: ClickHouse-logs-internal
+    type: grafana-clickhouse-datasource
+    jsonData:
+      defaultDatabase: logs_internal
+      port: 9000
+      server: xatu-clickhouse-01
+      tlsSkipVerify: true
+      username: readonly
+    user: readonly
+    secureJsonData:
+      password: $CLICKHOUSE_USER_READONLY_PASSWORD
+
+  - name: ClickHouse-logs-external
+    type: grafana-clickhouse-datasource
+    jsonData:
+      defaultDatabase: logs_external
+      port: 9000
+      server: xatu-clickhouse-01
+      tlsSkipVerify: true
+      username: readonly
+    user: readonly
+    secureJsonData:
+      password: $CLICKHOUSE_USER_READONLY_PASSWORD
+
   - name: Tempo
     type: tempo
     access: proxy

--- a/deploy/local/docker-compose/vector-logs-init.sql
+++ b/deploy/local/docker-compose/vector-logs-init.sql
@@ -1,0 +1,52 @@
+CREATE DATABASE IF NOT EXISTS logs_internal ON CLUSTER '{cluster}';
+CREATE DATABASE IF NOT EXISTS logs_external ON CLUSTER '{cluster}';
+
+CREATE TABLE IF NOT EXISTS logs_internal.logs_local ON CLUSTER '{cluster}'
+(
+    `Timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `LogDate` Date DEFAULT toDate(Timestamp),
+    `IngressUser` LowCardinality(String) DEFAULT '',
+    `Namespace` LowCardinality(String) DEFAULT '',
+    `Pod` String DEFAULT '' CODEC(ZSTD(1)),
+    `Container` LowCardinality(String) DEFAULT '',
+    `Node` LowCardinality(String) DEFAULT '',
+    `Stream` LowCardinality(String) DEFAULT '',
+    `Message` String CODEC(ZSTD(1)),
+    INDEX idx_msg Message TYPE tokenbf_v1(30720, 2, 0) GRANULARITY 1,
+    INDEX idx_pod Pod TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_namespace Namespace TYPE set(100) GRANULARITY 4
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/logs_internal/logs_local', '{replica}')
+PARTITION BY LogDate
+ORDER BY (IngressUser, Namespace, Timestamp)
+TTL LogDate + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS logs_internal.logs ON CLUSTER '{cluster}'
+AS logs_internal.logs_local
+ENGINE = Distributed('{cluster}', 'logs_internal', 'logs_local', rand());
+
+CREATE TABLE IF NOT EXISTS logs_external.logs_local ON CLUSTER '{cluster}'
+(
+    `Timestamp` DateTime64(3) CODEC(DoubleDelta, ZSTD(1)),
+    `LogDate` Date DEFAULT toDate(Timestamp),
+    `IngressUser` LowCardinality(String) DEFAULT '',
+    `Namespace` LowCardinality(String) DEFAULT '',
+    `Pod` String DEFAULT '' CODEC(ZSTD(1)),
+    `Container` LowCardinality(String) DEFAULT '',
+    `Node` LowCardinality(String) DEFAULT '',
+    `Stream` LowCardinality(String) DEFAULT '',
+    `Message` String CODEC(ZSTD(1)),
+    INDEX idx_msg Message TYPE tokenbf_v1(30720, 2, 0) GRANULARITY 1,
+    INDEX idx_pod Pod TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_namespace Namespace TYPE set(100) GRANULARITY 4
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/logs_external/logs_local', '{replica}')
+PARTITION BY LogDate
+ORDER BY (IngressUser, Namespace, Timestamp)
+TTL LogDate + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS logs_external.logs ON CLUSTER '{cluster}'
+AS logs_external.logs_local
+ENGINE = Distributed('{cluster}', 'logs_external', 'logs_local', rand());

--- a/deploy/local/docker-compose/vector-logs.yaml
+++ b/deploy/local/docker-compose/vector-logs.yaml
@@ -1,0 +1,85 @@
+sources:
+  docker:
+    type: docker_logs
+    docker_host: unix:///var/run/docker.sock
+
+transforms:
+  enrich:
+    type: remap
+    inputs:
+      - docker
+    source: |
+      # Capture fields before deleting originals
+      project = to_string(get!(., ["label", "com.docker.compose.project"])) ?? "unknown"
+      service = to_string(get!(., ["label", "com.docker.compose.service"])) ?? "unknown"
+      container = to_string(.container_name) ?? "unknown"
+      stream = to_string(.stream) ?? "stdout"
+      msg = to_string(.message) ?? ""
+      ts = .timestamp
+
+      # Build the output schema
+      .IngressUser = "local"
+      .Namespace = project
+      .Pod = service
+      .Container = container
+      .Node = "localhost"
+      .Stream = stream
+      .Message = msg
+      .Timestamp = ts
+
+      # Remove all original fields
+      del(.source_type)
+      del(.container_created_at)
+      del(.container_id)
+      del(.container_name)
+      del(.host)
+      del(.image)
+      del(.label)
+      del(.message)
+      del(.stream)
+      del(.timestamp)
+
+  enforce_limits:
+    type: remap
+    inputs:
+      - enrich
+    source: |
+      max_message_bytes = 262144
+      if length(string!(.Message)) > max_message_bytes {
+        .Message = slice!(string!(.Message), start: 0, end: max_message_bytes)
+      }
+
+sinks:
+  clickhouse_internal:
+    type: clickhouse
+    inputs:
+      - enforce_limits
+    endpoint: "http://${CLICKHOUSE_ENDPOINT:-xatu-clickhouse-01:8123}"
+    database: logs_internal
+    table: logs
+    auth:
+      strategy: basic
+      user: "${CLICKHOUSE_USER:-default}"
+      password: "${CLICKHOUSE_PASSWORD:-}"
+    batch:
+      max_events: 1000
+      timeout_secs: 3
+    skip_unknown_fields: true
+    date_time_best_effort: true
+
+  clickhouse_external:
+    type: clickhouse
+    inputs:
+      - enforce_limits
+    endpoint: "http://${CLICKHOUSE_ENDPOINT:-xatu-clickhouse-01:8123}"
+    database: logs_external
+    table: logs
+    auth:
+      strategy: basic
+      user: "${CLICKHOUSE_USER:-default}"
+      password: "${CLICKHOUSE_PASSWORD:-}"
+    batch:
+      max_events: 1000
+      timeout_secs: 3
+    skip_unknown_fields: true
+    date_time_best_effort: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -523,6 +523,59 @@ services:
         condition: service_completed_successfully
       xatu-init-kafka:
         condition: service_completed_successfully
+
+  xatu-vector-logs-init:
+    profiles:
+      - ""
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
+    container_name: xatu-vector-logs-init
+    volumes:
+      - ./deploy/local/docker-compose/vector-logs-init.sql:/init.sql:ro
+    networks:
+      - xatu-net
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        clickhouse-client \
+          --host xatu-clickhouse-01 \
+          --user $${CLICKHOUSE_USER} \
+          --password $${CLICKHOUSE_PASSWORD} \
+          --multiquery \
+          --queries-file /init.sql
+    environment:
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+    depends_on:
+      xatu-clickhouse-01:
+        condition: service_healthy
+      xatu-clickhouse-02:
+        condition: service_healthy
+
+  xatu-vector-logs:
+    profiles:
+      - ""
+    image: timberio/vector:0.42.0-debian
+    container_name: xatu-vector-logs
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./deploy/local/docker-compose/vector-logs.yaml:/etc/vector/vector.yaml:ro
+    networks:
+      - xatu-net
+    environment:
+      CLICKHOUSE_ENDPOINT: "xatu-clickhouse-01:8123"
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8686/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
+    depends_on:
+      xatu-vector-logs-init:
+        condition: service_completed_successfully
+
   xatu-postgres-migrator:
     profiles:
       - ""


### PR DESCRIPTION
- Adds a Vector container that captures logs from all Docker containers via the Docker socket and writes them to ClickHouse
- Creates `logs_internal` and `logs_external` databases/tables matching the production schema, initialized via a standalone init container (separate from xatu's ClickHouse migrations)
- Adds Grafana datasources for both log databases
- Works for any container on the Docker daemon, xatu stack, tysm, or any other local compose project

<img width="1800" height="664" alt="Screenshot 2026-04-09 at 16 46 15" src="https://github.com/user-attachments/assets/2aab8121-47e3-47c3-811f-ff227960b7d2" />
