### PR TITLE
refactor: widen block_access_index from UInt16 to UInt32 per EIP-7928

### DIFF
--- a/deploy/migrations/clickhouse/002_gloas_bals_support.up.sql
+++ b/deploy/migrations/clickhouse/002_gloas_bals_support.up.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS default.canonical_beacon_block_access_list_local ON C
     block_hash FixedString(66) CODEC(ZSTD(1)),
     address FixedString(42) CODEC(ZSTD(1)),
     change_type LowCardinality(String) CODEC(ZSTD(1)),
-    block_access_index UInt16 CODEC(DoubleDelta, ZSTD(1)),
+    block_access_index UInt32 CODEC(DoubleDelta, ZSTD(1)),
     storage_key FixedString(66) CODEC(ZSTD(1)),
     new_value Nullable(String) CODEC(ZSTD(1)),
     meta_client_name LowCardinality(String) CODEC(ZSTD(1)),

--- a/deploy/migrations/clickhouse/003_gloas_epbs_support.up.sql
+++ b/deploy/migrations/clickhouse/003_gloas_epbs_support.up.sql
@@ -679,8 +679,8 @@ ALTER TABLE default.beacon_api_eth_v2_beacon_block ON CLUSTER '{cluster}'
 --    Pre-Gloas rows: empty string. Gloas+: "validator" or "builder".
 ---------------------------------------------------------------------
 ALTER TABLE default.canonical_beacon_block_withdrawal_local ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `withdrawal_type` LowCardinality(String) DEFAULT '' COMMENT 'Classification of the withdrawal recipient (Gloas+: validator|builder; pre-Gloas: empty)' CODEC(ZSTD(1));
+    ADD COLUMN IF NOT EXISTS `withdrawal_type` LowCardinality(String) DEFAULT '' COMMENT 'Classification of the withdrawal recipient (Gloas+: validator|builder, pre-Gloas: empty)' CODEC(ZSTD(1));
 
 ALTER TABLE default.canonical_beacon_block_withdrawal ON CLUSTER '{cluster}'
-    ADD COLUMN IF NOT EXISTS `withdrawal_type` LowCardinality(String) DEFAULT '' COMMENT 'Classification of the withdrawal recipient (Gloas+: validator|builder; pre-Gloas: empty)' CODEC(ZSTD(1));
+    ADD COLUMN IF NOT EXISTS `withdrawal_type` LowCardinality(String) DEFAULT '' COMMENT 'Classification of the withdrawal recipient (Gloas+: validator|builder, pre-Gloas: empty)' CODEC(ZSTD(1));
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_access_list.gen.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_access_list.gen.go
@@ -23,7 +23,7 @@ type canonicalBeaconBlockAccessListBatch struct {
 	BlockHash                                 route.SafeColFixedStr
 	Address                                   route.SafeColFixedStr
 	ChangeType                                proto.ColStr
-	BlockAccessIndex                          proto.ColUInt16
+	BlockAccessIndex                          proto.ColUInt32
 	StorageKey                                route.SafeColFixedStr
 	NewValue                                  *proto.ColNullable[string]
 	MetaClientName                            proto.ColStr

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_access_list.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_access_list.go
@@ -77,7 +77,7 @@ func (b *canonicalBeaconBlockAccessListBatch) appendPayload(event *xatu.Decorate
 	b.ChangeType.Append(change.GetChangeType())
 
 	if blockAccessIndex := change.GetBlockAccessIndex(); blockAccessIndex != nil {
-		b.BlockAccessIndex.Append(uint16(blockAccessIndex.GetValue())) //nolint:gosec // block_access_index fits uint16
+		b.BlockAccessIndex.Append(blockAccessIndex.GetValue())
 	} else {
 		b.BlockAccessIndex.Append(0)
 	}


### PR DESCRIPTION
Aligns `block_access_index` storage with the EIP-7928 spec, which defines it as `uint32`. The xatu proto, conversion helpers and snapshot tests already used `uint32`; only the ClickHouse migration and the generated route batch were narrowing it to `UInt16`, which caused snapshot tests to fail with `expected uint32(0x5), got uint16(0x5)`.

[EIP-7928 — Block-Level Access Lists](https://eips.ethereum.org/EIPS/eip-7928) defines:

> `BlockAccessIndex = uint32  # Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)`

See the SSZ container definitions section: <https://eips.ethereum.org/EIPS/eip-7928#specification>.