### PR TITLE
fix(kafka): exporter size check should use MaxMessageBytes, not FlushBytes

### DIFF
--- a/pkg/output/kafka/exporter.go
+++ b/pkg/output/kafka/exporter.go
@@ -86,11 +86,12 @@ func (e *ItemExporter) sendUpstream(_ context.Context, items []*xatu.DecoratedEv
 		}
 
 		msgByteSize := m.ByteSize(2)
-		if msgByteSize > e.config.FlushBytes {
+		if msgByteSize > e.config.MaxMessageBytes {
 			e.log.
 				WithField("event_id", routingKey).
 				WithField("msg_size", msgByteSize).
-				Debug("Message too large, consider increasing `max_message_bytes`")
+				WithField("max_message_bytes", e.config.MaxMessageBytes).
+				Warn("Message exceeds max_message_bytes, dropping")
 
 			continue
 		}

--- a/pkg/output/kafka/exporter_test.go
+++ b/pkg/output/kafka/exporter_test.go
@@ -163,7 +163,7 @@ func TestTopicForEvent(t *testing.T) {
 func TestExportItemsStaticTopic(t *testing.T) {
 	mock := &mockProducer{}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1000000},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		Topic:          "static-topic",
 	}, newTestLogger(), mock)
 
@@ -190,7 +190,7 @@ func TestExportItemsStaticTopic(t *testing.T) {
 func TestExportItemsTopicPattern(t *testing.T) {
 	mock := &mockProducer{}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1000000},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		TopicPattern:   "xatu-${event-name}",
 	}, newTestLogger(), mock)
 
@@ -210,7 +210,7 @@ func TestExportItemsTopicPattern(t *testing.T) {
 func TestExportItemsOversizedMessageSkipped(t *testing.T) {
 	mock := &mockProducer{}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
 
@@ -226,7 +226,7 @@ func TestExportItemsOversizedMessageSkipped(t *testing.T) {
 func TestExportItemsEmptyBatchAfterFiltering(t *testing.T) {
 	mock := &mockProducer{}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
 
@@ -249,7 +249,7 @@ func TestExportItemsProducerErrors(t *testing.T) {
 		err: sarama.ProducerErrors{prodErr},
 	}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1000000},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
 
@@ -270,7 +270,7 @@ func TestExportItemsGenericError(t *testing.T) {
 		err: errors.New("connection refused"),
 	}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1000000},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
 
@@ -285,7 +285,7 @@ func TestExportItemsGenericError(t *testing.T) {
 func TestShutdownClosesProducer(t *testing.T) {
 	mock := &mockProducer{}
 	exporter := NewItemExporter("test", &Config{
-		ProducerConfig: ProducerConfig{FlushBytes: 1000000},
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
 


### PR DESCRIPTION
## Summary

The per-message size check in `pkg/output/kafka/exporter.go` `sendUpstream` was comparing `m.ByteSize(2)` against `e.config.FlushBytes` (the batch flush threshold) instead of `e.config.MaxMessageBytes` (the per-message cap). The log message itself read "consider increasing `max_message_bytes`", agreeing that `MaxMessageBytes` was the intended field.

PR #809 introduced `MaxMessageBytes` to `ProducerConfig` and wired it into the Sarama config, but missed this consumer. Drops were also being logged at `Debug` level, so production deployments running `level=info` never saw them.

## Real impact

Blob-tx mempool events from `xatu-mimicry` sentries (~1.3 MiB hex-encoded raw tx) were being silently dropped in the kafka-protobuf path. The parallel HTTP -> vector -> general-* path doesn't go through this exporter, so the same events landed there normally — visible as a chronic ~0.2% mempool_transaction loss in `clickhouse-raw` between the two paths.

## Changes

- Compare `msgByteSize` against `MaxMessageBytes` instead of `FlushBytes`.
- Bump the drop log from `Debug` to `Warn` and clarify the message; include `max_message_bytes` as a structured field.
- Update `exporter_test.go` size-check tests to use `MaxMessageBytes` instead of `FlushBytes`.

The default for `MaxMessageBytes` (1,000,000) matches the previous `FlushBytes` default and Sarama's historical default, so existing deployments don't see a behavior change unless they raise it.