### PR TITLE
fix(kafka): make Producer.MaxMessageBytes configurable

### DIFF
--- a/pkg/output/kafka/client.go
+++ b/pkg/output/kafka/client.go
@@ -64,12 +64,17 @@ var (
 // ProducerConfig contains the fields needed to build a Sarama producer.
 // It is shared by all Kafka-based sinks.
 type ProducerConfig struct {
-	Brokers         string              `yaml:"brokers"`
-	TLS             bool                `yaml:"tls" default:"false"`
-	TLSClientConfig *TLSClientConfig    `yaml:"tlsClientConfig"`
-	SASLConfig      *SASLConfig         `yaml:"sasl"`
-	FlushFrequency  time.Duration       `yaml:"flushFrequency" default:"10s"`
-	FlushBytes      int                 `yaml:"flushBytes" default:"1000000"`
+	Brokers         string           `yaml:"brokers"`
+	TLS             bool             `yaml:"tls" default:"false"`
+	TLSClientConfig *TLSClientConfig `yaml:"tlsClientConfig"`
+	SASLConfig      *SASLConfig      `yaml:"sasl"`
+	FlushFrequency  time.Duration    `yaml:"flushFrequency" default:"10s"`
+	FlushBytes      int              `yaml:"flushBytes" default:"1000000"`
+	// MaxMessageBytes is the maximum permitted size of a message produced
+	// by this client. Must be set <= the broker's message.max.bytes. Default
+	// 1000000 matches sarama's historical default; raise this when publishing
+	// large payloads (e.g. blob-tx mempool events with sidecars).
+	MaxMessageBytes int                 `yaml:"maxMessageBytes" default:"1000000"`
 	MaxRetries      int                 `yaml:"maxRetries" default:"3"`
 	Compression     CompressionStrategy `yaml:"compression" default:"none"`
 	RequiredAcks    RequiredAcks        `yaml:"requiredAcks" default:"leader"`
@@ -183,6 +188,7 @@ func NewSyncProducer(config *ProducerConfig, maxExportBatchSize int) (sarama.Syn
 func InitSaramaConfig(config *ProducerConfig, maxExportBatchSize int) (*sarama.Config, error) {
 	c := sarama.NewConfig()
 	c.Producer.Flush.Bytes = config.FlushBytes
+	c.Producer.MaxMessageBytes = config.MaxMessageBytes
 	c.Producer.Flush.Messages = maxExportBatchSize
 	c.Producer.Flush.Frequency = config.FlushFrequency
 	c.Producer.Retry.Max = config.MaxRetries

--- a/pkg/output/kafka/client_test.go
+++ b/pkg/output/kafka/client_test.go
@@ -271,10 +271,11 @@ func TestInitSaramaConfig(t *testing.T) {
 
 	t.Run("producer settings propagated", func(t *testing.T) {
 		cfg := &ProducerConfig{
-			Brokers:        "localhost:9092",
-			FlushBytes:     2_000_000,
-			FlushFrequency: 5_000_000_000, // 5s as Duration
-			MaxRetries:     7,
+			Brokers:         "localhost:9092",
+			FlushBytes:      2_000_000,
+			FlushFrequency:  5_000_000_000, // 5s as Duration
+			MaxRetries:      7,
+			MaxMessageBytes: 10_485_760,
 		}
 
 		sc, err := InitSaramaConfig(cfg, 1024)
@@ -283,6 +284,7 @@ func TestInitSaramaConfig(t *testing.T) {
 		assert.Equal(t, 1024, sc.Producer.Flush.Messages)
 		assert.Equal(t, cfg.FlushFrequency, sc.Producer.Flush.Frequency)
 		assert.Equal(t, 7, sc.Producer.Retry.Max)
+		assert.Equal(t, 10_485_760, sc.Producer.MaxMessageBytes)
 		assert.True(t, sc.Producer.Return.Successes)
 		assert.False(t, sc.Metadata.Full)
 	})


### PR DESCRIPTION
## Summary

The kafka producer config (`pkg/output/kafka/client.go:InitSaramaConfig`) never set `Producer.MaxMessageBytes`, so sarama silently used its 1,000,000-byte (~1 MiB) default. Messages above that cap were rejected at the producer and never reached the broker — even when the broker side was configured for a larger limit.

Concrete impact: blob-tx mempool events from `xatu-mimicry` sentries (~1.3-1.6 MiB each, EIP-4844 transactions with sidecars) failed to publish to `xatu-protobuf-*` topics, leading to ~0.2% loss visible when diffing `clickhouse-raw` against the `xatu` cluster.

## Change

- Add `MaxMessageBytes` to `ProducerConfig` (yaml: `maxMessageBytes`).
- Default `1000000` to preserve current behavior — existing deployments are unaffected.
- Wire it through `InitSaramaConfig` so deployments that need to publish large payloads can override via yaml.

The matching platform-side change to set `maxMessageBytes: 10485760` in `xatu-internal-server/values.yaml` (matching the broker's `message.max.bytes`) is being landed separately.