### PR TITLE
Lowercase telemetry service names

### DIFF
--- a/cmd/consumoor.go
+++ b/cmd/consumoor.go
@@ -99,7 +99,7 @@ var consumoorCmd = &cobra.Command{
 		}
 
 		shutdownObs, err := observability.Setup(cmd.Context(), log,
-			xatu.Implementation+"/consumoor", xatu.Short(),
+			xatu.WithComponent("consumoor"), xatu.Short(),
 			&config.Tracing,
 		)
 		if err != nil {

--- a/pkg/proto/xatu/xatu.go
+++ b/pkg/proto/xatu/xatu.go
@@ -19,11 +19,16 @@ func Full() string {
 }
 
 func FullWithModule(module ModuleName) string {
-	return fmt.Sprintf("%s-%s/%s", Implementation, module.String(), Short())
+	return fmt.Sprintf("%s/%s", WithModule(module), Short())
 }
 
 func WithModule(module ModuleName) string {
-	return fmt.Sprintf("%s-%s", Implementation, module.String())
+	return WithComponent(module.String())
+}
+
+// WithComponent returns the telemetry service name for a Xatu component.
+func WithComponent(component string) string {
+	return fmt.Sprintf("%s-%s", ImplementationLower(), formatComponentName(component))
 }
 
 func Short() string {
@@ -40,4 +45,8 @@ func FullVWithPlatform() string {
 
 func ImplementationLower() string {
 	return strings.ToLower(Implementation)
+}
+
+func formatComponentName(component string) string {
+	return strings.ReplaceAll(strings.ToLower(component), "_", "-")
 }

--- a/pkg/proto/xatu/xatu_test.go
+++ b/pkg/proto/xatu/xatu_test.go
@@ -1,0 +1,69 @@
+package xatu
+
+import "testing"
+
+func TestWithModule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		module ModuleName
+		want   string
+	}{
+		{
+			name:   "server",
+			module: ModuleName_SERVER,
+			want:   "xatu-server",
+		},
+		{
+			name:   "el mimicry",
+			module: ModuleName_EL_MIMICRY,
+			want:   "xatu-el-mimicry",
+		},
+		{
+			name:   "relay monitor",
+			module: ModuleName_RELAY_MONITOR,
+			want:   "xatu-relay-monitor",
+		},
+		{
+			name:   "rpc snooper",
+			module: ModuleName_RPC_SNOOPER,
+			want:   "xatu-rpc-snooper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := WithModule(tt.module); got != tt.want {
+				t.Fatalf("WithModule(%s) = %q, want %q", tt.module, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithComponent(t *testing.T) {
+	t.Parallel()
+
+	if got := WithComponent("consumoor"); got != "xatu-consumoor" {
+		t.Fatalf("WithComponent(%q) = %q, want %q", "consumoor", got, "xatu-consumoor")
+	}
+}
+
+func TestFullWithModule(t *testing.T) {
+	originalRelease := Release
+	originalGitCommit := GitCommit
+
+	t.Cleanup(func() {
+		Release = originalRelease
+		GitCommit = originalGitCommit
+	})
+
+	Release = "v1.2.3"
+	GitCommit = "abcdef"
+
+	if got := FullWithModule(ModuleName_SERVER); got != "xatu-server/v1.2.3-abcdef" {
+		t.Fatalf("FullWithModule(%s) = %q, want %q", ModuleName_SERVER, got, "xatu-server/v1.2.3-abcdef")
+	}
+}


### PR DESCRIPTION
This changes Xatu telemetry service names to lowercase, dash-separated values such as `xatu-server`, `xatu-el-mimicry`, and `xatu-consumoor`, including the module/version helper. This is a breaking change for dashboards, alerts, and queries that match the old `Xatu-SERVER`/`Xatu/consumoor` names.