### PR TITLE
feat(discovery): support bootstrapRpcUrl for RPC-backed Status

### DIFF
--- a/example_discovery.yaml
+++ b/example_discovery.yaml
@@ -53,6 +53,10 @@ p2p:
     #   retryAttempts: 5    # max retry attempts for dialing a peer
     #   retryDelay: 5s      # delay between retry attempts
     #   dialTimeout: 15s    # timeout for dialing a peer
+    #   bootstrapRpcUrl: "" # optional EL JSON-RPC. When set, discovery serves
+    #                       # Status/headers/bodies/receipts from this endpoint
+    #                       # to keep negotiated peers connected. e.g.
+    #                       # http://localhost:8545
     # consensus layer discovery settings (optional, defaults shown)
     # consensus:
     #   retryAttempts: 1        # max retry attempts for dialing a peer
@@ -123,6 +127,7 @@ p2p:
   #     retryAttempts: 5
   #     retryDelay: 5s
   #     dialTimeout: 15s
+  #     bootstrapRpcUrl: "" # optional EL JSON-RPC for Status/headers/bodies/receipts
   #   consensus:  # optional
   #     retryAttempts: 1
   #     retryDelay: 2s

--- a/pkg/discovery/p2p/config.go
+++ b/pkg/discovery/p2p/config.go
@@ -72,9 +72,10 @@ func (c *Config) GetExecutionConfig() *static.ExecutionConfig {
 
 		// Convert xatu.ExecutionConfig to static.ExecutionConfig
 		return c.applyExecutionDefaults(&static.ExecutionConfig{
-			RetryAttempts: conf.Execution.RetryAttempts,
-			RetryDelay:    conf.Execution.RetryDelay,
-			DialTimeout:   conf.Execution.DialTimeout,
+			RetryAttempts:   conf.Execution.RetryAttempts,
+			RetryDelay:      conf.Execution.RetryDelay,
+			DialTimeout:     conf.Execution.DialTimeout,
+			BootstrapRPCURL: conf.Execution.BootstrapRPCURL,
 		})
 	default:
 		return defaultConfig

--- a/pkg/discovery/p2p/execution_peer.go
+++ b/pkg/discovery/p2p/execution_peer.go
@@ -3,10 +3,12 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/ethcore/pkg/execution/mimicry"
+	"github.com/ethpandaops/xatu/pkg/internal/rpcbootstrap"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -22,8 +24,28 @@ type ExecutionPeer struct {
 	handlerFunc func(ctx context.Context, status *xatu.ExecutionNodeStatus)
 }
 
-func NewExecutionPeer(ctx context.Context, log logrus.FieldLogger, nodeRecord string, handlerFunc func(ctx context.Context, status *xatu.ExecutionNodeStatus)) (*ExecutionPeer, error) {
-	client, err := mimicry.New(ctx, log, nodeRecord, "xatu")
+func NewExecutionPeer(ctx context.Context, log logrus.FieldLogger, nodeRecord, bootstrapRPCURL string, handlerFunc func(ctx context.Context, status *xatu.ExecutionNodeStatus)) (*ExecutionPeer, error) {
+	opts := []mimicry.Option{}
+
+	if bootstrapRPCURL != "" {
+		bootstrap, berr := rpcbootstrap.New(ctx, log, bootstrapRPCURL)
+		if berr != nil {
+			return nil, fmt.Errorf("initialize execution bootstrap RPC: %w", berr)
+		}
+
+		if _, berr = bootstrap.CurrentStatus(ctx); berr != nil {
+			return nil, fmt.Errorf("validate execution bootstrap RPC: %w", berr)
+		}
+
+		opts = append(opts,
+			mimicry.WithStatusProvider(bootstrap.Status),
+			mimicry.WithHeaderProvider(bootstrap.Headers),
+			mimicry.WithBodyProvider(bootstrap.Bodies),
+			mimicry.WithReceiptProvider(bootstrap.Receipts),
+		)
+	}
+
+	client, err := mimicry.New(ctx, log, nodeRecord, "xatu", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/discovery/p2p/static/config.go
+++ b/pkg/discovery/p2p/static/config.go
@@ -13,6 +13,12 @@ type ExecutionConfig struct {
 	RetryDelay time.Duration `yaml:"retryDelay" default:"5s"`
 	// DialTimeout is the timeout for dialing a peer.
 	DialTimeout time.Duration `yaml:"dialTimeout" default:"15s"`
+	// BootstrapRPCURL is an optional execution JSON-RPC endpoint used to build
+	// our own Status message and serve lightweight block/header/body/receipt
+	// requests during the eth handshake. When set, discovery becomes a more
+	// useful peer and recovers connections that would otherwise drop after
+	// Status exchange.
+	BootstrapRPCURL string `yaml:"bootstrapRpcUrl" default:""`
 }
 
 // ConsensusConfig holds configuration for consensus layer node discovery dialing.

--- a/pkg/discovery/p2p/status.go
+++ b/pkg/discovery/p2p/status.go
@@ -148,7 +148,7 @@ func (s *Status) AddExecutionNodeRecords(ctx context.Context, nodeRecords []stri
 					default:
 					}
 
-					peer, err := NewExecutionPeer(s.ctx, s.log, record, s.publishExecutionStatus)
+					peer, err := NewExecutionPeer(s.ctx, s.log, record, s.executionConfig.BootstrapRPCURL, s.publishExecutionStatus)
 					if err != nil {
 						return err
 					}

--- a/pkg/discovery/p2p/xatu/config.go
+++ b/pkg/discovery/p2p/xatu/config.go
@@ -14,6 +14,12 @@ type ExecutionConfig struct {
 	RetryDelay time.Duration `yaml:"retryDelay" default:"5s"`
 	// DialTimeout is the timeout for dialing a peer.
 	DialTimeout time.Duration `yaml:"dialTimeout" default:"15s"`
+	// BootstrapRPCURL is an optional execution JSON-RPC endpoint used to build
+	// our own Status message and serve lightweight block/header/body/receipt
+	// requests during the eth handshake. When set, discovery becomes a more
+	// useful peer and recovers connections that would otherwise drop after
+	// Status exchange.
+	BootstrapRPCURL string `yaml:"bootstrapRpcUrl" default:""`
 }
 
 // ConsensusConfig holds configuration for consensus layer node discovery dialing.

--- a/pkg/internal/rpcbootstrap/rpcbootstrap.go
+++ b/pkg/internal/rpcbootstrap/rpcbootstrap.go
@@ -471,6 +471,8 @@ func bootstrapNetwork(networkID uint64) (*params.ChainConfig, *types.Block, *big
 		return params.SepoliaChainConfig, core.DefaultSepoliaGenesisBlock().ToBlock(), copyBigInt(params.SepoliaChainConfig.TerminalTotalDifficulty), nil
 	case 17000:
 		return params.HoleskyChainConfig, core.DefaultHoleskyGenesisBlock().ToBlock(), copyBigInt(params.HoleskyChainConfig.TerminalTotalDifficulty), nil
+	case 560048:
+		return params.HoodiChainConfig, core.DefaultHoodiGenesisBlock().ToBlock(), copyBigInt(params.HoodiChainConfig.TerminalTotalDifficulty), nil
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported bootstrap RPC network id: %d", networkID)
 	}

--- a/pkg/internal/rpcbootstrap/rpcbootstrap.go
+++ b/pkg/internal/rpcbootstrap/rpcbootstrap.go
@@ -1,4 +1,9 @@
-package execution
+// Package rpcbootstrap provides an execution-layer JSON-RPC backed source for
+// devp2p Status, headers, bodies, and receipts. It is shared between the
+// mimicry and discovery modules so both can act as well-behaved peers during
+// the eth handshake using a real EL node as the source of truth for chain head
+// and historical data.
+package rpcbootstrap
 
 import (
 	"bytes"
@@ -31,16 +36,18 @@ const (
 	statusCacheTTL       = 10 * time.Second
 )
 
-type rpcBootstrap struct {
+// Bootstrap serves devp2p Status / headers / bodies / receipts to an eth peer
+// using a backing EL JSON-RPC endpoint as the source of truth.
+type Bootstrap struct {
 	log logrus.FieldLogger
 
 	client *ethclient.Client
 
 	mu          sync.Mutex
-	statusCache *rpcBootstrapStatus
+	statusCache *statusSnapshot
 }
 
-type rpcBootstrapStatus struct {
+type statusSnapshot struct {
 	networkID               uint64
 	genesis                 common.Hash
 	terminalTotalDifficulty *big.Int
@@ -51,41 +58,43 @@ type rpcBootstrapStatus struct {
 	expiresAt               time.Time
 }
 
-type rpcBootstrapChain struct {
+type bootstrapChain struct {
 	config  *params.ChainConfig
 	genesis *types.Block
 	head    *types.Header
 }
 
-func (c *rpcBootstrapChain) Config() *params.ChainConfig {
+func (c *bootstrapChain) Config() *params.ChainConfig {
 	return c.config
 }
 
-func (c *rpcBootstrapChain) Genesis() *types.Block {
+func (c *bootstrapChain) Genesis() *types.Block {
 	return c.genesis
 }
 
-func (c *rpcBootstrapChain) CurrentHeader() *types.Header {
+func (c *bootstrapChain) CurrentHeader() *types.Header {
 	return c.head
 }
 
-var sharedRPCBootstraps = struct {
+var sharedBootstraps = struct {
 	sync.Mutex
-	byURL map[string]*rpcBootstrap
+	byURL map[string]*Bootstrap
 }{
-	byURL: map[string]*rpcBootstrap{},
+	byURL: map[string]*Bootstrap{},
 }
 
-func newRPCBootstrap(ctx context.Context, log logrus.FieldLogger, url string) (*rpcBootstrap, error) {
-	sharedRPCBootstraps.Lock()
+// New returns a Bootstrap for the given EL JSON-RPC URL. Multiple callers with
+// the same URL share a single underlying client and Status cache.
+func New(ctx context.Context, log logrus.FieldLogger, url string) (*Bootstrap, error) {
+	sharedBootstraps.Lock()
 
-	if bootstrap, ok := sharedRPCBootstraps.byURL[url]; ok {
-		sharedRPCBootstraps.Unlock()
+	if bootstrap, ok := sharedBootstraps.byURL[url]; ok {
+		sharedBootstraps.Unlock()
 
 		return bootstrap, nil
 	}
 
-	sharedRPCBootstraps.Unlock()
+	sharedBootstraps.Unlock()
 
 	rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -95,39 +104,43 @@ func newRPCBootstrap(ctx context.Context, log logrus.FieldLogger, url string) (*
 		return nil, err
 	}
 
-	bootstrap := &rpcBootstrap{
+	bootstrap := &Bootstrap{
 		log:    log.WithField("bootstrap_rpc_url", url),
 		client: client,
 	}
 
-	sharedRPCBootstraps.Lock()
+	sharedBootstraps.Lock()
 
-	if existing, ok := sharedRPCBootstraps.byURL[url]; ok {
-		sharedRPCBootstraps.Unlock()
+	if existing, ok := sharedBootstraps.byURL[url]; ok {
+		sharedBootstraps.Unlock()
 		client.Close()
 
 		return existing, nil
 	}
 
-	sharedRPCBootstraps.byURL[url] = bootstrap
-	sharedRPCBootstraps.Unlock()
+	sharedBootstraps.byURL[url] = bootstrap
+	sharedBootstraps.Unlock()
 
 	return bootstrap, nil
 }
 
-func ValidateBootstrapRPC(ctx context.Context, log logrus.FieldLogger, url string) error {
-	bootstrap, err := newRPCBootstrap(ctx, log, url)
+// Validate dials the URL and confirms a Status snapshot can be built.
+func Validate(ctx context.Context, log logrus.FieldLogger, url string) error {
+	bootstrap, err := New(ctx, log, url)
 	if err != nil {
 		return err
 	}
 
-	_, err = bootstrap.currentStatus(ctx)
+	_, err = bootstrap.CurrentStatus(ctx)
 
 	return err
 }
 
-func (b *rpcBootstrap) status(ctx context.Context, protocolVersion uint, peerStatus mimicry.Status) (mimicry.Status, error) {
-	snapshot, err := b.currentStatus(ctx)
+// Status returns a Status message for the given protocolVersion sourced from
+// the current chain head. It also validates the peer's claimed Status against
+// our snapshot for early rejection of incompatible peers.
+func (b *Bootstrap) Status(ctx context.Context, protocolVersion uint, peerStatus mimicry.Status) (mimicry.Status, error) {
+	snapshot, err := b.CurrentStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +178,9 @@ func (b *rpcBootstrap) status(ctx context.Context, protocolVersion uint, peerSta
 	}
 }
 
-func (b *rpcBootstrap) currentStatus(ctx context.Context) (*rpcBootstrapStatus, error) {
+// CurrentStatus returns the cached chain-head snapshot, refreshing it when
+// stale.
+func (b *Bootstrap) CurrentStatus(ctx context.Context) (*statusSnapshot, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -192,13 +207,13 @@ func (b *rpcBootstrap) currentStatus(ctx context.Context) (*rpcBootstrapStatus, 
 	}
 
 	forkID := forkid.NewID(chainConfig, genesis, head.Number.Uint64(), head.Time)
-	forkFilter := forkid.NewFilter(&rpcBootstrapChain{
+	forkFilter := forkid.NewFilter(&bootstrapChain{
 		config:  chainConfig,
 		genesis: genesis,
 		head:    head,
 	})
 
-	b.statusCache = &rpcBootstrapStatus{
+	b.statusCache = &statusSnapshot{
 		networkID:               networkID.Uint64(),
 		genesis:                 genesis.Hash(),
 		terminalTotalDifficulty: new(big.Int).Set(terminalTotalDifficulty),
@@ -212,51 +227,8 @@ func (b *rpcBootstrap) currentStatus(ctx context.Context) (*rpcBootstrapStatus, 
 	return b.statusCache, nil
 }
 
-func validatePeerStatus(peerStatus mimicry.Status, snapshot *rpcBootstrapStatus) error {
-	if peerStatus == nil {
-		return nil
-	}
-
-	if peerStatus.GetNetworkID() != snapshot.networkID {
-		return fmt.Errorf("peer network id %d does not match bootstrap RPC network id %d", peerStatus.GetNetworkID(), snapshot.networkID)
-	}
-
-	if !bytes.Equal(peerStatus.GetGenesis(), snapshot.genesis[:]) {
-		return fmt.Errorf("peer genesis %x does not match bootstrap genesis %x", peerStatus.GetGenesis(), snapshot.genesis[:])
-	}
-
-	peerForkID, err := forkIDFromPeerStatus(peerStatus)
-	if err != nil {
-		return err
-	}
-
-	if err := snapshot.forkFilter(peerForkID); err != nil {
-		return fmt.Errorf(
-			"peer fork id 0x%x/%d is incompatible with bootstrap fork id 0x%x/%d: %w",
-			peerForkID.Hash[:],
-			peerForkID.Next,
-			snapshot.forkID.Hash[:],
-			snapshot.forkID.Next,
-			err,
-		)
-	}
-
-	return nil
-}
-
-func forkIDFromPeerStatus(peerStatus mimicry.Status) (forkid.ID, error) {
-	hash := peerStatus.GetForkIDHash()
-	if len(hash) != 4 {
-		return forkid.ID{}, fmt.Errorf("peer fork id hash must be 4 bytes, got %d", len(hash))
-	}
-
-	var forkHash [4]byte
-	copy(forkHash[:], hash)
-
-	return forkid.ID{Hash: forkHash, Next: peerStatus.GetForkIDNext()}, nil
-}
-
-func (b *rpcBootstrap) headers(ctx context.Context, request *eth.GetBlockHeadersRequest) ([]*types.Header, error) {
+// Headers serves a GetBlockHeaders response sourced from the backing RPC.
+func (b *Bootstrap) Headers(ctx context.Context, request *eth.GetBlockHeadersRequest) ([]*types.Header, error) {
 	if request == nil || request.Amount == 0 {
 		return nil, nil
 	}
@@ -329,7 +301,8 @@ func (b *rpcBootstrap) headers(ctx context.Context, request *eth.GetBlockHeaders
 	return headers, nil
 }
 
-func (b *rpcBootstrap) bodies(ctx context.Context, hashes []common.Hash) ([]eth.BlockBody, error) {
+// Bodies serves a GetBlockBodies response sourced from the backing RPC.
+func (b *Bootstrap) Bodies(ctx context.Context, hashes []common.Hash) ([]eth.BlockBody, error) {
 	if len(hashes) == 0 {
 		return nil, nil
 	}
@@ -367,7 +340,8 @@ func (b *rpcBootstrap) bodies(ctx context.Context, hashes []common.Hash) ([]eth.
 	return bodies, nil
 }
 
-func (b *rpcBootstrap) receipts(ctx context.Context, request mimicry.ReceiptRequest) ([]*eth.ReceiptList, error) {
+// Receipts serves a GetReceipts response sourced from the backing RPC.
+func (b *Bootstrap) Receipts(ctx context.Context, request mimicry.ReceiptRequest) ([]*eth.ReceiptList, error) {
 	hashes := request.Hashes
 	if len(hashes) == 0 {
 		return nil, nil
@@ -409,6 +383,58 @@ func (b *rpcBootstrap) receipts(ctx context.Context, request mimicry.ReceiptRequ
 	return receipts, nil
 }
 
+func (b *Bootstrap) originHeader(ctx context.Context, origin eth.HashOrNumber) (*types.Header, error) {
+	if origin.Hash != (common.Hash{}) {
+		return b.client.HeaderByHash(ctx, origin.Hash)
+	}
+
+	return b.client.HeaderByNumber(ctx, new(big.Int).SetUint64(origin.Number))
+}
+
+func validatePeerStatus(peerStatus mimicry.Status, snapshot *statusSnapshot) error {
+	if peerStatus == nil {
+		return nil
+	}
+
+	if peerStatus.GetNetworkID() != snapshot.networkID {
+		return fmt.Errorf("peer network id %d does not match bootstrap RPC network id %d", peerStatus.GetNetworkID(), snapshot.networkID)
+	}
+
+	if !bytes.Equal(peerStatus.GetGenesis(), snapshot.genesis[:]) {
+		return fmt.Errorf("peer genesis %x does not match bootstrap genesis %x", peerStatus.GetGenesis(), snapshot.genesis[:])
+	}
+
+	peerForkID, err := forkIDFromPeerStatus(peerStatus)
+	if err != nil {
+		return err
+	}
+
+	if err := snapshot.forkFilter(peerForkID); err != nil {
+		return fmt.Errorf(
+			"peer fork id 0x%x/%d is incompatible with bootstrap fork id 0x%x/%d: %w",
+			peerForkID.Hash[:],
+			peerForkID.Next,
+			snapshot.forkID.Hash[:],
+			snapshot.forkID.Next,
+			err,
+		)
+	}
+
+	return nil
+}
+
+func forkIDFromPeerStatus(peerStatus mimicry.Status) (forkid.ID, error) {
+	hash := peerStatus.GetForkIDHash()
+	if len(hash) != 4 {
+		return forkid.ID{}, fmt.Errorf("peer fork id hash must be 4 bytes, got %d", len(hash))
+	}
+
+	var forkHash [4]byte
+	copy(forkHash[:], hash)
+
+	return forkid.ID{Hash: forkHash, Next: peerStatus.GetForkIDNext()}, nil
+}
+
 func encodeBlockBody(block *types.Block) (eth.BlockBody, error) {
 	transactions, err := rlp.EncodeToRawList([]*types.Transaction(block.Transactions()))
 	if err != nil {
@@ -435,14 +461,6 @@ func encodeBlockBody(block *types.Block) (eth.BlockBody, error) {
 	}
 
 	return body, nil
-}
-
-func (b *rpcBootstrap) originHeader(ctx context.Context, origin eth.HashOrNumber) (*types.Header, error) {
-	if origin.Hash != (common.Hash{}) {
-		return b.client.HeaderByHash(ctx, origin.Hash)
-	}
-
-	return b.client.HeaderByNumber(ctx, new(big.Int).SetUint64(origin.Number))
 }
 
 func bootstrapNetwork(networkID uint64) (*params.ChainConfig, *types.Block, *big.Int, error) {

--- a/pkg/internal/rpcbootstrap/rpcbootstrap_test.go
+++ b/pkg/internal/rpcbootstrap/rpcbootstrap_test.go
@@ -1,4 +1,4 @@
-package execution
+package rpcbootstrap
 
 import (
 	"math/big"
@@ -59,7 +59,7 @@ func TestValidatePeerStatusAcceptsCompatibleForkID(t *testing.T) {
 	))
 }
 
-func snapshotForTest(t *testing.T, networkID, headNumber, headTime uint64) *rpcBootstrapStatus {
+func snapshotForTest(t *testing.T, networkID, headNumber, headTime uint64) *statusSnapshot {
 	t.Helper()
 
 	chainConfig, genesis, terminalTotalDifficulty, err := bootstrapNetwork(networkID)
@@ -71,13 +71,13 @@ func snapshotForTest(t *testing.T, networkID, headNumber, headTime uint64) *rpcB
 	}
 	forkID := forkid.NewID(chainConfig, genesis, headNumber, headTime)
 
-	return &rpcBootstrapStatus{
+	return &statusSnapshot{
 		networkID:               networkID,
 		genesis:                 genesis.Hash(),
 		terminalTotalDifficulty: terminalTotalDifficulty,
 		headNumber:              headNumber,
 		forkID:                  forkID,
-		forkFilter: forkid.NewFilter(&rpcBootstrapChain{
+		forkFilter: forkid.NewFilter(&bootstrapChain{
 			config:  chainConfig,
 			genesis: genesis,
 			head:    head,

--- a/pkg/mimicry/mimicry.go
+++ b/pkg/mimicry/mimicry.go
@@ -15,8 +15,8 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/beevik/ntp"
+	"github.com/ethpandaops/xatu/pkg/internal/rpcbootstrap"
 	"github.com/ethpandaops/xatu/pkg/mimicry/coordinator"
-	"github.com/ethpandaops/xatu/pkg/mimicry/p2p/execution"
 	"github.com/ethpandaops/xatu/pkg/mimicry/p2p/handler"
 	"github.com/ethpandaops/xatu/pkg/output"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -62,7 +62,7 @@ func New(ctx context.Context, log logrus.FieldLogger, config *Config, overrides 
 	}
 
 	if config.Ethereum.BootstrapRPCURL != "" {
-		if err := execution.ValidateBootstrapRPC(ctx, log, config.Ethereum.BootstrapRPCURL); err != nil {
+		if err := rpcbootstrap.Validate(ctx, log, config.Ethereum.BootstrapRPCURL); err != nil {
 			return nil, fmt.Errorf("validate ethereum.bootstrapRpcUrl: %w", err)
 		}
 	}

--- a/pkg/mimicry/p2p/execution/execution.go
+++ b/pkg/mimicry/p2p/execution/execution.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethpandaops/ethcore/pkg/execution/mimicry"
+	"github.com/ethpandaops/xatu/pkg/internal/rpcbootstrap"
 	coordCache "github.com/ethpandaops/xatu/pkg/mimicry/coordinator/cache"
 	"github.com/ethpandaops/xatu/pkg/mimicry/ethereum"
 	"github.com/ethpandaops/xatu/pkg/mimicry/p2p/handler"
@@ -79,20 +80,20 @@ func New(ctx context.Context, log logrus.FieldLogger, nodeRecord string, handler
 	}
 
 	if ethereumConfig != nil && ethereumConfig.BootstrapRPCURL != "" {
-		bootstrap, berr := newRPCBootstrap(ctx, log, ethereumConfig.BootstrapRPCURL)
+		bootstrap, berr := rpcbootstrap.New(ctx, log, ethereumConfig.BootstrapRPCURL)
 		if berr != nil {
 			return nil, fmt.Errorf("initialize execution bootstrap RPC: %w", berr)
 		}
 
-		if _, berr = bootstrap.currentStatus(ctx); berr != nil {
+		if _, berr = bootstrap.CurrentStatus(ctx); berr != nil {
 			return nil, fmt.Errorf("validate execution bootstrap RPC: %w", berr)
 		}
 
 		opts = append(opts,
-			mimicry.WithStatusProvider(bootstrap.status),
-			mimicry.WithHeaderProvider(bootstrap.headers),
-			mimicry.WithBodyProvider(bootstrap.bodies),
-			mimicry.WithReceiptProvider(bootstrap.receipts),
+			mimicry.WithStatusProvider(bootstrap.Status),
+			mimicry.WithHeaderProvider(bootstrap.Headers),
+			mimicry.WithBodyProvider(bootstrap.Bodies),
+			mimicry.WithReceiptProvider(bootstrap.Receipts),
 		)
 	}
 


### PR DESCRIPTION
## Summary

Brings the RPC-backed Status / headers / bodies / receipts behavior introduced for mimicry in PR #811 to discovery.

When discovery negotiates the eth handshake with a peer it currently sends a synthetic Status from the ethcore client and answers no chain-data requests, so peers that don't accept that pattern (most healthy mainnet EL clients) drop the connection before discovery can capture a `NodeRecordExecution` event. Wiring an optional `bootstrapRpcUrl` lets discovery serve the same accurate Status, headers, bodies, and receipts that mimicry now does, keeping more peers connected long enough to record their identity and capabilities.

## Changes

- Promote `pkg/mimicry/p2p/execution/rpc_bootstrap.go` (and its tests) to a shared `pkg/internal/rpcbootstrap` package so both modules consume one implementation. Methods/types exported as `Bootstrap`, `New`, `Validate`, `Status`, `Headers`, `Bodies`, `Receipts`, `CurrentStatus`.
- Update `pkg/mimicry` to import the shared package; behavior unchanged.
- Add `BootstrapRPCURL string \`yaml:"bootstrapRpcUrl"\`` to `pkg/discovery/p2p/{xatu,static}.ExecutionConfig`.
- Thread the URL through `pkg/discovery/p2p/config.go` -> `status.go` -> `NewExecutionPeer`. When set, `NewExecutionPeer` builds a `rpcbootstrap.Bootstrap` and passes `WithStatusProvider` / `WithHeaderProvider` / `WithBodyProvider` / `WithReceiptProvider` to `mimicry.New`.
- Update `example_discovery.yaml` with commented `bootstrapRpcUrl` examples.

When `bootstrapRpcUrl` is unset, discovery behavior is identical to today.

## Notes

- Field validates lazily at first use (when the URL is dialed). The same approach mimicry takes today.
- Companion deployment in [ethpandaops/platform](https://github.com/ethpandaops/platform) wires this against an erpc load balancer fronting the utility-cluster EL ingresses.