### PR TITLE
chore: bump go-eth2-client to fix grandine attestation log spam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ethpandaops/beacon v0.69.0
 	github.com/ethpandaops/ethcore v0.0.0-20260513090510-be891b9812d8
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26
+	github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514061636-bc9a4456dc4f
 	github.com/failsafe-go/failsafe-go v0.9.6
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/go-co-op/gocron/v2 v2.16.6

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ethpandaops/beacon v0.69.0
 	github.com/ethpandaops/ethcore v0.0.0-20260513090510-be891b9812d8
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f
+	github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26
 	github.com/failsafe-go/failsafe-go v0.9.6
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/go-co-op/gocron/v2 v2.16.6

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/ethpandaops/ethereum-package-go v0.8.1 h1:VN5l8UXveyw7gp0Glj8BRzS/D5R
 github.com/ethpandaops/ethereum-package-go v0.8.1/go.mod h1:LQThCwlCeeNBTdXOFV+xSwudoced53x+o/Orya3Y+oo=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26 h1:5TE5TZCTkFUC8SbYkqUiOfBfTSYsgCp//07ElwMalvs=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26/go.mod h1:U3KdR8QSq8vqs9LWSGAF4ETHJpcB62E1DFf0gVMgWv0=
+github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514061636-bc9a4456dc4f h1:ofO4/SNOio95jJELNKBSkLFwJ0aQLbnsz6SH4MCwCak=
+github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514061636-bc9a4456dc4f/go.mod h1:U3KdR8QSq8vqs9LWSGAF4ETHJpcB62E1DFf0gVMgWv0=
 github.com/failsafe-go/failsafe-go v0.9.6 h1:vPSH2cry0Ee5cnR9wc9qshCDO6jdrMA9elBJNwyo4Uk=
 github.com/failsafe-go/failsafe-go v0.9.6/go.mod h1:IeRpglkcwzKagjDMh90ZhN2l4Ovt3+jemQBUbThag54=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/ethpandaops/ethereum-package-go v0.8.1 h1:VN5l8UXveyw7gp0Glj8BRzS/D5R
 github.com/ethpandaops/ethereum-package-go v0.8.1/go.mod h1:LQThCwlCeeNBTdXOFV+xSwudoced53x+o/Orya3Y+oo=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f h1:9k0z0tEayikToEqZn71xKIRtCNzH6mwUkIJk70kbSSk=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f/go.mod h1:U3KdR8QSq8vqs9LWSGAF4ETHJpcB62E1DFf0gVMgWv0=
+github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26 h1:5TE5TZCTkFUC8SbYkqUiOfBfTSYsgCp//07ElwMalvs=
+github.com/ethpandaops/go-eth2-client v0.1.3-0.20260514055930-70e764a00d26/go.mod h1:U3KdR8QSq8vqs9LWSGAF4ETHJpcB62E1DFf0gVMgWv0=
 github.com/failsafe-go/failsafe-go v0.9.6 h1:vPSH2cry0Ee5cnR9wc9qshCDO6jdrMA9elBJNwyo4Uk=
 github.com/failsafe-go/failsafe-go v0.9.6/go.mod h1:IeRpglkcwzKagjDMh90ZhN2l4Ovt3+jemQBUbThag54=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=


### PR DESCRIPTION
Pulls in [ethpandaops/go-eth2-client#26](https://github.com/ethpandaops/go-eth2-client/pull/26), which reroutes SingleAttestation payloads grandine emits on the legacy `attestation` SSE topic. Stops xatu-sentry on grandine-backed nodes from spamming "Failed to parse attestation: aggregation bits missing" and recovers the attestation events that were being dropped.

Blocked on the upstream PR landing; will rebase to a tagged commit on master once merged.