### PR TITLE
Scope consumoor Kafka traces

### DIFF
--- a/pkg/consumoor/source/benthos_test.go
+++ b/pkg/consumoor/source/benthos_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	yaml "gopkg.in/yaml.v3"
@@ -381,6 +386,55 @@ func TestWriteBatchRejectSinkFailureMakesMessageRetry(t *testing.T) {
 	assert.Equal(t, []int{0}, failedIndexesFromBatchError(t, msgs, err))
 }
 
+func TestWriteBatchTraceScopeDoesNotInheritBatchSpanWithoutHeader(t *testing.T) {
+	recorder := setupConsumoorTraceTest(t)
+	output := newTraceTestOutput(t)
+
+	msgs := service.MessageBatch{
+		newKafkaMessage(mustEventJSON(t, "evt-1", xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD), "topic-a", 0, 1),
+	}
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "benthos.batch")
+	err := output.WriteBatch(ctx, msgs)
+
+	parent.End()
+
+	require.NoError(t, err)
+
+	handleSpan := requireEndedSpan(t, recorder, "consumoor.HandleMessage")
+	assert.False(t, handleSpan.Parent().IsValid(), "messages without traceparent must start a local trace, not inherit the Benthos batch context")
+
+	writeSpan := requireEndedSpan(t, recorder, "consumoor.WriteGroup")
+	assert.False(t, writeSpan.Parent().IsValid(), "group write span must not inherit the Benthos batch context")
+}
+
+func TestWriteBatchTraceScopeHonorsKafkaTraceparent(t *testing.T) {
+	recorder := setupConsumoorTraceTest(t)
+	output := newTraceTestOutput(t)
+
+	msg := newKafkaMessage(mustEventJSON(t, "evt-1", xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD), "topic-a", 0, 1)
+	parent := testRemoteSpanContext()
+	otel.GetTextMapPropagator().Inject(
+		oteltrace.ContextWithRemoteSpanContext(context.Background(), parent),
+		newBenthosHeaderCarrier(msg),
+	)
+
+	ctx, batchSpan := otel.Tracer("test").Start(context.Background(), "benthos.batch")
+	err := output.WriteBatch(ctx, service.MessageBatch{msg})
+
+	batchSpan.End()
+
+	require.NoError(t, err)
+
+	handleSpan := requireEndedSpan(t, recorder, "consumoor.HandleMessage")
+	assert.Equal(t, parent.TraceID(), handleSpan.SpanContext().TraceID())
+	assert.Equal(t, parent.SpanID(), handleSpan.Parent().SpanID())
+	assert.True(t, handleSpan.Parent().IsRemote())
+
+	writeSpan := requireEndedSpan(t, recorder, "consumoor.WriteGroup")
+	assert.False(t, writeSpan.Parent().IsValid(), "group write span should link message spans instead of joining an arbitrary batch parent")
+}
+
 func failedIndexesFromBatchError(t *testing.T, msgs service.MessageBatch, err error) []int {
 	t.Helper()
 
@@ -440,6 +494,72 @@ func newKafkaMessage(payload []byte, topic string, partition int32, offset int64
 	msg.MetaSet("kafka_offset", strconv.FormatInt(offset, 10))
 
 	return msg
+}
+
+func newTraceTestOutput(t *testing.T) *xatuClickHouseOutput {
+	t.Helper()
+
+	return &xatuClickHouseOutput{
+		log:      logrus.New(),
+		encoding: "json",
+		router: newRouter(t, []route.Route{
+			testRoute{
+				eventName: xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD,
+				table:     "beacon_head",
+			},
+		}),
+		writer:     &testWriter{},
+		metrics:    newTestMetrics(),
+		logSampler: telemetry.NewLogSampler(time.Minute),
+		rejectSink: &testRejectSink{},
+	}
+}
+
+func setupConsumoorTraceTest(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(recorder),
+	)
+
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+	})
+
+	return recorder
+}
+
+func requireEndedSpan(t *testing.T, recorder *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	for _, span := range recorder.Ended() {
+		if span.Name() == name {
+			return span
+		}
+	}
+
+	require.Failf(t, "span not found", "missing ended span %q", name)
+
+	return nil
+}
+
+func testRemoteSpanContext() oteltrace.SpanContext {
+	return oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:     oteltrace.SpanID{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18},
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	})
 }
 
 func TestWriteBatchMultiTableTransientFailureFailsAllImpactedMessages(t *testing.T) {

--- a/pkg/consumoor/source/benthos_test.go
+++ b/pkg/consumoor/source/benthos_test.go
@@ -435,6 +435,35 @@ func TestWriteBatchTraceScopeHonorsKafkaTraceparent(t *testing.T) {
 	assert.False(t, writeSpan.Parent().IsValid(), "group write span should link message spans instead of joining an arbitrary batch parent")
 }
 
+func TestWriteBatchTraceScopeSeparatesRecordTraceparents(t *testing.T) {
+	recorder := setupConsumoorTraceTest(t)
+	output := newTraceTestOutput(t)
+
+	parent1 := testRemoteSpanContext()
+	parent2 := testRemoteSpanContext2()
+
+	msg1 := newKafkaMessage(mustEventJSON(t, "evt-1", xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD), "topic-a", 0, 1)
+	msg1.MetaSet("traceparent", traceparentHeader(parent1))
+
+	msg2 := newKafkaMessage(mustEventJSON(t, "evt-2", xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD), "topic-a", 0, 2)
+	msg2.MetaSet("TraceParent", traceparentHeader(parent2))
+
+	err := output.WriteBatch(context.Background(), service.MessageBatch{msg1, msg2})
+	require.NoError(t, err)
+
+	handleSpans := endedSpansByName(recorder, "consumoor.HandleMessage")
+	require.Len(t, handleSpans, 2)
+
+	traceIDs := make(map[oteltrace.TraceID]struct{}, len(handleSpans))
+	for _, span := range handleSpans {
+		traceIDs[span.SpanContext().TraceID()] = struct{}{}
+	}
+
+	assert.Contains(t, traceIDs, parent1.TraceID())
+	assert.Contains(t, traceIDs, parent2.TraceID())
+	assert.Len(t, traceIDs, 2)
+}
+
 func failedIndexesFromBatchError(t *testing.T, msgs service.MessageBatch, err error) []int {
 	t.Helper()
 
@@ -553,6 +582,18 @@ func requireEndedSpan(t *testing.T, recorder *tracetest.SpanRecorder, name strin
 	return nil
 }
 
+func endedSpansByName(recorder *tracetest.SpanRecorder, name string) []sdktrace.ReadOnlySpan {
+	out := make([]sdktrace.ReadOnlySpan, 0)
+
+	for _, span := range recorder.Ended() {
+		if span.Name() == name {
+			out = append(out, span)
+		}
+	}
+
+	return out
+}
+
 func testRemoteSpanContext() oteltrace.SpanContext {
 	return oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
 		TraceID:    oteltrace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
@@ -560,6 +601,24 @@ func testRemoteSpanContext() oteltrace.SpanContext {
 		TraceFlags: oteltrace.FlagsSampled,
 		Remote:     true,
 	})
+}
+
+func testRemoteSpanContext2() oteltrace.SpanContext {
+	return oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    oteltrace.TraceID{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30},
+		SpanID:     oteltrace.SpanID{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38},
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	})
+}
+
+func traceparentHeader(sc oteltrace.SpanContext) string {
+	flags := "00"
+	if sc.TraceFlags().IsSampled() {
+		flags = "01"
+	}
+
+	return fmt.Sprintf("00-%s-%s-%s", sc.TraceID(), sc.SpanID(), flags)
 }
 
 func TestWriteBatchMultiTableTransientFailureFailsAllImpactedMessages(t *testing.T) {

--- a/pkg/consumoor/source/output.go
+++ b/pkg/consumoor/source/output.go
@@ -129,12 +129,13 @@ func (o *xatuClickHouseOutput) WriteBatch(
 
 	propagator := otel.GetTextMapPropagator()
 	tracer := observability.Tracer()
+	batchCtx := contextWithoutActiveSpan(ctx)
 
 	for i, msg := range msgs {
 		kafka := kafkaMetadata(msg)
 		o.metrics.MessagesConsumed().WithLabelValues(kafka.Topic).Inc()
 
-		msgCtx := propagator.Extract(ctx, newBenthosHeaderCarrier(msg))
+		msgCtx := propagator.Extract(batchCtx, newBenthosHeaderCarrier(msg))
 		msgCtx, msgSpan := tracer.Start(msgCtx, "consumoor.HandleMessage",
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
@@ -351,7 +352,7 @@ func (o *xatuClickHouseOutput) processGroup(
 		links = append(links, trace.Link{SpanContext: sc})
 	}
 
-	ctx, span := observability.Tracer().Start(ctx, "consumoor.WriteGroup",
+	ctx, span := observability.Tracer().Start(contextWithoutActiveSpan(ctx), "consumoor.WriteGroup",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithLinks(links...),
 		trace.WithAttributes(
@@ -561,6 +562,10 @@ func (o *xatuClickHouseOutput) rejectMessage(
 	}
 
 	return nil
+}
+
+func contextWithoutActiveSpan(ctx context.Context) context.Context {
+	return trace.ContextWithSpanContext(ctx, trace.SpanContext{})
 }
 
 func addBatchFailure(

--- a/pkg/consumoor/source/propagation.go
+++ b/pkg/consumoor/source/propagation.go
@@ -1,6 +1,8 @@
 package source
 
 import (
+	"strings"
+
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
@@ -21,11 +23,21 @@ func (c benthosHeaderCarrier) Get(key string) string {
 	}
 
 	v, ok := c.msg.MetaGet(key)
-	if !ok {
-		return ""
+	if ok {
+		return v
 	}
 
-	return v
+	var value string
+
+	_ = c.msg.MetaWalk(func(k, v string) error {
+		if strings.EqualFold(k, key) {
+			value = v
+		}
+
+		return nil
+	})
+
+	return value
 }
 
 func (c benthosHeaderCarrier) Set(key, value string) {

--- a/pkg/output/http/exporter.go
+++ b/pkg/output/http/exporter.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,13 +55,15 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEv
 }
 
 func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[xatu.DecoratedEvent]) error {
+	var err error
+
 	for _, group := range processor.GroupTraceableItemsByPropagation(traceableItems) {
-		if err := e.exportItems(ctx, group.Items, group.Context); err != nil {
-			return err
+		if exportErr := e.exportItems(ctx, group.Items, group.Context); exportErr != nil {
+			err = errors.Join(err, exportErr)
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (e ItemExporter) exportItems(ctx context.Context, items []*xatu.DecoratedEvent, propagationCtx context.Context) error {

--- a/pkg/output/http/exporter.go
+++ b/pkg/output/http/exporter.go
@@ -54,12 +54,8 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEv
 }
 
 func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[xatu.DecoratedEvent]) error {
-	for _, item := range traceableItems {
-		if item == nil || item.Item() == nil {
-			continue
-		}
-
-		if err := e.exportItems(ctx, []*xatu.DecoratedEvent{item.Item()}, item.Context()); err != nil {
+	for _, group := range processor.GroupTraceableItemsByPropagation(traceableItems) {
+		if err := e.exportItems(ctx, group.Items, group.Context); err != nil {
 			return err
 		}
 	}

--- a/pkg/output/http/exporter.go
+++ b/pkg/output/http/exporter.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/processor"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -49,12 +50,30 @@ func NewItemExporter(name string, config *Config, log observability.ContextualLo
 }
 
 func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEvent) error {
+	return e.exportItems(ctx, items, ctx)
+}
+
+func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[xatu.DecoratedEvent]) error {
+	for _, item := range traceableItems {
+		if item == nil || item.Item() == nil {
+			continue
+		}
+
+		if err := e.exportItems(ctx, []*xatu.DecoratedEvent{item.Item()}, item.Context()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e ItemExporter) exportItems(ctx context.Context, items []*xatu.DecoratedEvent, propagationCtx context.Context) error {
 	ctx, span := observability.Tracer().Start(ctx, "HTTPItemExporter.ExportItems", trace.WithAttributes(attribute.Int64("num_events", int64(len(items)))))
 	defer span.End()
 
 	e.log.WithField("events", len(items)).WithContext(ctx).Debug("Sending batch of events to HTTP sink")
 
-	if err := e.sendUpstream(ctx, items); err != nil {
+	if err := e.sendUpstream(ctx, propagationCtx, items); err != nil {
 		e.log.
 			WithError(err).
 			WithField("num_events", len(items)).WithContext(ctx).
@@ -72,7 +91,7 @@ func (e ItemExporter) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (e *ItemExporter) sendUpstream(ctx context.Context, items []*xatu.DecoratedEvent) error {
+func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items []*xatu.DecoratedEvent) error {
 	httpMethod := "POST"
 
 	var rsp *http.Response
@@ -98,7 +117,7 @@ func (e *ItemExporter) sendUpstream(ctx context.Context, items []*xatu.Decorated
 	buf = compressed
 
 	// TODO: check that this also handles processor timeout
-	req, err := http.NewRequestWithContext(ctx, httpMethod, e.config.Address, buf)
+	req, err := http.NewRequestWithContext(processor.ContextWithPropagation(ctx, propagationCtx), httpMethod, e.config.Address, buf)
 	if err != nil {
 		return err
 	}

--- a/pkg/output/http/exporter_test.go
+++ b/pkg/output/http/exporter_test.go
@@ -1,0 +1,202 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/ethpandaops/xatu/pkg/processor"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+type recordedHTTPRequest struct {
+	traceparent string
+	eventCount  int
+}
+
+type recordingHTTPServer struct {
+	mu       sync.Mutex
+	requests []recordedHTTPRequest
+	server   *httptest.Server
+}
+
+func TestHTTPSinkProcessorPropagatesAndBatchesByTraceContext(t *testing.T) {
+	setupHTTPTraceTest(t)
+
+	recorder := startRecordingHTTPServer(t)
+	sink := newTestHTTPSink(t, recorder.server.URL, 2)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	ctx1, span1 := otel.Tracer("test").Start(context.Background(), "event-1")
+	defer span1.End()
+
+	ctx2, span2 := otel.Tracer("test").Start(context.Background(), "event-2")
+	defer span2.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx1, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx2, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD, "id-2")))
+
+	require.Eventually(t, func() bool {
+		return len(recorder.snapshotRequests()) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	requests := recorder.snapshotRequests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, 1, requests[0].eventCount)
+	assert.Equal(t, 1, requests[1].eventCount)
+
+	sc1 := spanContextFromHTTPTraceparent(requests[0].traceparent)
+	sc2 := spanContextFromHTTPTraceparent(requests[1].traceparent)
+
+	require.True(t, sc1.IsValid())
+	require.True(t, sc2.IsValid())
+	assert.Equal(t, span1.SpanContext().TraceID(), sc1.TraceID())
+	assert.Equal(t, span2.SpanContext().TraceID(), sc2.TraceID())
+	assert.NotEqual(t, sc1.TraceID(), sc2.TraceID())
+}
+
+func TestHTTPSinkProcessorBatchesSharedTraceContext(t *testing.T) {
+	setupHTTPTraceTest(t)
+
+	recorder := startRecordingHTTPServer(t)
+	sink := newTestHTTPSink(t, recorder.server.URL, 100)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "shared")
+	defer span.End()
+
+	events := make([]*xatu.DecoratedEvent, 0, 100)
+	for i := range 100 {
+		events = append(events, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, fmt.Sprintf("id-%d", i)))
+	}
+
+	require.NoError(t, sink.HandleNewDecoratedEvents(ctx, events))
+
+	require.Eventually(t, func() bool {
+		requests := recorder.snapshotRequests()
+
+		return len(requests) == 1 && requests[0].eventCount == 100
+	}, time.Second, 10*time.Millisecond)
+
+	requests := recorder.snapshotRequests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, span.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[0].traceparent).TraceID())
+}
+
+func startRecordingHTTPServer(t *testing.T) *recordingHTTPServer {
+	t.Helper()
+
+	recorder := &recordingHTTPServer{}
+
+	recorder.server = httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(stdhttp.StatusInternalServerError)
+
+			return
+		}
+
+		recorder.mu.Lock()
+		recorder.requests = append(recorder.requests, recordedHTTPRequest{
+			traceparent: r.Header.Get("traceparent"),
+			eventCount:  strings.Count(string(raw), "\n"),
+		})
+		recorder.mu.Unlock()
+
+		w.WriteHeader(stdhttp.StatusOK)
+	}))
+
+	t.Cleanup(recorder.server.Close)
+
+	return recorder
+}
+
+func (r *recordingHTTPServer) snapshotRequests() []recordedHTTPRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]recordedHTTPRequest(nil), r.requests...)
+}
+
+func newTestHTTPSink(t *testing.T, address string, batchSize int) *HTTP {
+	t.Helper()
+
+	sink, err := New("test", &Config{
+		Address:            address,
+		Headers:            map[string]string{},
+		MaxQueueSize:       batchSize,
+		BatchTimeout:       time.Hour,
+		ExportTimeout:      5 * time.Second,
+		MaxExportBatchSize: batchSize,
+		Workers:            1,
+	}, logrus.New(), &xatu.EventFilterConfig{}, processor.ShippingMethodAsync)
+	require.NoError(t, err)
+
+	return sink
+}
+
+func setupHTTPTraceTest(t *testing.T) {
+	t.Helper()
+
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()),
+	)
+
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+	})
+}
+
+func newHTTPTestEvent(name xatu.Event_Name, id string) *xatu.DecoratedEvent {
+	return &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Name:     name,
+			Id:       id,
+			DateTime: timestamppb.New(time.Unix(1_700_000_000, 0)),
+		},
+	}
+}
+
+func spanContextFromHTTPTraceparent(traceparent string) trace.SpanContext {
+	return trace.SpanContextFromContext(
+		otel.GetTextMapPropagator().Extract(
+			context.Background(),
+			propagation.MapCarrier{"traceparent": traceparent},
+		),
+	)
+}

--- a/pkg/output/http/exporter_test.go
+++ b/pkg/output/http/exporter_test.go
@@ -19,6 +19,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/ethpandaops/xatu/pkg/processor"
@@ -28,12 +29,15 @@ import (
 type recordedHTTPRequest struct {
 	traceparent string
 	eventCount  int
+	eventIDs    []string
+	eventNames  []xatu.Event_Name
 }
 
 type recordingHTTPServer struct {
-	mu       sync.Mutex
-	requests []recordedHTTPRequest
-	server   *httptest.Server
+	mu        sync.Mutex
+	requests  []recordedHTTPRequest
+	server    *httptest.Server
+	statusFor func(recordedHTTPRequest) int
 }
 
 func TestHTTPSinkProcessorPropagatesAndBatchesByTraceContext(t *testing.T) {
@@ -109,10 +113,110 @@ func TestHTTPSinkProcessorBatchesSharedTraceContext(t *testing.T) {
 	assert.Equal(t, span.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[0].traceparent).TraceID())
 }
 
+func TestHTTPSinkProcessorPreservesSparseMixedTraceGroups(t *testing.T) {
+	setupHTTPTraceTest(t)
+
+	recorder := startRecordingHTTPServer(t)
+	sink := newTestHTTPSink(t, recorder.server.URL, 12)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	for i := range 10 {
+		require.NoError(t, sink.HandleNewDecoratedEvent(
+			context.Background(),
+			newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_ATTESTATION_V2, fmt.Sprintf("attestation-%d", i)),
+		))
+	}
+
+	headCtx, headSpan := otel.Tracer("test").Start(context.Background(), "head")
+	defer headSpan.End()
+
+	blockCtx, blockSpan := otel.Tracer("test").Start(context.Background(), "block")
+	defer blockSpan.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(headCtx, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2, "head-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(blockCtx, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2, "block-1")))
+
+	require.Eventually(t, func() bool {
+		return len(recorder.snapshotRequests()) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	requests := recorder.snapshotRequests()
+	require.Len(t, requests, 3)
+
+	assert.Equal(t, 10, requests[0].eventCount)
+	assert.Equal(t, 1, requests[1].eventCount)
+	assert.Equal(t, 1, requests[2].eventCount)
+	assert.Equal(t, []string{"head-1"}, requests[1].eventIDs)
+	assert.Equal(t, []string{"block-1"}, requests[2].eventIDs)
+	assert.Equal(t, []xatu.Event_Name{xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2}, requests[1].eventNames)
+	assert.Equal(t, []xatu.Event_Name{xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2}, requests[2].eventNames)
+
+	assert.Equal(t, headSpan.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[1].traceparent).TraceID())
+	assert.Equal(t, blockSpan.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[2].traceparent).TraceID())
+}
+
+func TestHTTPSinkProcessorAttemptsSparseGroupsAfterEarlierGroupFailure(t *testing.T) {
+	setupHTTPTraceTest(t)
+
+	recorder := startRecordingHTTPServerWithStatus(t, func(req recordedHTTPRequest) int {
+		if req.eventCount == 10 {
+			return stdhttp.StatusInternalServerError
+		}
+
+		return stdhttp.StatusOK
+	})
+	sink := newTestHTTPSink(t, recorder.server.URL, 12)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	for i := range 10 {
+		require.NoError(t, sink.HandleNewDecoratedEvent(
+			context.Background(),
+			newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_ATTESTATION_V2, fmt.Sprintf("attestation-%d", i)),
+		))
+	}
+
+	headCtx, headSpan := otel.Tracer("test").Start(context.Background(), "head")
+	defer headSpan.End()
+
+	blockCtx, blockSpan := otel.Tracer("test").Start(context.Background(), "block")
+	defer blockSpan.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(headCtx, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2, "head-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(blockCtx, newHTTPTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2, "block-1")))
+
+	require.Eventually(t, func() bool {
+		return len(recorder.snapshotRequests()) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	requests := recorder.snapshotRequests()
+	require.Len(t, requests, 3)
+
+	assert.Equal(t, []string{"head-1"}, requests[1].eventIDs)
+	assert.Equal(t, []string{"block-1"}, requests[2].eventIDs)
+	assert.Equal(t, headSpan.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[1].traceparent).TraceID())
+	assert.Equal(t, blockSpan.SpanContext().TraceID(), spanContextFromHTTPTraceparent(requests[2].traceparent).TraceID())
+}
+
 func startRecordingHTTPServer(t *testing.T) *recordingHTTPServer {
 	t.Helper()
 
-	recorder := &recordingHTTPServer{}
+	return startRecordingHTTPServerWithStatus(t, nil)
+}
+
+func startRecordingHTTPServerWithStatus(t *testing.T, statusFor func(recordedHTTPRequest) int) *recordingHTTPServer {
+	t.Helper()
+
+	recorder := &recordingHTTPServer{statusFor: statusFor}
 
 	recorder.server = httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		raw, err := io.ReadAll(r.Body)
@@ -122,19 +226,63 @@ func startRecordingHTTPServer(t *testing.T) *recordingHTTPServer {
 			return
 		}
 
-		recorder.mu.Lock()
-		recorder.requests = append(recorder.requests, recordedHTTPRequest{
+		events, err := decodeRecordedHTTPEvents(raw)
+		if err != nil {
+			w.WriteHeader(stdhttp.StatusInternalServerError)
+
+			return
+		}
+
+		eventIDs := make([]string, 0, len(events))
+		eventNames := make([]xatu.Event_Name, 0, len(events))
+
+		for _, event := range events {
+			eventIDs = append(eventIDs, event.GetEvent().GetId())
+			eventNames = append(eventNames, event.GetEvent().GetName())
+		}
+
+		recorded := recordedHTTPRequest{
 			traceparent: r.Header.Get("traceparent"),
-			eventCount:  strings.Count(string(raw), "\n"),
-		})
+			eventCount:  len(events),
+			eventIDs:    eventIDs,
+			eventNames:  eventNames,
+		}
+
+		recorder.mu.Lock()
+		recorder.requests = append(recorder.requests, recorded)
 		recorder.mu.Unlock()
 
-		w.WriteHeader(stdhttp.StatusOK)
+		status := stdhttp.StatusOK
+		if recorder.statusFor != nil {
+			status = recorder.statusFor(recorded)
+		}
+
+		w.WriteHeader(status)
 	}))
 
 	t.Cleanup(recorder.server.Close)
 
 	return recorder
+}
+
+func decodeRecordedHTTPEvents(raw []byte) ([]*xatu.DecoratedEvent, error) {
+	lines := strings.Split(string(raw), "\n")
+	events := make([]*xatu.DecoratedEvent, 0, len(lines))
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		event := &xatu.DecoratedEvent{}
+		if err := protojson.Unmarshal([]byte(line), event); err != nil {
+			return nil, err
+		}
+
+		events = append(events, event)
+	}
+
+	return events, nil
 }
 
 func (r *recordingHTTPServer) snapshotRequests() []recordedHTTPRequest {

--- a/pkg/output/kafka/exporter.go
+++ b/pkg/output/kafka/exporter.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/processor"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -39,8 +40,28 @@ func NewItemExporter(
 
 // ExportItems sends a batch of decorated events to Kafka.
 func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEvent) error {
-	propagationCtx := ctx
+	return e.exportItems(ctx, items, propagationContexts(ctx, len(items)))
+}
 
+// ExportTraceableItems sends queued processor items to Kafka while preserving
+// each item's original caller context for record-level trace propagation.
+func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[xatu.DecoratedEvent]) error {
+	items := make([]*xatu.DecoratedEvent, 0, len(traceableItems))
+	propagationCtxs := make([]context.Context, 0, len(traceableItems))
+
+	for _, item := range traceableItems {
+		if item == nil || item.Item() == nil {
+			continue
+		}
+
+		items = append(items, item.Item())
+		propagationCtxs = append(propagationCtxs, item.Context())
+	}
+
+	return e.exportItems(ctx, items, propagationCtxs)
+}
+
+func (e ItemExporter) exportItems(ctx context.Context, items []*xatu.DecoratedEvent, propagationCtxs []context.Context) error {
 	ctx, span := observability.Tracer().Start(ctx,
 		"KafkaItemExporter.ExportItems",
 		trace.WithAttributes(attribute.Int64("num_events", int64(len(items)))),
@@ -49,7 +70,7 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEv
 
 	e.log.WithField("events", len(items)).WithContext(ctx).Debug("Sending batch of events to Kafka sink")
 
-	if err := e.sendUpstream(ctx, propagationCtx, items); err != nil {
+	if err := e.sendUpstream(ctx, items, propagationCtxs); err != nil {
 		e.log.
 			WithError(err).
 			WithField("num_events", len(items)).WithContext(ctx).
@@ -68,12 +89,12 @@ func (e ItemExporter) Shutdown(_ context.Context) error {
 	return e.client.Close()
 }
 
-func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items []*xatu.DecoratedEvent) error {
+func (e *ItemExporter) sendUpstream(ctx context.Context, items []*xatu.DecoratedEvent, propagationCtxs []context.Context) error {
 	msgs := make([]*sarama.ProducerMessage, 0, len(items))
 
 	propagator := otel.GetTextMapPropagator()
 
-	for _, p := range items {
+	for i, p := range items {
 		r, err := e.config.MarshalEvent(p)
 		if err != nil {
 			return err
@@ -89,7 +110,7 @@ func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items [
 			Value: eventPayload,
 		}
 
-		propagator.Inject(propagationCtx, newSaramaHeaderCarrier(&m.Headers))
+		propagator.Inject(propagationContextAt(propagationCtxs, i), newSaramaHeaderCarrier(&m.Headers))
 
 		msgByteSize := m.ByteSize(2)
 		if msgByteSize > e.config.MaxMessageBytes {
@@ -133,6 +154,23 @@ func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items [
 	e.log.WithField("count", len(msgs)-errorCount).WithContext(ctx).Debug("Items written to Kafka")
 
 	return nil
+}
+
+func propagationContexts(ctx context.Context, count int) []context.Context {
+	out := make([]context.Context, count)
+	for i := range out {
+		out[i] = ctx
+	}
+
+	return out
+}
+
+func propagationContextAt(ctxs []context.Context, index int) context.Context {
+	if index >= 0 && index < len(ctxs) && ctxs[index] != nil {
+		return ctxs[index]
+	}
+
+	return context.Background()
 }
 
 // topicForEvent returns the Kafka topic for a given event, dispatching

--- a/pkg/output/kafka/exporter.go
+++ b/pkg/output/kafka/exporter.go
@@ -39,6 +39,8 @@ func NewItemExporter(
 
 // ExportItems sends a batch of decorated events to Kafka.
 func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEvent) error {
+	propagationCtx := ctx
+
 	ctx, span := observability.Tracer().Start(ctx,
 		"KafkaItemExporter.ExportItems",
 		trace.WithAttributes(attribute.Int64("num_events", int64(len(items)))),
@@ -47,7 +49,7 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*xatu.DecoratedEv
 
 	e.log.WithField("events", len(items)).WithContext(ctx).Debug("Sending batch of events to Kafka sink")
 
-	if err := e.sendUpstream(ctx, items); err != nil {
+	if err := e.sendUpstream(ctx, propagationCtx, items); err != nil {
 		e.log.
 			WithError(err).
 			WithField("num_events", len(items)).WithContext(ctx).
@@ -66,7 +68,7 @@ func (e ItemExporter) Shutdown(_ context.Context) error {
 	return e.client.Close()
 }
 
-func (e *ItemExporter) sendUpstream(ctx context.Context, items []*xatu.DecoratedEvent) error {
+func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items []*xatu.DecoratedEvent) error {
 	msgs := make([]*sarama.ProducerMessage, 0, len(items))
 
 	propagator := otel.GetTextMapPropagator()
@@ -87,7 +89,7 @@ func (e *ItemExporter) sendUpstream(ctx context.Context, items []*xatu.Decorated
 			Value: eventPayload,
 		}
 
-		propagator.Inject(ctx, newSaramaHeaderCarrier(&m.Headers))
+		propagator.Inject(propagationCtx, newSaramaHeaderCarrier(&m.Headers))
 
 		msgByteSize := m.ByteSize(2)
 		if msgByteSize > e.config.MaxMessageBytes {

--- a/pkg/output/kafka/exporter_test.go
+++ b/pkg/output/kafka/exporter_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -242,6 +247,53 @@ func TestExportItemsEmptyBatchAfterFiltering(t *testing.T) {
 	assert.Empty(t, mock.messages, "no SendMessages call when all messages are oversized")
 }
 
+func TestExportItemsDoesNotPropagateBatchSpan(t *testing.T) {
+	setupKafkaTraceTest(t)
+
+	mock := &mockProducer{}
+	exporter := NewItemExporter("test", &Config{
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
+		Topic:          "topic",
+	}, newTestLogger(), mock)
+
+	events := []*xatu.DecoratedEvent{
+		newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1"),
+		newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD, "id-2"),
+	}
+
+	err := exporter.ExportItems(context.Background(), events)
+	require.NoError(t, err)
+	require.Len(t, mock.messages, 2)
+
+	for _, msg := range mock.messages {
+		assert.False(t, spanContextFromHeaders(msg.Headers).IsValid(), "batch exporter span must not be injected into Kafka records")
+	}
+}
+
+func TestExportItemsPropagatesCallerContext(t *testing.T) {
+	setupKafkaTraceTest(t)
+
+	mock := &mockProducer{}
+	exporter := NewItemExporter("test", &Config{
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
+		Topic:          "topic",
+	}, newTestLogger(), mock)
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "caller")
+	defer parent.End()
+
+	err := exporter.ExportItems(ctx, []*xatu.DecoratedEvent{
+		newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1"),
+	})
+	require.NoError(t, err)
+	require.Len(t, mock.messages, 1)
+
+	sc := spanContextFromHeaders(mock.messages[0].Headers)
+	require.True(t, sc.IsValid())
+	assert.Equal(t, parent.SpanContext().TraceID(), sc.TraceID())
+	assert.Equal(t, parent.SpanContext().SpanID(), sc.SpanID())
+}
+
 func TestExportItemsProducerErrors(t *testing.T) {
 	prodErr := &sarama.ProducerError{
 		Msg: &sarama.ProducerMessage{Topic: "t"},
@@ -294,4 +346,37 @@ func TestShutdownClosesProducer(t *testing.T) {
 	err := exporter.Shutdown(context.Background())
 	require.NoError(t, err)
 	assert.True(t, mock.closed, "Shutdown should call Close on the producer")
+}
+
+func setupKafkaTraceTest(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(recorder),
+	)
+
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+	})
+
+	return recorder
+}
+
+func spanContextFromHeaders(headers []sarama.RecordHeader) trace.SpanContext {
+	return trace.SpanContextFromContext(
+		otel.GetTextMapPropagator().Extract(
+			context.Background(),
+			newSaramaHeaderCarrier(&headers),
+		),
+	)
 }

--- a/pkg/output/kafka/exporter_test.go
+++ b/pkg/output/kafka/exporter_test.go
@@ -3,7 +3,9 @@ package kafka
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/sirupsen/logrus"
@@ -16,32 +18,50 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/processor"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
 // mockProducer implements sarama.SyncProducer for testing.
 type mockProducer struct {
+	mu       sync.Mutex
 	messages []*sarama.ProducerMessage
 	err      error
 	closed   bool
 }
 
 func (m *mockProducer) SendMessage(msg *sarama.ProducerMessage) (int32, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.messages = append(m.messages, msg)
 
 	return 0, 0, m.err
 }
 
 func (m *mockProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.messages = append(m.messages, msgs...)
 
 	return m.err
 }
 
 func (m *mockProducer) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.closed = true
 
 	return nil
+}
+
+func (m *mockProducer) snapshotMessages() []*sarama.ProducerMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]*sarama.ProducerMessage(nil), m.messages...)
 }
 
 func (m *mockProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
@@ -292,6 +312,68 @@ func TestExportItemsPropagatesCallerContext(t *testing.T) {
 	require.True(t, sc.IsValid())
 	assert.Equal(t, parent.SpanContext().TraceID(), sc.TraceID())
 	assert.Equal(t, parent.SpanContext().SpanID(), sc.SpanID())
+}
+
+func TestKafkaSinkProcessorPropagatesPerItemContexts(t *testing.T) {
+	setupKafkaTraceTest(t)
+
+	mock := &mockProducer{}
+	exporter := NewItemExporter("test", &Config{
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
+		Topic:          "topic",
+	}, newTestLogger(), mock)
+
+	proc, err := processor.NewBatchItemProcessor[xatu.DecoratedEvent](
+		exporter,
+		"processor",
+		newTestLogger(),
+		processor.WithMaxExportBatchSize(2),
+		processor.WithWorkers(1),
+		processor.WithBatchTimeout(time.Hour),
+	)
+	require.NoError(t, err)
+
+	filter, err := xatu.NewEventFilter(&xatu.EventFilterConfig{})
+	require.NoError(t, err)
+
+	sink := &Kafka{
+		name:   "test",
+		config: &Config{},
+		log:    newTestLogger(),
+		proc:   proc,
+		filter: filter,
+	}
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	ctx1, span1 := otel.Tracer("test").Start(context.Background(), "event-1")
+	defer span1.End()
+
+	ctx2, span2 := otel.Tracer("test").Start(context.Background(), "event-2")
+	defer span2.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx1, newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx2, newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD, "id-2")))
+
+	require.Eventually(t, func() bool {
+		return len(mock.snapshotMessages()) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	messages := mock.snapshotMessages()
+	sc1 := spanContextFromHeaders(messages[0].Headers)
+	sc2 := spanContextFromHeaders(messages[1].Headers)
+
+	require.True(t, sc1.IsValid())
+	require.True(t, sc2.IsValid())
+	assert.Equal(t, span1.SpanContext().TraceID(), sc1.TraceID())
+	assert.Equal(t, span1.SpanContext().SpanID(), sc1.SpanID())
+	assert.Equal(t, span2.SpanContext().TraceID(), sc2.TraceID())
+	assert.Equal(t, span2.SpanContext().SpanID(), sc2.SpanID())
+	assert.NotEqual(t, sc1.TraceID(), sc2.TraceID())
 }
 
 func TestExportItemsProducerErrors(t *testing.T) {

--- a/pkg/output/kafka/exporter_test.go
+++ b/pkg/output/kafka/exporter_test.go
@@ -317,8 +317,10 @@ func TestExportItemsPropagatesCallerContext(t *testing.T) {
 func TestKafkaSinkProcessorPropagatesPerItemContexts(t *testing.T) {
 	setupKafkaTraceTest(t)
 
+	const name = "test"
+
 	mock := &mockProducer{}
-	exporter := NewItemExporter("test", &Config{
+	exporter := NewItemExporter(name, &Config{
 		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
 		Topic:          "topic",
 	}, newTestLogger(), mock)
@@ -337,7 +339,7 @@ func TestKafkaSinkProcessorPropagatesPerItemContexts(t *testing.T) {
 	require.NoError(t, err)
 
 	sink := &Kafka{
-		name:   "test",
+		name:   name,
 		config: &Config{},
 		log:    newTestLogger(),
 		proc:   proc,
@@ -350,10 +352,10 @@ func TestKafkaSinkProcessorPropagatesPerItemContexts(t *testing.T) {
 		require.NoError(t, sink.Stop(context.Background()))
 	}()
 
-	ctx1, span1 := otel.Tracer("test").Start(context.Background(), "event-1")
+	ctx1, span1 := otel.Tracer(name).Start(context.Background(), "event-1")
 	defer span1.End()
 
-	ctx2, span2 := otel.Tracer("test").Start(context.Background(), "event-2")
+	ctx2, span2 := otel.Tracer(name).Start(context.Background(), "event-2")
 	defer span2.End()
 
 	require.NoError(t, sink.HandleNewDecoratedEvent(ctx1, newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1")))
@@ -374,6 +376,54 @@ func TestKafkaSinkProcessorPropagatesPerItemContexts(t *testing.T) {
 	assert.Equal(t, span2.SpanContext().TraceID(), sc2.TraceID())
 	assert.Equal(t, span2.SpanContext().SpanID(), sc2.SpanID())
 	assert.NotEqual(t, sc1.TraceID(), sc2.TraceID())
+}
+
+func TestKafkaSinkProcessorNoActiveSpanDoesNotInjectTraceparent(t *testing.T) {
+	setupKafkaTraceTest(t)
+
+	const name = "test"
+
+	mock := &mockProducer{}
+	exporter := NewItemExporter(name, &Config{
+		ProducerConfig: ProducerConfig{MaxMessageBytes: 1000000},
+		Topic:          "topic",
+	}, newTestLogger(), mock)
+
+	proc, err := processor.NewBatchItemProcessor[xatu.DecoratedEvent](
+		exporter,
+		"processor",
+		newTestLogger(),
+		processor.WithMaxExportBatchSize(1),
+		processor.WithWorkers(1),
+		processor.WithBatchTimeout(time.Hour),
+	)
+	require.NoError(t, err)
+
+	filter, err := xatu.NewEventFilter(&xatu.EventFilterConfig{})
+	require.NoError(t, err)
+
+	sink := &Kafka{
+		name:   name,
+		config: &Config{},
+		log:    newTestLogger(),
+		proc:   proc,
+		filter: filter,
+	}
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(context.Background(), newTestEvent(xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1")))
+
+	require.Eventually(t, func() bool {
+		return len(mock.snapshotMessages()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	messages := mock.snapshotMessages()
+	assert.False(t, spanContextFromHeaders(messages[0].Headers).IsValid())
 }
 
 func TestExportItemsProducerErrors(t *testing.T) {

--- a/pkg/output/xatu/exporter.go
+++ b/pkg/output/xatu/exporter.go
@@ -2,6 +2,7 @@ package xatu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -88,13 +89,15 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*pb.DecoratedEven
 }
 
 func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[pb.DecoratedEvent]) error {
+	var err error
+
 	for _, group := range processor.GroupTraceableItemsByPropagation(traceableItems) {
-		if err := e.exportItems(ctx, group.Items, group.Context); err != nil {
-			return err
+		if exportErr := e.exportItems(ctx, group.Items, group.Context); exportErr != nil {
+			err = errors.Join(err, exportErr)
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (e ItemExporter) exportItems(ctx context.Context, items []*pb.DecoratedEvent, propagationCtx context.Context) error {

--- a/pkg/output/xatu/exporter.go
+++ b/pkg/output/xatu/exporter.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/processor"
 	pb "github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -83,12 +84,30 @@ func NewItemExporter(name string, config *Config, log observability.ContextualLo
 }
 
 func (e ItemExporter) ExportItems(ctx context.Context, items []*pb.DecoratedEvent) error {
+	return e.exportItems(ctx, items, ctx)
+}
+
+func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[pb.DecoratedEvent]) error {
+	for _, item := range traceableItems {
+		if item == nil || item.Item() == nil {
+			continue
+		}
+
+		if err := e.exportItems(ctx, []*pb.DecoratedEvent{item.Item()}, item.Context()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e ItemExporter) exportItems(ctx context.Context, items []*pb.DecoratedEvent, propagationCtx context.Context) error {
 	_, span := observability.Tracer().Start(ctx, "XatuItemExporter.ExportItems", trace.WithAttributes(attribute.Int64("num_events", int64(len(items)))))
 	defer span.End()
 
 	e.log.WithField("events", len(items)).WithContext(ctx).Debug("Sending batch of events to xatu sink")
 
-	if err := e.sendUpstream(ctx, items); err != nil {
+	if err := e.sendUpstream(ctx, propagationCtx, items); err != nil {
 		e.log.
 			WithError(err).
 			WithField("num_events", len(items)).WithContext(ctx).
@@ -106,7 +125,7 @@ func (e ItemExporter) Shutdown(ctx context.Context) error {
 	return e.conn.Close()
 }
 
-func (e *ItemExporter) sendUpstream(ctx context.Context, items []*pb.DecoratedEvent) error {
+func (e *ItemExporter) sendUpstream(ctx, propagationCtx context.Context, items []*pb.DecoratedEvent) error {
 	req := &pb.CreateEventsRequest{
 		Events: items,
 	}
@@ -114,6 +133,7 @@ func (e *ItemExporter) sendUpstream(ctx context.Context, items []*pb.DecoratedEv
 	logCtx := e.log.WithField("num_events", len(items))
 
 	md := metadata.New(e.config.Headers)
+	ctx = processor.ContextWithPropagation(ctx, propagationCtx)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	for key, value := range e.headers {

--- a/pkg/output/xatu/exporter.go
+++ b/pkg/output/xatu/exporter.go
@@ -88,12 +88,8 @@ func (e ItemExporter) ExportItems(ctx context.Context, items []*pb.DecoratedEven
 }
 
 func (e ItemExporter) ExportTraceableItems(ctx context.Context, traceableItems []*processor.TraceableItem[pb.DecoratedEvent]) error {
-	for _, item := range traceableItems {
-		if item == nil || item.Item() == nil {
-			continue
-		}
-
-		if err := e.exportItems(ctx, []*pb.DecoratedEvent{item.Item()}, item.Context()); err != nil {
+	for _, group := range processor.GroupTraceableItemsByPropagation(traceableItems) {
+		if err := e.exportItems(ctx, group.Items, group.Context); err != nil {
 			return err
 		}
 	}

--- a/pkg/output/xatu/exporter_test.go
+++ b/pkg/output/xatu/exporter_test.go
@@ -1,0 +1,175 @@
+package xatu
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/ethpandaops/xatu/pkg/processor"
+	pb "github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+type recordedCreateEventsCall struct {
+	traceparent string
+	eventCount  int
+}
+
+type recordingIngester struct {
+	pb.UnimplementedEventIngesterServer
+
+	mu    sync.Mutex
+	calls []recordedCreateEventsCall
+}
+
+func (r *recordingIngester) CreateEvents(ctx context.Context, req *pb.CreateEventsRequest) (*pb.CreateEventsResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	traceparent := ""
+	if values := md.Get("traceparent"); len(values) > 0 {
+		traceparent = values[0]
+	}
+
+	r.mu.Lock()
+	r.calls = append(r.calls, recordedCreateEventsCall{
+		traceparent: traceparent,
+		eventCount:  len(req.GetEvents()),
+	})
+	r.mu.Unlock()
+
+	return &pb.CreateEventsResponse{
+		EventsIngested: wrapperspb.UInt64(uint64(len(req.GetEvents()))),
+	}, nil
+}
+
+func (r *recordingIngester) snapshotCalls() []recordedCreateEventsCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]recordedCreateEventsCall(nil), r.calls...)
+}
+
+func TestXatuSinkProcessorPropagatesPerItemContexts(t *testing.T) {
+	setupXatuTraceTest(t)
+
+	addr, ingester := startRecordingIngester(t)
+
+	sink, err := New("test", &Config{
+		Address:            addr,
+		Headers:            map[string]string{},
+		MaxQueueSize:       10,
+		BatchTimeout:       time.Hour,
+		ExportTimeout:      5 * time.Second,
+		MaxExportBatchSize: 2,
+		Workers:            1,
+	}, logrus.New(), &pb.EventFilterConfig{}, processor.ShippingMethodAsync)
+	require.NoError(t, err)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	ctx1, span1 := otel.Tracer("test").Start(context.Background(), "event-1")
+	defer span1.End()
+
+	ctx2, span2 := otel.Tracer("test").Start(context.Background(), "event-2")
+	defer span2.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx1, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, "id-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(ctx2, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_HEAD, "id-2")))
+
+	require.Eventually(t, func() bool {
+		return len(ingester.snapshotCalls()) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	calls := ingester.snapshotCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, 1, calls[0].eventCount)
+	assert.Equal(t, 1, calls[1].eventCount)
+
+	sc1 := spanContextFromTraceparent(calls[0].traceparent)
+	sc2 := spanContextFromTraceparent(calls[1].traceparent)
+
+	require.True(t, sc1.IsValid())
+	require.True(t, sc2.IsValid())
+	assert.Equal(t, span1.SpanContext().TraceID(), sc1.TraceID())
+	assert.Equal(t, span2.SpanContext().TraceID(), sc2.TraceID())
+	assert.NotEqual(t, sc1.TraceID(), sc2.TraceID())
+}
+
+func startRecordingIngester(t *testing.T) (string, *recordingIngester) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	ingester := &recordingIngester{}
+	pb.RegisterEventIngesterServer(server, ingester)
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	return listener.Addr().String(), ingester
+}
+
+func setupXatuTraceTest(t *testing.T) {
+	t.Helper()
+
+	previousProvider := otel.GetTracerProvider()
+	previousPropagator := otel.GetTextMapPropagator()
+
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()),
+	)
+
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+		otel.SetTracerProvider(previousProvider)
+		otel.SetTextMapPropagator(previousPropagator)
+	})
+}
+
+func newTestEvent(name pb.Event_Name, id string) *pb.DecoratedEvent {
+	return &pb.DecoratedEvent{
+		Event: &pb.Event{
+			Name:     name,
+			Id:       id,
+			DateTime: timestamppb.New(time.Unix(1_700_000_000, 0)),
+		},
+	}
+}
+
+func spanContextFromTraceparent(traceparent string) trace.SpanContext {
+	return trace.SpanContextFromContext(
+		otel.GetTextMapPropagator().Extract(
+			context.Background(),
+			propagation.MapCarrier{"traceparent": traceparent},
+		),
+	)
+}

--- a/pkg/output/xatu/exporter_test.go
+++ b/pkg/output/xatu/exporter_test.go
@@ -2,6 +2,7 @@ package xatu
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -111,6 +112,49 @@ func TestXatuSinkProcessorPropagatesPerItemContexts(t *testing.T) {
 	assert.Equal(t, span1.SpanContext().TraceID(), sc1.TraceID())
 	assert.Equal(t, span2.SpanContext().TraceID(), sc2.TraceID())
 	assert.NotEqual(t, sc1.TraceID(), sc2.TraceID())
+}
+
+func TestXatuSinkProcessorBatchesSharedContext(t *testing.T) {
+	setupXatuTraceTest(t)
+
+	addr, ingester := startRecordingIngester(t)
+
+	sink, err := New("test", &Config{
+		Address:            addr,
+		Headers:            map[string]string{},
+		MaxQueueSize:       100,
+		BatchTimeout:       time.Hour,
+		ExportTimeout:      5 * time.Second,
+		MaxExportBatchSize: 100,
+		Workers:            1,
+	}, logrus.New(), &pb.EventFilterConfig{}, processor.ShippingMethodAsync)
+	require.NoError(t, err)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "shared")
+	defer span.End()
+
+	events := make([]*pb.DecoratedEvent, 0, 100)
+	for i := range 100 {
+		events = append(events, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_BLOCK, fmt.Sprintf("id-%d", i)))
+	}
+
+	require.NoError(t, sink.HandleNewDecoratedEvents(ctx, events))
+
+	require.Eventually(t, func() bool {
+		calls := ingester.snapshotCalls()
+
+		return len(calls) == 1 && calls[0].eventCount == 100
+	}, time.Second, 10*time.Millisecond)
+
+	calls := ingester.snapshotCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, span.SpanContext().TraceID(), spanContextFromTraceparent(calls[0].traceparent).TraceID())
 }
 
 func startRecordingIngester(t *testing.T) (string, *recordingIngester) {

--- a/pkg/output/xatu/exporter_test.go
+++ b/pkg/output/xatu/exporter_test.go
@@ -17,7 +17,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -28,13 +30,16 @@ import (
 type recordedCreateEventsCall struct {
 	traceparent string
 	eventCount  int
+	eventIDs    []string
+	eventNames  []pb.Event_Name
 }
 
 type recordingIngester struct {
 	pb.UnimplementedEventIngesterServer
 
-	mu    sync.Mutex
-	calls []recordedCreateEventsCall
+	mu     sync.Mutex
+	calls  []recordedCreateEventsCall
+	errFor func(recordedCreateEventsCall) error
 }
 
 func (r *recordingIngester) CreateEvents(ctx context.Context, req *pb.CreateEventsRequest) (*pb.CreateEventsResponse, error) {
@@ -45,15 +50,34 @@ func (r *recordingIngester) CreateEvents(ctx context.Context, req *pb.CreateEven
 		traceparent = values[0]
 	}
 
-	r.mu.Lock()
-	r.calls = append(r.calls, recordedCreateEventsCall{
+	events := req.GetEvents()
+	eventIDs := make([]string, 0, len(events))
+	eventNames := make([]pb.Event_Name, 0, len(events))
+
+	for _, event := range events {
+		eventIDs = append(eventIDs, event.GetEvent().GetId())
+		eventNames = append(eventNames, event.GetEvent().GetName())
+	}
+
+	call := recordedCreateEventsCall{
 		traceparent: traceparent,
-		eventCount:  len(req.GetEvents()),
-	})
+		eventCount:  len(events),
+		eventIDs:    eventIDs,
+		eventNames:  eventNames,
+	}
+
+	r.mu.Lock()
+	r.calls = append(r.calls, call)
 	r.mu.Unlock()
 
+	if r.errFor != nil {
+		if err := r.errFor(call); err != nil {
+			return nil, err
+		}
+	}
+
 	return &pb.CreateEventsResponse{
-		EventsIngested: wrapperspb.UInt64(uint64(len(req.GetEvents()))),
+		EventsIngested: wrapperspb.UInt64(uint64(len(events))),
 	}, nil
 }
 
@@ -157,14 +181,134 @@ func TestXatuSinkProcessorBatchesSharedContext(t *testing.T) {
 	assert.Equal(t, span.SpanContext().TraceID(), spanContextFromTraceparent(calls[0].traceparent).TraceID())
 }
 
+func TestXatuSinkProcessorPreservesSparseMixedTraceGroups(t *testing.T) {
+	setupXatuTraceTest(t)
+
+	addr, ingester := startRecordingIngester(t)
+
+	sink, err := New("test", &Config{
+		Address:            addr,
+		Headers:            map[string]string{},
+		MaxQueueSize:       12,
+		BatchTimeout:       time.Hour,
+		ExportTimeout:      5 * time.Second,
+		MaxExportBatchSize: 12,
+		Workers:            1,
+	}, logrus.New(), &pb.EventFilterConfig{}, processor.ShippingMethodAsync)
+	require.NoError(t, err)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	for i := range 10 {
+		require.NoError(t, sink.HandleNewDecoratedEvent(
+			context.Background(),
+			newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_ATTESTATION_V2, fmt.Sprintf("attestation-%d", i)),
+		))
+	}
+
+	headCtx, headSpan := otel.Tracer("test").Start(context.Background(), "head")
+	defer headSpan.End()
+
+	blockCtx, blockSpan := otel.Tracer("test").Start(context.Background(), "block")
+	defer blockSpan.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(headCtx, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2, "head-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(blockCtx, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2, "block-1")))
+
+	require.Eventually(t, func() bool {
+		return len(ingester.snapshotCalls()) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	calls := ingester.snapshotCalls()
+	require.Len(t, calls, 3)
+
+	assert.Equal(t, 10, calls[0].eventCount)
+	assert.Equal(t, 1, calls[1].eventCount)
+	assert.Equal(t, 1, calls[2].eventCount)
+	assert.Equal(t, []string{"head-1"}, calls[1].eventIDs)
+	assert.Equal(t, []string{"block-1"}, calls[2].eventIDs)
+	assert.Equal(t, []pb.Event_Name{pb.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2}, calls[1].eventNames)
+	assert.Equal(t, []pb.Event_Name{pb.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2}, calls[2].eventNames)
+
+	assert.Equal(t, headSpan.SpanContext().TraceID(), spanContextFromTraceparent(calls[1].traceparent).TraceID())
+	assert.Equal(t, blockSpan.SpanContext().TraceID(), spanContextFromTraceparent(calls[2].traceparent).TraceID())
+}
+
+func TestXatuSinkProcessorAttemptsSparseGroupsAfterEarlierGroupFailure(t *testing.T) {
+	setupXatuTraceTest(t)
+
+	addr, ingester := startRecordingIngesterWithError(t, func(call recordedCreateEventsCall) error {
+		if call.eventCount == 10 {
+			return status.Error(codes.Internal, "first group failed")
+		}
+
+		return nil
+	})
+
+	sink, err := New("test", &Config{
+		Address:            addr,
+		Headers:            map[string]string{},
+		MaxQueueSize:       12,
+		BatchTimeout:       time.Hour,
+		ExportTimeout:      5 * time.Second,
+		MaxExportBatchSize: 12,
+		Workers:            1,
+	}, logrus.New(), &pb.EventFilterConfig{}, processor.ShippingMethodAsync)
+	require.NoError(t, err)
+
+	require.NoError(t, sink.Start(context.Background()))
+
+	defer func() {
+		require.NoError(t, sink.Stop(context.Background()))
+	}()
+
+	for i := range 10 {
+		require.NoError(t, sink.HandleNewDecoratedEvent(
+			context.Background(),
+			newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_ATTESTATION_V2, fmt.Sprintf("attestation-%d", i)),
+		))
+	}
+
+	headCtx, headSpan := otel.Tracer("test").Start(context.Background(), "head")
+	defer headSpan.End()
+
+	blockCtx, blockSpan := otel.Tracer("test").Start(context.Background(), "block")
+	defer blockSpan.End()
+
+	require.NoError(t, sink.HandleNewDecoratedEvent(headCtx, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_HEAD_V2, "head-1")))
+	require.NoError(t, sink.HandleNewDecoratedEvent(blockCtx, newTestEvent(pb.Event_BEACON_API_ETH_V1_EVENTS_BLOCK_V2, "block-1")))
+
+	require.Eventually(t, func() bool {
+		return len(ingester.snapshotCalls()) == 3
+	}, time.Second, 10*time.Millisecond)
+
+	calls := ingester.snapshotCalls()
+	require.Len(t, calls, 3)
+
+	assert.Equal(t, []string{"head-1"}, calls[1].eventIDs)
+	assert.Equal(t, []string{"block-1"}, calls[2].eventIDs)
+	assert.Equal(t, headSpan.SpanContext().TraceID(), spanContextFromTraceparent(calls[1].traceparent).TraceID())
+	assert.Equal(t, blockSpan.SpanContext().TraceID(), spanContextFromTraceparent(calls[2].traceparent).TraceID())
+}
+
 func startRecordingIngester(t *testing.T) (string, *recordingIngester) {
+	t.Helper()
+
+	return startRecordingIngesterWithError(t, nil)
+}
+
+func startRecordingIngesterWithError(t *testing.T, errFor func(recordedCreateEventsCall) error) (string, *recordingIngester) {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	server := grpc.NewServer()
-	ingester := &recordingIngester{}
+	ingester := &recordingIngester{errFor: errFor}
 	pb.RegisterEventIngesterServer(server, ingester)
 
 	go func() {

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -35,6 +35,12 @@ type ItemExporter[T any] interface {
 	Shutdown(ctx context.Context) error
 }
 
+// TraceableItemExporter is implemented by exporters that need each queued
+// item's original caller context in addition to the worker/export context.
+type TraceableItemExporter[T any] interface {
+	ExportTraceableItems(ctx context.Context, items []*TraceableItem[T]) error
+}
+
 const (
 	DefaultMaxQueueSize       = 51200
 	DefaultScheduleDelay      = 5000
@@ -121,11 +127,30 @@ type BatchItemProcessor[T any] struct {
 }
 
 type TraceableItem[T any] struct {
-	item *T
+	item      *T
+	callerCtx context.Context //nolint:containedctx // trace context propagation across async batching
 	// resultCh signals export completion for sync shipping. A nil value
 	// means success; a non-nil error means the export failed. Closed
 	// exactly once by the worker after the value is sent.
 	resultCh chan error
+}
+
+// Item returns the queued item.
+func (ti *TraceableItem[T]) Item() *T {
+	if ti == nil {
+		return nil
+	}
+
+	return ti.item
+}
+
+// Context returns the caller context captured when the item was queued.
+func (ti *TraceableItem[T]) Context() context.Context {
+	if ti == nil || ti.callerCtx == nil {
+		return context.Background()
+	}
+
+	return ti.callerCtx
 }
 
 // NewBatchItemProcessor creates a new batch item processor.
@@ -239,7 +264,8 @@ func (bvp *BatchItemProcessor[T]) Write(ctx context.Context, s []*T) error {
 			}
 
 			item := &TraceableItem[T]{
-				item: i,
+				item:      i,
+				callerCtx: context.WithoutCancel(ctx),
 			}
 
 			if bvp.o.ShippingMethod == ShippingMethodSync {
@@ -281,7 +307,9 @@ func (bvp *BatchItemProcessor[T]) exportWithTimeout(ctx context.Context, itemsBa
 		defer cancel()
 	}
 
+	traceableItems := make([]*TraceableItem[T], 0, len(itemsBatch))
 	items := make([]*T, 0, len(itemsBatch))
+
 	for _, ti := range itemsBatch {
 		if ti == nil {
 			bvp.log.WithContext(ctx).Warnf("Attempted to export a nil item. This item has been dropped. This probably shouldn't happen and is likely a bug.")
@@ -289,11 +317,19 @@ func (bvp *BatchItemProcessor[T]) exportWithTimeout(ctx context.Context, itemsBa
 			continue
 		}
 
+		traceableItems = append(traceableItems, ti)
 		items = append(items, ti.item)
 	}
 
 	startTime := time.Now()
-	err := bvp.e.ExportItems(ctx, items)
+
+	var err error
+	if traceableExporter, ok := bvp.e.(TraceableItemExporter[T]); ok {
+		err = traceableExporter.ExportTraceableItems(ctx, traceableItems)
+	} else {
+		err = bvp.e.ExportItems(ctx, items)
+	}
+
 	bvp.metrics.ObserveExportDuration(bvp.name, time.Since(startTime))
 
 	if err != nil {

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ethpandaops/xatu/pkg/observability"
 )
@@ -39,6 +41,29 @@ type ItemExporter[T any] interface {
 // item's original caller context in addition to the worker/export context.
 type TraceableItemExporter[T any] interface {
 	ExportTraceableItems(ctx context.Context, items []*TraceableItem[T]) error
+}
+
+// PropagationContext returns a detached context containing only OTel
+// propagation state from ctx.
+func PropagationContext(ctx context.Context) context.Context {
+	return ContextWithPropagation(context.Background(), ctx)
+}
+
+// ContextWithPropagation returns parent with OTel propagation state copied
+// from propagationCtx. It preserves parent cancellation/deadline and avoids
+// retaining unrelated values from propagationCtx.
+func ContextWithPropagation(parent, propagationCtx context.Context) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	if propagationCtx == nil {
+		propagationCtx = context.Background()
+	}
+
+	ctx := trace.ContextWithSpanContext(parent, trace.SpanContextFromContext(propagationCtx))
+
+	return baggage.ContextWithBaggage(ctx, baggage.FromContext(propagationCtx))
 }
 
 const (
@@ -265,7 +290,7 @@ func (bvp *BatchItemProcessor[T]) Write(ctx context.Context, s []*T) error {
 
 			item := &TraceableItem[T]{
 				item:      i,
-				callerCtx: context.WithoutCancel(ctx),
+				callerCtx: PropagationContext(ctx),
 			}
 
 			if bvp.o.ShippingMethod == ShippingMethodSync {

--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +45,11 @@ type TraceableItemExporter[T any] interface {
 	ExportTraceableItems(ctx context.Context, items []*TraceableItem[T]) error
 }
 
+type TraceableItemGroup[T any] struct {
+	Context context.Context //nolint:containedctx // minimal OTel propagation context for this export group
+	Items   []*T
+}
+
 // PropagationContext returns a detached context containing only OTel
 // propagation state from ctx.
 func PropagationContext(ctx context.Context) context.Context {
@@ -64,6 +71,65 @@ func ContextWithPropagation(parent, propagationCtx context.Context) context.Cont
 	ctx := trace.ContextWithSpanContext(parent, trace.SpanContextFromContext(propagationCtx))
 
 	return baggage.ContextWithBaggage(ctx, baggage.FromContext(propagationCtx))
+}
+
+func GroupTraceableItemsByPropagation[T any](items []*TraceableItem[T]) []TraceableItemGroup[T] {
+	groupsByKey := make(map[string]int, len(items))
+	groups := make([]TraceableItemGroup[T], 0, len(items))
+
+	for _, item := range items {
+		if item == nil || item.Item() == nil {
+			continue
+		}
+
+		itemCtx := item.Context()
+		key := propagationGroupKey(itemCtx)
+
+		idx, ok := groupsByKey[key]
+		if !ok {
+			idx = len(groups)
+			groupsByKey[key] = idx
+
+			groups = append(groups, TraceableItemGroup[T]{
+				Context: itemCtx,
+				Items:   make([]*T, 0, 1),
+			})
+		}
+
+		groups[idx].Items = append(groups[idx].Items, item.Item())
+	}
+
+	return groups
+}
+
+func propagationGroupKey(ctx context.Context) string {
+	sc := trace.SpanContextFromContext(ctx)
+
+	return fmt.Sprintf(
+		"%s\x00%s\x00%x\x00%t\x00%s\x00%s",
+		sc.TraceID(),
+		sc.SpanID(),
+		byte(sc.TraceFlags()),
+		sc.IsRemote(),
+		sc.TraceState().String(),
+		canonicalBaggage(baggage.FromContext(ctx)),
+	)
+}
+
+func canonicalBaggage(bag baggage.Baggage) string {
+	members := bag.Members()
+	if len(members) == 0 {
+		return ""
+	}
+
+	out := make([]string, 0, len(members))
+	for _, member := range members {
+		out = append(out, member.String())
+	}
+
+	sort.Strings(out)
+
+	return strings.Join(out, "\x00")
 }
 
 const (

--- a/pkg/processor/batch_test.go
+++ b/pkg/processor/batch_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -53,6 +54,8 @@ func traceCtx(seed byte) context.Context {
 type TestItem struct {
 	name string
 }
+
+type contextValueKey struct{}
 
 type testBatchExporter[T TestItem] struct {
 	mu             sync.Mutex
@@ -149,6 +152,32 @@ func TestNewBatchItemProcessorWithNilExporter(t *testing.T) {
 
 	if err := bsp.Shutdown(context.Background()); err != nil {
 		t.Errorf("failed to Shutdown the BatchItemProcessor: %v", err)
+	}
+}
+
+func TestPropagationContextTrimsValuesAndPreservesOTelState(t *testing.T) {
+	member, err := baggage.NewMember("user", "alice")
+	require.NoError(t, err)
+
+	bag, err := baggage.New(member)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(traceCtx(0x42), contextValueKey{}, "retain-me-not")
+	ctx = baggage.ContextWithBaggage(ctx, bag)
+
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	trimmed := PropagationContext(ctx)
+
+	assert.Nil(t, trimmed.Value(contextValueKey{}))
+	assert.Equal(t, trace.SpanContextFromContext(ctx), trace.SpanContextFromContext(trimmed))
+	assert.Equal(t, "alice", baggage.FromContext(trimmed).Member("user").Value())
+
+	select {
+	case <-trimmed.Done():
+		t.Fatal("propagation context must be detached from caller cancellation")
+	default:
 	}
 }
 


### PR DESCRIPTION
Diagnosis: consumoor was not creating thousands of micro-step spans; it was honoring a shared Kafka `traceparent` written by `KafkaItemExporter.ExportItems`, which created one producer span for an entire batch and injected that same span into every record. When that batch span was sampled, every `consumoor.HandleMessage` span for the batch landed in one trace, and `consumoor.WriteGroup` could also inherit a Benthos callback span when no header was present.

Fix: Kafka output now propagates the caller context into Kafka records instead of its own batch export span, so the export batch span no longer becomes the parent for unrelated messages. This keeps #835's sentry -> server -> consumoor propagation intact: valid Kafka traceparents are still honored, unsampled parents still suppress child spans, and no-header messages fall back to the local sampler.
