### PR TITLE
fix(output/http): bound http.Transport connection pool to fix v1.12.0 OOM

### DIFF
--- a/pkg/output/http/exporter.go
+++ b/pkg/output/http/exporter.go
@@ -28,7 +28,7 @@ type ItemExporter struct {
 func NewItemExporter(name string, config *Config, log observability.ContextualLogger) (ItemExporter, error) {
 	log = log.WithField("output_name", name).WithField("output_type", SinkType)
 
-	t := http.DefaultTransport.(*http.Transport).Clone()
+	t := newTransport(config)
 
 	if config.KeepAlive != nil && !*config.KeepAlive {
 		log.WithField("keep_alive", *config.KeepAlive).Warn("Disabling keep-alives")
@@ -46,6 +46,29 @@ func NewItemExporter(name string, config *Config, log observability.ContextualLo
 		},
 		compressor: &Compressor{Strategy: config.Compression},
 	}, nil
+}
+
+// newTransport clones http.DefaultTransport and sizes the per-host connection
+// pool to the worker count so concurrent exports don't stack up in
+// awaitWantConn against the stdlib default of MaxIdleConnsPerHost=2.
+func newTransport(config *Config) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+
+	t := base.Clone()
+
+	if config.Workers > 0 {
+		t.MaxConnsPerHost = config.Workers
+		t.MaxIdleConnsPerHost = config.Workers
+
+		if config.Workers > t.MaxIdleConns {
+			t.MaxIdleConns = config.Workers
+		}
+	}
+
+	return t
 }
 
 func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEvent) error {

--- a/pkg/output/http/exporter_test.go
+++ b/pkg/output/http/exporter_test.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewTransportSizesPoolToWorkers(t *testing.T) {
+	cases := []struct {
+		name    string
+		workers int
+		want    int
+	}{
+		{name: "default", workers: 1, want: 1},
+		{name: "moderate", workers: 64, want: 64},
+		{name: "high", workers: 2048, want: 2048},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newTransport(&Config{Workers: tc.workers})
+
+			if got.MaxConnsPerHost != tc.want {
+				t.Errorf("MaxConnsPerHost = %d, want %d", got.MaxConnsPerHost, tc.want)
+			}
+
+			if got.MaxIdleConnsPerHost != tc.want {
+				t.Errorf("MaxIdleConnsPerHost = %d, want %d", got.MaxIdleConnsPerHost, tc.want)
+			}
+
+			if got.MaxIdleConns < tc.want {
+				t.Errorf("MaxIdleConns = %d, want >= %d", got.MaxIdleConns, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewTransportNoWorkersKeepsDefaults(t *testing.T) {
+	defaults, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		t.Fatal("http.DefaultTransport is not *http.Transport")
+	}
+
+	got := newTransport(&Config{Workers: 0})
+
+	if got.MaxConnsPerHost != defaults.MaxConnsPerHost {
+		t.Errorf("MaxConnsPerHost = %d, want default %d", got.MaxConnsPerHost, defaults.MaxConnsPerHost)
+	}
+
+	if got.MaxIdleConnsPerHost != defaults.MaxIdleConnsPerHost {
+		t.Errorf("MaxIdleConnsPerHost = %d, want default %d", got.MaxIdleConnsPerHost, defaults.MaxIdleConnsPerHost)
+	}
+}


### PR DESCRIPTION
PR #835 wrapped the HTTP output sink's transport with `otelhttp.NewTransport` on top of an unconfigured `http.DefaultTransport` clone, whose `MaxIdleConnsPerHost=2` left the pool starved under load. With `BatchItemProcessor` running thousands of workers all POSTing to the same upstream, exports stacked up in `awaitWantConn` (live pprof showed 362 goroutines blocked there, 27,931 total, 30+ GB resident)

This sizes `MaxConnsPerHost`, `MaxIdleConnsPerHost` and `MaxIdleConns` to `config.Workers` so the pool tracks concurrent export demand instead of throttling against the stdlib default.