### PR TITLE
feat: decode Gloas data_column_sidecar gossip events

### DIFF
--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar.go
@@ -60,13 +60,9 @@ func (b *libp2pGossipsubDataColumnSidecarBatch) validate(event *xatu.DecoratedEv
 		return fmt.Errorf("nil ColumnIndex: %w", route.ErrInvalidEvent)
 	}
 
-	if payload.GetProposerIndex() == nil {
-		return fmt.Errorf("nil ProposerIndex: %w", route.ErrInvalidEvent)
-	}
-
-	if payload.GetKzgCommitmentsCount() == nil {
-		return fmt.Errorf("nil KzgCommitmentsCount: %w", route.ErrInvalidEvent)
-	}
+	// ProposerIndex and KzgCommitmentsCount are header-derived and only present
+	// on Fulu sidecars. Gloas sidecars (EIP-7732) drop the signed block header,
+	// so these are legitimately absent there — appendPayload defaults them to 0.
 
 	additional := event.GetMeta().GetClient().GetLibp2PTraceGossipsubDataColumnSidecar()
 	if additional == nil {

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar_test.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar_test.go
@@ -1,6 +1,7 @@
 package libp2p
 
 import (
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -10,6 +11,12 @@ import (
 	libp2ppb "github.com/ethpandaops/xatu/pkg/proto/libp2p"
 	"github.com/ethpandaops/xatu/pkg/proto/libp2p/gossipsub"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+const (
+	colColumnIndex     = "column_index"
+	colProposerIndex   = "proposer_index"
+	colBeaconBlockRoot = "beacon_block_root"
 )
 
 func TestSnapshot_libp2p_gossipsub_data_column_sidecar(t *testing.T) {
@@ -51,5 +58,56 @@ func TestSnapshot_libp2p_gossipsub_data_column_sidecar(t *testing.T) {
 		},
 	}, 1, map[string]any{
 		"peer_id_unique_key": expectedPeerIDKey,
+	})
+}
+
+// TestSnapshot_libp2p_gossipsub_data_column_sidecar_Gloas verifies that a Gloas
+// data column sidecar event — which has no proposer_index or kzg_commitments_count
+// because the signed block header is dropped (EIP-7732) — is still accepted and
+// flattened, with the header-derived columns defaulting to zero.
+func TestSnapshot_libp2p_gossipsub_data_column_sidecar_Gloas(t *testing.T) {
+	const (
+		testPeerID  = "16Uiu2HAmPeer1"
+		testNetwork = "mainnet"
+		testTopic   = "/eth2/bba4da96/data_column_sidecar_7/ssz_snappy"
+	)
+
+	expectedPeerIDKey := route.SeaHashInt64(testPeerID + testNetwork)
+	blockRoot := "0x" + strings.Repeat("ab", 32)
+
+	testfixture.AssertSnapshot(t, newlibp2pGossipsubDataColumnSidecarBatch(), &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Name:     xatu.Event_LIBP2P_TRACE_GOSSIPSUB_DATA_COLUMN_SIDECAR,
+			DateTime: testfixture.TS(),
+			Id:       "gs-dcs-gloas-1",
+		},
+		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
+			AdditionalData: &xatu.ClientMeta_Libp2PTraceGossipsubDataColumnSidecar{
+				Libp2PTraceGossipsubDataColumnSidecar: &xatu.ClientMeta_AdditionalLibP2PTraceGossipSubDataColumnSidecarData{
+					Slot:           testfixture.SlotEpochAdditional(),
+					Epoch:          testfixture.EpochAdditional(),
+					WallclockSlot:  testfixture.WallclockSlotAdditional(),
+					WallclockEpoch: testfixture.WallclockEpochAdditional(),
+					Propagation:    testfixture.PropagationAdditional(),
+					Topic:          wrapperspb.String(testTopic),
+					Metadata: &libp2ppb.TraceEventMetadata{
+						PeerId: wrapperspb.String(testPeerID),
+					},
+				},
+			},
+		}),
+		Data: &xatu.DecoratedEvent_Libp2PTraceGossipsubDataColumnSidecar{
+			// Gloas: index and block_root only — no proposer_index / kzg_commitments_count.
+			Libp2PTraceGossipsubDataColumnSidecar: &gossipsub.DataColumnSidecar{
+				Index:     wrapperspb.UInt64(7),
+				BlockRoot: wrapperspb.String(blockRoot),
+			},
+		},
+	}, 1, map[string]any{
+		"peer_id_unique_key":    expectedPeerIDKey,
+		colColumnIndex:          uint64(7),
+		colProposerIndex:        uint32(0),
+		"kzg_commitments_count": uint32(0),
+		colBeaconBlockRoot:      blockRoot,
 	})
 }

--- a/pkg/clmimicry/gossipsub_data_column_sidecar.go
+++ b/pkg/clmimicry/gossipsub_data_column_sidecar.go
@@ -21,25 +21,9 @@ func (p *Processor) handleGossipDataColumnSidecar(
 	event *TraceEvent,
 	payload *TraceEventDataColumnSidecar,
 ) error {
-	if payload.DataColumnSidecar == nil {
-		return fmt.Errorf("handleGossipDataColumnSidecar() called with nil data column sidecar")
-	}
-
-	header := payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader()
-
-	blockRoot, err := header.HashTreeRoot()
+	data, err := dataColumnSidecarProto(payload)
 	if err != nil {
-		return fmt.Errorf("failed to calculate block header hash tree root: %w", err)
-	}
-
-	data := &gossipsub.DataColumnSidecar{
-		Index:               wrapperspb.UInt64(payload.DataColumnSidecar.GetIndex()),
-		Slot:                wrapperspb.UInt64(uint64(header.GetSlot())),
-		ProposerIndex:       wrapperspb.UInt64(uint64(header.GetProposerIndex())),
-		StateRoot:           wrapperspb.String(fmt.Sprintf("0x%x", header.GetStateRoot())),
-		ParentRoot:          wrapperspb.String(fmt.Sprintf("0x%x", header.GetParentRoot())),
-		BlockRoot:           wrapperspb.String(fmt.Sprintf("0x%x", blockRoot)),
-		KzgCommitmentsCount: wrapperspb.UInt32(uint32(len(payload.DataColumnSidecar.GetKzgCommitments()))), //nolint:gosec // conversion fine.
+		return err
 	}
 
 	metadata, ok := proto.Clone(clientMeta).(*xatu.ClientMeta)
@@ -83,9 +67,13 @@ func (p *Processor) createAdditionalGossipSubDataColumnSidecarData(
 		return nil, fmt.Errorf("failed to get wallclock time: %w", err)
 	}
 
-	slotNumber := payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetSlot()
-	slot := p.wallclock.Slots().FromNumber(uint64(slotNumber))
-	epoch := p.wallclock.Epochs().FromSlot(uint64(slotNumber))
+	slotNumber, err := dataColumnSidecarSlot(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	slot := p.wallclock.Slots().FromNumber(slotNumber)
+	epoch := p.wallclock.Epochs().FromSlot(slotNumber)
 	timestampAdjusted := timestamp.Add(p.clockDrift)
 
 	return &xatu.ClientMeta_AdditionalLibP2PTraceGossipSubDataColumnSidecarData{
@@ -102,7 +90,7 @@ func (p *Processor) createAdditionalGossipSubDataColumnSidecarData(
 			StartDateTime: timestamppb.New(epoch.TimeWindow().Start()),
 		},
 		Slot: &xatu.SlotV2{
-			Number:        wrapperspb.UInt64(uint64(slotNumber)),
+			Number:        wrapperspb.UInt64(slotNumber),
 			StartDateTime: timestamppb.New(slot.TimeWindow().Start()),
 		},
 		Propagation: &xatu.PropagationV2{
@@ -115,4 +103,56 @@ func (p *Processor) createAdditionalGossipSubDataColumnSidecarData(
 		MessageSize: wrapperspb.UInt32(uint32(payload.MsgSize)),
 		MessageId:   wrapperspb.String(payload.MsgID),
 	}, nil
+}
+
+// dataColumnSidecarProto projects a data column sidecar payload onto the
+// gossipsub summary proto, handling both fork shapes.
+//
+// Gloas sidecars (EIP-7732) drop the signed block header, so proposer_index,
+// state_root, parent_root and kzg_commitments_count have no source and are
+// left unset; slot and block_root are carried directly on the sidecar.
+func dataColumnSidecarProto(payload *TraceEventDataColumnSidecar) (*gossipsub.DataColumnSidecar, error) {
+	switch {
+	case payload.DataColumnSidecarGloas != nil:
+		sidecar := payload.DataColumnSidecarGloas
+
+		return &gossipsub.DataColumnSidecar{
+			Index:     wrapperspb.UInt64(sidecar.GetIndex()),
+			Slot:      wrapperspb.UInt64(uint64(sidecar.GetSlot())),
+			BlockRoot: wrapperspb.String(fmt.Sprintf("0x%x", sidecar.GetBeaconBlockRoot())),
+		}, nil
+	case payload.DataColumnSidecar != nil:
+		header := payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader()
+
+		blockRoot, err := header.HashTreeRoot()
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate block header hash tree root: %w", err)
+		}
+
+		return &gossipsub.DataColumnSidecar{
+			Index:               wrapperspb.UInt64(payload.DataColumnSidecar.GetIndex()),
+			Slot:                wrapperspb.UInt64(uint64(header.GetSlot())),
+			ProposerIndex:       wrapperspb.UInt64(uint64(header.GetProposerIndex())),
+			StateRoot:           wrapperspb.String(fmt.Sprintf("0x%x", header.GetStateRoot())),
+			ParentRoot:          wrapperspb.String(fmt.Sprintf("0x%x", header.GetParentRoot())),
+			BlockRoot:           wrapperspb.String(fmt.Sprintf("0x%x", blockRoot)),
+			KzgCommitmentsCount: wrapperspb.UInt32(uint32(len(payload.DataColumnSidecar.GetKzgCommitments()))), //nolint:gosec // conversion fine.
+		}, nil
+	default:
+		return nil, fmt.Errorf("handleGossipDataColumnSidecar() called with nil data column sidecar")
+	}
+}
+
+// dataColumnSidecarSlot returns the slot of a data column sidecar payload,
+// reading it from the Gloas sidecar directly or from the Fulu sidecar's
+// signed block header.
+func dataColumnSidecarSlot(payload *TraceEventDataColumnSidecar) (uint64, error) {
+	switch {
+	case payload.DataColumnSidecarGloas != nil:
+		return uint64(payload.DataColumnSidecarGloas.GetSlot()), nil
+	case payload.DataColumnSidecar != nil:
+		return uint64(payload.DataColumnSidecar.GetSignedBlockHeader().GetHeader().GetSlot()), nil
+	default:
+		return 0, fmt.Errorf("handleGossipDataColumnSidecar() called with nil data column sidecar")
+	}
 }

--- a/pkg/clmimicry/gossipsub_data_column_sidecar_test.go
+++ b/pkg/clmimicry/gossipsub_data_column_sidecar_test.go
@@ -616,6 +616,81 @@ func Test_handleGossipDataColumnSidecar(t *testing.T) {
 	}
 }
 
+func Test_handleGossipDataColumnSidecar_Gloas(t *testing.T) {
+	peerID, err := peer.Decode(examplePeerID)
+	require.NoError(t, err)
+
+	beaconBlockRoot := [32]byte{13, 14, 15, 16}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSink := mock.NewMockSink(ctrl)
+	config := &Config{
+		Events: EventConfig{
+			GossipSubDataColumnSidecarEnabled: true,
+		},
+	}
+	mimicry := createTestMimicryWithWallclock(t, config, mockSink)
+
+	expectEventWithValidation(t, mockSink, func(t *testing.T, event *xatu.DecoratedEvent) {
+		t.Helper()
+
+		assert.Equal(t, xatu.Event_LIBP2P_TRACE_GOSSIPSUB_DATA_COLUMN_SIDECAR, event.GetEvent().GetName())
+
+		data := event.GetLibp2PTraceGossipsubDataColumnSidecar()
+		require.NotNil(t, data)
+
+		// Gloas sidecars carry index, slot and beacon_block_root directly.
+		assert.Equal(t, uint64(7), data.GetIndex().GetValue())
+		assert.Equal(t, uint64(300), data.GetSlot().GetValue())
+		assert.Equal(t, fmt.Sprintf("0x%x", beaconBlockRoot[:]), data.GetBlockRoot().GetValue())
+
+		// Header-derived fields have no source on Gloas and are left unset.
+		assert.Nil(t, data.GetProposerIndex())
+		assert.Nil(t, data.GetStateRoot())
+		assert.Nil(t, data.GetParentRoot())
+		assert.Nil(t, data.GetKzgCommitmentsCount())
+
+		additionalData := event.GetMeta().GetClient().GetLibp2PTraceGossipsubDataColumnSidecar()
+		require.NotNil(t, additionalData)
+		assert.Equal(t, uint64(300), additionalData.GetSlot().GetNumber().GetValue())
+		assert.NotNil(t, additionalData.GetEpoch())
+		assert.NotNil(t, additionalData.GetPropagation())
+		assert.Equal(t, peerID.String(), additionalData.GetMetadata().GetPeerId().GetValue())
+	})
+
+	event := &TraceEvent{
+		Type:      "HANDLE_MESSAGE",
+		PeerID:    peerID,
+		Timestamp: time.Now(),
+		Topic:     "/eth2/fc90fcde/data_column_sidecar_7/ssz_snappy",
+	}
+	event.Payload = &TraceEventDataColumnSidecar{
+		TraceEventPayloadMetaData: TraceEventPayloadMetaData{
+			Topic:   "/eth2/fc90fcde/data_column_sidecar_7/ssz_snappy",
+			MsgID:   "gloas-msg",
+			MsgSize: 1234,
+			PeerID:  peerID.String(),
+		},
+		DataColumnSidecarGloas: &ethtypes.DataColumnSidecarGloas{
+			Index:           7,
+			Slot:            primitives.Slot(300),
+			BeaconBlockRoot: beaconBlockRoot[:],
+			Column:          [][]byte{make([]byte, 2048)},
+			KzgProofs:       [][]byte{make([]byte, 48)},
+		},
+	}
+
+	err = mimicry.processor.handleHermesGossipSubEvent(
+		context.Background(),
+		event,
+		createTestClientMeta(),
+		createTestTraceMeta(),
+	)
+	assert.NoError(t, err)
+}
+
 func Test_createAdditionalGossipSubDataColumnSidecarData(t *testing.T) {
 	// Create test wallclock
 	wallclock := ethwallclock.NewEthereumBeaconChain(

--- a/pkg/clmimicry/hermes_event_payload.go
+++ b/pkg/clmimicry/hermes_event_payload.go
@@ -128,9 +128,15 @@ type TraceEventAttesterSlashing struct {
 }
 
 // TraceEventDataColumnSidecar represents a data column sidecar event.
+//
+// Exactly one of DataColumnSidecar / DataColumnSidecarGloas is set, depending
+// on the fork the sidecar was gossiped under. The Gloas variant (EIP-7732)
+// drops the signed block header, so it carries slot and beacon_block_root
+// directly instead.
 type TraceEventDataColumnSidecar struct {
 	TraceEventPayloadMetaData
-	DataColumnSidecar *ethtypes.DataColumnSidecar
+	DataColumnSidecar      *ethtypes.DataColumnSidecar
+	DataColumnSidecarGloas *ethtypes.DataColumnSidecarGloas
 }
 
 // TraceEventExecutionPayloadEnvelope represents a Gloas execution_payload gossip event (EIP-7732).

--- a/pkg/clmimicry/payload_builders.go
+++ b/pkg/clmimicry/payload_builders.go
@@ -119,11 +119,19 @@ func NewBlobSidecarPayload(blob *ethtypes.BlobSidecar, meta *TraceEventPayloadMe
 	}
 }
 
-// NewDataColumnSidecarPayload creates a data column sidecar payload.
+// NewDataColumnSidecarPayload creates a Fulu data column sidecar payload.
 func NewDataColumnSidecarPayload(dataColumn *ethtypes.DataColumnSidecar, meta *TraceEventPayloadMetaData) *TraceEventDataColumnSidecar {
 	return &TraceEventDataColumnSidecar{
 		TraceEventPayloadMetaData: *meta,
 		DataColumnSidecar:         dataColumn,
+	}
+}
+
+// NewDataColumnSidecarGloasPayload creates a Gloas data column sidecar payload (EIP-7732).
+func NewDataColumnSidecarGloasPayload(dataColumn *ethtypes.DataColumnSidecarGloas, meta *TraceEventPayloadMetaData) *TraceEventDataColumnSidecar {
+	return &TraceEventDataColumnSidecar{
+		TraceEventPayloadMetaData: *meta,
+		DataColumnSidecarGloas:    dataColumn,
 	}
 }
 


### PR DESCRIPTION
Gloas restructures `DataColumnSidecar`: the signed block header is dropped and `slot` + `beacon_block_root` are carried directly on the sidecar. The existing gossip handler assumed the Fulu shape (`GetSignedBlockHeader()`), so Gloas `data_column_sidecar` events were silently dropped.

- `TraceEventDataColumnSidecar` gains a `DataColumnSidecarGloas` field plus a `NewDataColumnSidecarGloasPayload` builder; exactly one fork variant is set.
- `handleGossipDataColumnSidecar` is fork-branched: Gloas reads `slot` and `beacon_block_root` directly. `proposer_index` / `state_root` / `parent_root`/ `kzg_commitments_count` have no source on a Gloas sidecar and are left unset.
- The `libp2p_gossipsub_data_column_sidecar` ClickHouse route no longer rejects events with a nil `proposer_index` / `kzg_commitments_count` — those are legitimately absent on Gloas rows, and `appendPayload` already defaults them to 0. No schema change (the table is cross-fork shared; columns unchanged).