### PR TITLE
consumoor: add disabledTables config to skip output tables

### DIFF
--- a/pkg/clickhouse/router/engine.go
+++ b/pkg/clickhouse/router/engine.go
@@ -35,6 +35,11 @@ type Engine struct {
 	// produces multiple.
 	routesByEvent map[xatu.Event_Name][]route.Route
 
+	// disabledByConfig marks event names that had at least one registered
+	// route before config-driven filtering removed all of them. These are
+	// dropped (StatusDelivered) rather than NAK'd at Route() time.
+	disabledByConfig map[xatu.Event_Name]struct{}
+
 	metrics    *telemetry.Metrics
 	logSampler *telemetry.LogSampler
 }
@@ -44,13 +49,15 @@ func New(
 	log logrus.FieldLogger,
 	routes []route.Route,
 	disabledEvents []xatu.Event_Name,
+	disabledTables map[string]struct{},
 	metrics *telemetry.Metrics,
 ) *Engine {
 	r := &Engine{
-		log:           log.WithField("component", "router"),
-		routesByEvent: make(map[xatu.Event_Name][]route.Route, len(routes)),
-		metrics:       metrics,
-		logSampler:    telemetry.NewLogSampler(logSampleInterval),
+		log:              log.WithField("component", "router"),
+		routesByEvent:    make(map[xatu.Event_Name][]route.Route, len(routes)),
+		disabledByConfig: make(map[xatu.Event_Name]struct{}, len(disabledEvents)),
+		metrics:          metrics,
+		logSampler:       telemetry.NewLogSampler(logSampleInterval),
 	}
 
 	disabled := make(map[xatu.Event_Name]struct{}, len(disabledEvents))
@@ -58,10 +65,22 @@ func New(
 		disabled[name] = struct{}{}
 	}
 
-	// Register routes by event name.
+	// Register routes by event name, skipping routes whose target table is
+	// disabled or whose event is disabled. Event names that had any route
+	// before filtering are recorded in disabledByConfig so they are dropped
+	// (not NAK'd) at Route() time when all their routes are filtered out.
 	for _, route := range routes {
+		tableDisabled := false
+		if _, ok := disabledTables[route.TableName()]; ok {
+			tableDisabled = true
+		}
+
 		for _, name := range route.EventNames() {
-			if _, isDisabled := disabled[name]; isDisabled {
+			_, eventDisabled := disabled[name]
+
+			if tableDisabled || eventDisabled {
+				r.disabledByConfig[name] = struct{}{}
+
 				continue
 			}
 
@@ -69,9 +88,16 @@ func New(
 		}
 	}
 
+	// An event that had at least one surviving route is not disabled —
+	// drop it from disabledByConfig so Route() does not short-circuit it.
+	for name := range r.routesByEvent {
+		delete(r.disabledByConfig, name)
+	}
+
 	// Log registration summary
 	log.WithField("registered_events", len(r.routesByEvent)).
 		WithField("disabled_events", len(disabled)).
+		WithField("disabled_tables", len(disabledTables)).
 		Info("Routing engine initialized")
 
 	return r
@@ -93,6 +119,23 @@ func (r *Engine) Route(event *xatu.DecoratedEvent) Outcome {
 	// matching route is deployed.
 	routesForEvent, ok := r.routesByEvent[eventName]
 	if !ok {
+		if _, disabledByConfig := r.disabledByConfig[eventName]; disabledByConfig {
+			if r.metrics != nil {
+				r.metrics.MessagesDropped().WithLabelValues(eventName.String(), "disabled_by_config").Inc()
+			}
+
+			if ok, suppressed := r.logSampler.Allow("config_drop:" + eventName.String()); ok {
+				entry := r.log.WithField("event_name", eventName.String())
+				if suppressed > 0 {
+					entry = entry.WithField("suppressed", suppressed)
+				}
+
+				entry.Debug("Event has no enabled routes after config filtering — dropping")
+			}
+
+			return Outcome{Status: StatusDelivered}
+		}
+
 		if reason, intentionallyUnsupported := route.UnsupportedReason(eventName); intentionallyUnsupported {
 			if r.metrics != nil {
 				r.metrics.MessagesDropped().WithLabelValues(eventName.String(), "no_flattener").Inc()

--- a/pkg/clickhouse/router/engine_test.go
+++ b/pkg/clickhouse/router/engine_test.go
@@ -55,6 +55,7 @@ func TestNewRouterSkipsDisabledEvents(t *testing.T) {
 		logrus.New(),
 		routes,
 		[]xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
+		nil,
 		newTestMetrics(),
 	)
 
@@ -67,6 +68,86 @@ func TestNewRouterSkipsDisabledEvents(t *testing.T) {
 	require.Equal(t, "table_b", disconnectedRoutes[0].TableName())
 }
 
+func TestNewRouterSkipsDisabledTables(t *testing.T) {
+	routes := []route.Route{
+		filterTestRoute{
+			table:  route.TableName("libp2p_peer"),
+			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED, xatu.Event_LIBP2P_TRACE_DISCONNECTED},
+		},
+		filterTestRoute{
+			table:  route.TableName("libp2p_connected"),
+			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
+		},
+	}
+
+	router := New(
+		logrus.New(),
+		routes,
+		nil,
+		map[string]struct{}{"libp2p_peer": {}},
+		newTestMetrics(),
+	)
+
+	require.Contains(t, router.routesByEvent, xatu.Event_LIBP2P_TRACE_CONNECTED)
+	require.Len(t, router.routesByEvent[xatu.Event_LIBP2P_TRACE_CONNECTED], 1)
+	require.Equal(t, "libp2p_connected", router.routesByEvent[xatu.Event_LIBP2P_TRACE_CONNECTED][0].TableName())
+	require.NotContains(t, router.routesByEvent, xatu.Event_LIBP2P_TRACE_DISCONNECTED)
+}
+
+func TestRouteEventWithAllTablesDisabledIsDropped(t *testing.T) {
+	routes := []route.Route{
+		filterTestRoute{
+			table:  route.TableName("libp2p_peer"),
+			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_DISCONNECTED},
+		},
+	}
+
+	router := New(
+		logrus.New(),
+		routes,
+		nil,
+		map[string]struct{}{"libp2p_peer": {}},
+		newTestMetrics(),
+	)
+
+	outcome := router.Route(&xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Id:   "e1",
+			Name: xatu.Event_LIBP2P_TRACE_DISCONNECTED,
+		},
+	})
+
+	require.Equal(t, StatusDelivered, outcome.Status)
+	require.Empty(t, outcome.Results)
+}
+
+func TestRouteDisabledEventIsDropped(t *testing.T) {
+	routes := []route.Route{
+		filterTestRoute{
+			table:  route.TableName("libp2p_connected"),
+			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
+		},
+	}
+
+	router := New(
+		logrus.New(),
+		routes,
+		[]xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
+		nil,
+		newTestMetrics(),
+	)
+
+	outcome := router.Route(&xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Id:   "e1",
+			Name: xatu.Event_LIBP2P_TRACE_CONNECTED,
+		},
+	})
+
+	require.Equal(t, StatusDelivered, outcome.Status)
+	require.Empty(t, outcome.Results)
+}
+
 func TestRouteIntentionallyUnsupportedEventIsDropped(t *testing.T) {
 	routes := []route.Route{
 		filterTestRoute{
@@ -75,7 +156,7 @@ func TestRouteIntentionallyUnsupportedEventIsDropped(t *testing.T) {
 		},
 	}
 
-	router := New(logrus.New(), routes, nil, newTestMetrics())
+	router := New(logrus.New(), routes, nil, nil, newTestMetrics())
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{
@@ -96,7 +177,7 @@ func TestRouteUnknownEventIsNAKed(t *testing.T) {
 		},
 	}
 
-	router := New(logrus.New(), routes, nil, newTestMetrics())
+	router := New(logrus.New(), routes, nil, nil, newTestMetrics())
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{

--- a/pkg/clickhouse/router/engine_test.go
+++ b/pkg/clickhouse/router/engine_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testEventID            = "e1"
+	testTableLibp2pPeer    = "libp2p_peer"
+	testTableLibp2pConnect = "libp2p_connected"
+)
+
 type filterTestRoute struct {
 	table  route.TableName
 	events []xatu.Event_Name
@@ -71,11 +77,11 @@ func TestNewRouterSkipsDisabledEvents(t *testing.T) {
 func TestNewRouterSkipsDisabledTables(t *testing.T) {
 	routes := []route.Route{
 		filterTestRoute{
-			table:  route.TableName("libp2p_peer"),
+			table:  route.TableName(testTableLibp2pPeer),
 			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED, xatu.Event_LIBP2P_TRACE_DISCONNECTED},
 		},
 		filterTestRoute{
-			table:  route.TableName("libp2p_connected"),
+			table:  route.TableName(testTableLibp2pConnect),
 			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
 		},
 	}
@@ -84,20 +90,20 @@ func TestNewRouterSkipsDisabledTables(t *testing.T) {
 		logrus.New(),
 		routes,
 		nil,
-		map[string]struct{}{"libp2p_peer": {}},
+		map[string]struct{}{testTableLibp2pPeer: {}},
 		newTestMetrics(),
 	)
 
 	require.Contains(t, router.routesByEvent, xatu.Event_LIBP2P_TRACE_CONNECTED)
 	require.Len(t, router.routesByEvent[xatu.Event_LIBP2P_TRACE_CONNECTED], 1)
-	require.Equal(t, "libp2p_connected", router.routesByEvent[xatu.Event_LIBP2P_TRACE_CONNECTED][0].TableName())
+	require.Equal(t, testTableLibp2pConnect, router.routesByEvent[xatu.Event_LIBP2P_TRACE_CONNECTED][0].TableName())
 	require.NotContains(t, router.routesByEvent, xatu.Event_LIBP2P_TRACE_DISCONNECTED)
 }
 
 func TestRouteEventWithAllTablesDisabledIsDropped(t *testing.T) {
 	routes := []route.Route{
 		filterTestRoute{
-			table:  route.TableName("libp2p_peer"),
+			table:  route.TableName(testTableLibp2pPeer),
 			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_DISCONNECTED},
 		},
 	}
@@ -106,13 +112,13 @@ func TestRouteEventWithAllTablesDisabledIsDropped(t *testing.T) {
 		logrus.New(),
 		routes,
 		nil,
-		map[string]struct{}{"libp2p_peer": {}},
+		map[string]struct{}{testTableLibp2pPeer: {}},
 		newTestMetrics(),
 	)
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{
-			Id:   "e1",
+			Id:   testEventID,
 			Name: xatu.Event_LIBP2P_TRACE_DISCONNECTED,
 		},
 	})
@@ -124,7 +130,7 @@ func TestRouteEventWithAllTablesDisabledIsDropped(t *testing.T) {
 func TestRouteDisabledEventIsDropped(t *testing.T) {
 	routes := []route.Route{
 		filterTestRoute{
-			table:  route.TableName("libp2p_connected"),
+			table:  route.TableName(testTableLibp2pConnect),
 			events: []xatu.Event_Name{xatu.Event_LIBP2P_TRACE_CONNECTED},
 		},
 	}
@@ -139,7 +145,7 @@ func TestRouteDisabledEventIsDropped(t *testing.T) {
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{
-			Id:   "e1",
+			Id:   testEventID,
 			Name: xatu.Event_LIBP2P_TRACE_CONNECTED,
 		},
 	})
@@ -160,7 +166,7 @@ func TestRouteIntentionallyUnsupportedEventIsDropped(t *testing.T) {
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{
-			Id:   "e1",
+			Id:   testEventID,
 			Name: xatu.Event_BEACON_API_ETH_V1_DEBUG_FORK_CHOICE_V2,
 		},
 	})
@@ -181,7 +187,7 @@ func TestRouteUnknownEventIsNAKed(t *testing.T) {
 
 	outcome := router.Route(&xatu.DecoratedEvent{
 		Event: &xatu.Event{
-			Id:   "e1",
+			Id:   testEventID,
 			Name: xatu.Event_Name(999_999),
 		},
 	})

--- a/pkg/consumoor/config.go
+++ b/pkg/consumoor/config.go
@@ -27,6 +27,12 @@ type Config struct {
 
 	// DisabledEvents is a list of event names to drop without processing.
 	DisabledEvents []string `yaml:"disabledEvents"`
+
+	// DisabledTables is a list of ClickHouse table names whose routes should
+	// be skipped. Events that route to these tables are not flattened or
+	// written. Events that route to both a disabled and an enabled table
+	// continue to be written to the enabled table.
+	DisabledTables []string `yaml:"disabledTables"`
 }
 
 // Validate checks the configuration for errors.
@@ -45,6 +51,38 @@ func (c *Config) Validate() error {
 
 	if _, err := c.DisabledEventEnums(); err != nil {
 		return err
+	}
+
+	if err := c.validateDisabledTables(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DisabledTableSet returns the configured disabled tables as a set for
+// fast membership lookup. Empty strings are ignored.
+func (c *Config) DisabledTableSet() map[string]struct{} {
+	out := make(map[string]struct{}, len(c.DisabledTables))
+
+	for _, name := range c.DisabledTables {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+
+		out[trimmed] = struct{}{}
+	}
+
+	return out
+}
+
+// validateDisabledTables rejects empty entries so typos surface at startup.
+func (c *Config) validateDisabledTables() error {
+	for i, name := range c.DisabledTables {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("disabledTables[%d] is empty", i)
+		}
 	}
 
 	return nil

--- a/pkg/consumoor/config_test.go
+++ b/pkg/consumoor/config_test.go
@@ -107,11 +107,11 @@ func TestDisabledTablesValidation(t *testing.T) {
 	})
 
 	t.Run("accepts non-empty entries", func(t *testing.T) {
-		require.NoError(t, mkConfig([]string{"libp2p_peer"}).Validate())
+		require.NoError(t, mkConfig([]string{testTableLibp2pPeer}).Validate())
 	})
 
 	t.Run("rejects empty entry", func(t *testing.T) {
-		err := mkConfig([]string{"libp2p_peer", "  "}).Validate()
+		err := mkConfig([]string{testTableLibp2pPeer, "  "}).Validate()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "disabledTables[1]")
 	})
@@ -119,13 +119,13 @@ func TestDisabledTablesValidation(t *testing.T) {
 
 func TestDisabledTableSet(t *testing.T) {
 	cfg := &Config{
-		DisabledTables: []string{"libp2p_peer", "  libp2p_connected  ", ""},
+		DisabledTables: []string{testTableLibp2pPeer, "  " + testTableLibp2pConnect + "  ", ""},
 	}
 
 	got := cfg.DisabledTableSet()
 	assert.Equal(t, map[string]struct{}{
-		"libp2p_peer":      {},
-		"libp2p_connected": {},
+		testTableLibp2pPeer:    {},
+		testTableLibp2pConnect: {},
 	}, got)
 }
 

--- a/pkg/consumoor/config_test.go
+++ b/pkg/consumoor/config_test.go
@@ -92,6 +92,43 @@ func TestDisabledEventEnums(t *testing.T) {
 	})
 }
 
+func TestDisabledTablesValidation(t *testing.T) {
+	mkConfig := func(disabled []string) *Config {
+		return &Config{
+			MetricsAddr:    ":9090",
+			Kafka:          *validKafkaConfig(),
+			ClickHouse:     *validClickHouseConfig(),
+			DisabledTables: disabled,
+		}
+	}
+
+	t.Run("accepts empty list", func(t *testing.T) {
+		require.NoError(t, mkConfig(nil).Validate())
+	})
+
+	t.Run("accepts non-empty entries", func(t *testing.T) {
+		require.NoError(t, mkConfig([]string{"libp2p_peer"}).Validate())
+	})
+
+	t.Run("rejects empty entry", func(t *testing.T) {
+		err := mkConfig([]string{"libp2p_peer", "  "}).Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disabledTables[1]")
+	})
+}
+
+func TestDisabledTableSet(t *testing.T) {
+	cfg := &Config{
+		DisabledTables: []string{"libp2p_peer", "  libp2p_connected  ", ""},
+	}
+
+	got := cfg.DisabledTableSet()
+	assert.Equal(t, map[string]struct{}{
+		"libp2p_peer":      {},
+		"libp2p_connected": {},
+	}, got)
+}
+
 func TestClickHouseConfigValidateChGo(t *testing.T) {
 	t.Run("accepts valid ch-go settings", func(t *testing.T) {
 		cfg := validClickHouseConfig()

--- a/pkg/consumoor/consumoor.go
+++ b/pkg/consumoor/consumoor.go
@@ -98,8 +98,8 @@ func New(
 	}
 
 	disabledTables := config.DisabledTableSet()
-	if err := validateDisabledTablesAgainstRoutes(disabledTables, registeredRoutes); err != nil {
-		return nil, err
+	if vErr := validateDisabledTablesAgainstRoutes(disabledTables, registeredRoutes); vErr != nil {
+		return nil, vErr
 	}
 
 	enabledRoutes := filterRoutesByTable(registeredRoutes, disabledTables)

--- a/pkg/consumoor/consumoor.go
+++ b/pkg/consumoor/consumoor.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os/signal"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -19,6 +20,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/ethpandaops/xatu/pkg/clickhouse"
+	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/all"
 	"github.com/ethpandaops/xatu/pkg/clickhouse/router"
 	"github.com/ethpandaops/xatu/pkg/clickhouse/telemetry"
@@ -95,11 +97,23 @@ func New(
 		return nil, fmt.Errorf("invalid disabledEvents config: %w", err)
 	}
 
-	rtr := router.New(log, registeredRoutes, disabledEvents, metrics)
+	disabledTables := config.DisabledTableSet()
+	if err := validateDisabledTablesAgainstRoutes(disabledTables, registeredRoutes); err != nil {
+		return nil, err
+	}
 
-	// Register columnar batch factories from routes on the writer so
-	// each table gets zero-reflection inserts.
-	writer.RegisterBatchFactories(registeredRoutes)
+	enabledRoutes := filterRoutesByTable(registeredRoutes, disabledTables)
+
+	if len(disabledTables) > 0 {
+		log.WithField("disabled_tables", sortedKeys(disabledTables)).
+			Info("Skipping routes for disabled output tables")
+	}
+
+	rtr := router.New(log, registeredRoutes, disabledEvents, disabledTables, metrics)
+
+	// Register columnar batch factories from enabled routes so disabled
+	// tables never get a writer or ch-go connection allocated.
+	writer.RegisterBatchFactories(enabledRoutes)
 
 	// Discover matching Kafka topics and create one stream per topic.
 	topics, err := source.DiscoverTopics(ctx, &config.Kafka)
@@ -555,6 +569,68 @@ func (c *Consumoor) startTopicStream(
 
 		return nil
 	})
+}
+
+// validateDisabledTablesAgainstRoutes rejects entries that do not match any
+// registered route's table name so typos fail fast at startup instead of
+// silently doing nothing.
+func validateDisabledTablesAgainstRoutes(disabled map[string]struct{}, routes []route.Route) error {
+	if len(disabled) == 0 {
+		return nil
+	}
+
+	known := make(map[string]struct{}, len(routes))
+	for _, r := range routes {
+		known[r.TableName()] = struct{}{}
+	}
+
+	unknown := make([]string, 0)
+
+	for name := range disabled {
+		if _, ok := known[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+
+		return fmt.Errorf("unknown disabledTables: %s", strings.Join(unknown, ", "))
+	}
+
+	return nil
+}
+
+// filterRoutesByTable returns a copy of routes excluding any whose target
+// table appears in disabled.
+func filterRoutesByTable(routes []route.Route, disabled map[string]struct{}) []route.Route {
+	if len(disabled) == 0 {
+		return routes
+	}
+
+	out := make([]route.Route, 0, len(routes))
+
+	for _, r := range routes {
+		if _, drop := disabled[r.TableName()]; drop {
+			continue
+		}
+
+		out = append(out, r)
+	}
+
+	return out
+}
+
+// sortedKeys returns the keys of m in ascending order. Used for stable log output.
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }
 
 func (c *Consumoor) startPProf(_ context.Context) error {

--- a/pkg/consumoor/consumoor_test.go
+++ b/pkg/consumoor/consumoor_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testTableLibp2pPeer    = "libp2p_peer"
+	testTableLibp2pConnect = "libp2p_connected"
+)
+
 type stubRoute struct {
 	table  string
 	events []xatu.Event_Name
@@ -21,8 +26,8 @@ func (r stubRoute) NewBatch() route.ColumnarBatch             { return nil }
 
 func TestValidateDisabledTablesAgainstRoutes(t *testing.T) {
 	routes := []route.Route{
-		stubRoute{table: "libp2p_peer"},
-		stubRoute{table: "libp2p_connected"},
+		stubRoute{table: testTableLibp2pPeer},
+		stubRoute{table: testTableLibp2pConnect},
 	}
 
 	t.Run("nil disabled set is fine", func(t *testing.T) {
@@ -31,38 +36,38 @@ func TestValidateDisabledTablesAgainstRoutes(t *testing.T) {
 
 	t.Run("accepts known table", func(t *testing.T) {
 		require.NoError(t, validateDisabledTablesAgainstRoutes(
-			map[string]struct{}{"libp2p_peer": {}}, routes,
+			map[string]struct{}{testTableLibp2pPeer: {}}, routes,
 		))
 	})
 
 	t.Run("rejects typo", func(t *testing.T) {
 		err := validateDisabledTablesAgainstRoutes(
-			map[string]struct{}{"lib2p2_peer": {}, "libp2p_peer": {}},
+			map[string]struct{}{"lib2p2_peer": {}, testTableLibp2pPeer: {}},
 			routes,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "lib2p2_peer")
-		assert.NotContains(t, err.Error(), "libp2p_peer,")
+		assert.NotContains(t, err.Error(), testTableLibp2pPeer+",")
 	})
 }
 
 func TestFilterRoutesByTable(t *testing.T) {
 	routes := []route.Route{
-		stubRoute{table: "libp2p_peer"},
-		stubRoute{table: "libp2p_connected"},
+		stubRoute{table: testTableLibp2pPeer},
+		stubRoute{table: testTableLibp2pConnect},
 		stubRoute{table: "libp2p_disconnected"},
 	}
 
-	got := filterRoutesByTable(routes, map[string]struct{}{"libp2p_peer": {}})
+	got := filterRoutesByTable(routes, map[string]struct{}{testTableLibp2pPeer: {}})
 
 	require.Len(t, got, 2)
-	assert.Equal(t, "libp2p_connected", got[0].TableName())
+	assert.Equal(t, testTableLibp2pConnect, got[0].TableName())
 	assert.Equal(t, "libp2p_disconnected", got[1].TableName())
 }
 
 func TestFilterRoutesByTableEmptyDisabledReturnsAll(t *testing.T) {
 	routes := []route.Route{
-		stubRoute{table: "libp2p_peer"},
+		stubRoute{table: testTableLibp2pPeer},
 	}
 
 	got := filterRoutesByTable(routes, nil)

--- a/pkg/consumoor/consumoor_test.go
+++ b/pkg/consumoor/consumoor_test.go
@@ -1,0 +1,70 @@
+package consumoor
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRoute struct {
+	table  string
+	events []xatu.Event_Name
+}
+
+func (r stubRoute) EventNames() []xatu.Event_Name             { return r.events }
+func (r stubRoute) TableName() string                         { return r.table }
+func (r stubRoute) ShouldProcess(_ *xatu.DecoratedEvent) bool { return true }
+func (r stubRoute) NewBatch() route.ColumnarBatch             { return nil }
+
+func TestValidateDisabledTablesAgainstRoutes(t *testing.T) {
+	routes := []route.Route{
+		stubRoute{table: "libp2p_peer"},
+		stubRoute{table: "libp2p_connected"},
+	}
+
+	t.Run("nil disabled set is fine", func(t *testing.T) {
+		require.NoError(t, validateDisabledTablesAgainstRoutes(nil, routes))
+	})
+
+	t.Run("accepts known table", func(t *testing.T) {
+		require.NoError(t, validateDisabledTablesAgainstRoutes(
+			map[string]struct{}{"libp2p_peer": {}}, routes,
+		))
+	})
+
+	t.Run("rejects typo", func(t *testing.T) {
+		err := validateDisabledTablesAgainstRoutes(
+			map[string]struct{}{"lib2p2_peer": {}, "libp2p_peer": {}},
+			routes,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lib2p2_peer")
+		assert.NotContains(t, err.Error(), "libp2p_peer,")
+	})
+}
+
+func TestFilterRoutesByTable(t *testing.T) {
+	routes := []route.Route{
+		stubRoute{table: "libp2p_peer"},
+		stubRoute{table: "libp2p_connected"},
+		stubRoute{table: "libp2p_disconnected"},
+	}
+
+	got := filterRoutesByTable(routes, map[string]struct{}{"libp2p_peer": {}})
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "libp2p_connected", got[0].TableName())
+	assert.Equal(t, "libp2p_disconnected", got[1].TableName())
+}
+
+func TestFilterRoutesByTableEmptyDisabledReturnsAll(t *testing.T) {
+	routes := []route.Route{
+		stubRoute{table: "libp2p_peer"},
+	}
+
+	got := filterRoutesByTable(routes, nil)
+	assert.Equal(t, routes, got)
+}

--- a/pkg/consumoor/source/benthos_test.go
+++ b/pkg/consumoor/source/benthos_test.go
@@ -406,7 +406,7 @@ func failedIndexesFromBatchError(t *testing.T, msgs service.MessageBatch, err er
 func newRouter(t *testing.T, routes []route.Route) *router.Engine {
 	t.Helper()
 
-	return router.New(logrus.New(), routes, nil, newTestMetrics())
+	return router.New(logrus.New(), routes, nil, nil, newTestMetrics())
 }
 
 func newTestMetrics() *telemetry.Metrics {

--- a/pkg/output/clickhouse/clickhouse.go
+++ b/pkg/output/clickhouse/clickhouse.go
@@ -123,7 +123,7 @@ func New(
 			Info("Restricted clickhouse route catalog by table prefix")
 	}
 
-	router := chrouter.New(sLog, routes, nil, metrics)
+	router := chrouter.New(sLog, routes, nil, nil, metrics)
 
 	writer.RegisterBatchFactories(routes)
 

--- a/pkg/output/clickhouse/clickhouse_test.go
+++ b/pkg/output/clickhouse/clickhouse_test.go
@@ -188,7 +188,7 @@ func makeTestSink(
 	subsystem := fmt.Sprintf("sink_test_%d", time.Now().UnixNano())
 	metrics := telemetry.NewMetrics("xatu_sink_test", subsystem)
 
-	router := chrouter.New(log.WithField("c", "test_router"), routes, nil, metrics)
+	router := chrouter.New(log.WithField("c", "test_router"), routes, nil, nil, metrics)
 
 	if filterCfg == nil {
 		filterCfg = &xatu.EventFilterConfig{}


### PR DESCRIPTION
Adds `disabledTables` to the consumoor config so an output table can be turned off without code changes (e.g. `libp2p_peer`). Routes targeting a disabled table are skipped in both the router and writer; events whose every route lands in a disabled table are dropped (StatusDelivered) so Kafka offsets advance instead of redelivering forever. The same drop-vs-NAK fix applies to `disabledEvents`, which previously caused infinite redelivery when used on events outside the `intentionallyUnsupportedEvents` set.