### PR TITLE
feat(sentry-logs): make the xatu sink buffer/concurrency/timeout env-tunable

### DIFF
--- a/docs/sentry-logs.md
+++ b/docs/sentry-logs.md
@@ -75,12 +75,12 @@ The process will crash on startup if required environment variables are not set.
 | XATU_BATCH_TIMEOUT_SECS | No | `5` | Batch timeout in seconds |
 | XATU_SINK_CONCURRENCY | No | `adaptive` | In-flight requests to the xatu server; an integer (e.g. `10`) or `adaptive` |
 | XATU_SINK_TIMEOUT_SECS | No | `30` | Per-request timeout to the xatu server, in seconds |
-| XATU_SINK_BUFFER_MAX_SIZE | No | `1073741824` | On-disk sink buffer size in bytes (default 1 GiB) — absorbs ingestion bursts so events aren't dropped |
+| XATU_SINK_BUFFER_MAX_EVENTS | No | `500` | In-memory sink buffer size, in events |
 | XATU_SINK_BUFFER_WHEN_FULL | No | `block` | Behavior when the buffer fills: `block` (backpressure upstream) or `drop_newest` |
 
 **Note:** Requests are gzip-compressed by default for bandwidth efficiency. Set `XATU_COMPRESSION=none` to disable.
 
-**Note:** The sink uses an on-disk buffer at Vector's `data_dir` (`/var/lib/vector`), so that path must be a writable volume with enough free space for `XATU_SINK_BUFFER_MAX_SIZE`. This buffer lets the log reader keep draining the container log while the server is briefly slow, instead of dropping events under burst.
+**Note:** The sink uses an in-memory buffer by default. For burst-heavy ingestion (e.g. a genesis backfill) where the in-memory buffer can backpressure and drop events, switch to a disk buffer by overriding the full Vector config — the `xatu-sentry-logs` chart's `config` value — with `buffer: { type: disk, max_size: <bytes>, when_full: block }`. A disk buffer requires a writable Vector `data_dir` (`/var/lib/vector`).
 
 ### Log Sources
 

--- a/docs/sentry-logs.md
+++ b/docs/sentry-logs.md
@@ -73,8 +73,14 @@ The process will crash on startup if required environment variables are not set.
 | XATU_COMPRESSION | No | `gzip` | Compression algorithm: `gzip`, `none` |
 | XATU_BATCH_MAX_EVENTS | No | `5000` | Maximum events per batch |
 | XATU_BATCH_TIMEOUT_SECS | No | `5` | Batch timeout in seconds |
+| XATU_SINK_CONCURRENCY | No | `adaptive` | In-flight requests to the xatu server; an integer (e.g. `10`) or `adaptive` |
+| XATU_SINK_TIMEOUT_SECS | No | `30` | Per-request timeout to the xatu server, in seconds |
+| XATU_SINK_BUFFER_MAX_SIZE | No | `1073741824` | On-disk sink buffer size in bytes (default 1 GiB) — absorbs ingestion bursts so events aren't dropped |
+| XATU_SINK_BUFFER_WHEN_FULL | No | `block` | Behavior when the buffer fills: `block` (backpressure upstream) or `drop_newest` |
 
 **Note:** Requests are gzip-compressed by default for bandwidth efficiency. Set `XATU_COMPRESSION=none` to disable.
+
+**Note:** The sink uses an on-disk buffer at Vector's `data_dir` (`/var/lib/vector`), so that path must be a writable volume with enough free space for `XATU_SINK_BUFFER_MAX_SIZE`. This buffer lets the log reader keep draining the container log while the server is briefly slow, instead of dropping events under burst.
 
 ### Log Sources
 

--- a/docs/sentry-logs.md
+++ b/docs/sentry-logs.md
@@ -75,12 +75,13 @@ The process will crash on startup if required environment variables are not set.
 | XATU_BATCH_TIMEOUT_SECS | No | `5` | Batch timeout in seconds |
 | XATU_SINK_CONCURRENCY | No | `adaptive` | In-flight requests to the xatu server; an integer (e.g. `10`) or `adaptive` |
 | XATU_SINK_TIMEOUT_SECS | No | `30` | Per-request timeout to the xatu server, in seconds |
-| XATU_SINK_BUFFER_MAX_EVENTS | No | `500` | In-memory sink buffer size, in events |
+| XATU_SINK_BUFFER_TYPE | No | `memory` | Sink buffer type: `memory` or `disk` |
+| XATU_SINK_BUFFER_SIZE | No | `max_events: 500` | Buffer size as a `key: value` pair — `max_events: <n>` for memory, `max_size: <bytes>` for disk |
 | XATU_SINK_BUFFER_WHEN_FULL | No | `block` | Behavior when the buffer fills: `block` (backpressure upstream) or `drop_newest` |
 
 **Note:** Requests are gzip-compressed by default for bandwidth efficiency. Set `XATU_COMPRESSION=none` to disable.
 
-**Note:** The sink uses an in-memory buffer by default. For burst-heavy ingestion (e.g. a genesis backfill) where the in-memory buffer can backpressure and drop events, switch to a disk buffer by overriding the full Vector config — the `xatu-sentry-logs` chart's `config` value — with `buffer: { type: disk, max_size: <bytes>, when_full: block }`. A disk buffer requires a writable Vector `data_dir` (`/var/lib/vector`).
+**Note:** The buffer defaults to in-memory. For burst-heavy ingestion (e.g. a genesis backfill) set `XATU_SINK_BUFFER_TYPE=disk` and `XATU_SINK_BUFFER_SIZE='max_size: <bytes>'` (Vector's memory/disk buffers require different size keys, hence the `key: value` form). A disk buffer needs a writable Vector `data_dir` (`/var/lib/vector`).
 
 ### Log Sources
 

--- a/sentry-logs/configs/vector.yaml
+++ b/sentry-logs/configs/vector.yaml
@@ -415,8 +415,8 @@ sinks:
       max_events: ${XATU_BATCH_MAX_EVENTS:-5000}
       timeout_secs: ${XATU_BATCH_TIMEOUT_SECS:-5}
     buffer:
-      type: disk
-      max_size: ${XATU_SINK_BUFFER_MAX_SIZE:-1073741824}
+      type: memory
+      max_events: ${XATU_SINK_BUFFER_MAX_EVENTS:-500}
       when_full: ${XATU_SINK_BUFFER_WHEN_FULL:-block}
 
   # Debug sinks - uncomment for troubleshooting

--- a/sentry-logs/configs/vector.yaml
+++ b/sentry-logs/configs/vector.yaml
@@ -415,8 +415,8 @@ sinks:
       max_events: ${XATU_BATCH_MAX_EVENTS:-5000}
       timeout_secs: ${XATU_BATCH_TIMEOUT_SECS:-5}
     buffer:
-      type: memory
-      max_events: ${XATU_SINK_BUFFER_MAX_EVENTS:-500}
+      type: ${XATU_SINK_BUFFER_TYPE:-memory}
+      ${XATU_SINK_BUFFER_SIZE:-max_events: 500}
       when_full: ${XATU_SINK_BUFFER_WHEN_FULL:-block}
 
   # Debug sinks - uncomment for troubleshooting

--- a/sentry-logs/configs/vector.yaml
+++ b/sentry-logs/configs/vector.yaml
@@ -406,12 +406,18 @@ sinks:
     encoding:
       codec: json
     request:
+      concurrency: ${XATU_SINK_CONCURRENCY:-adaptive}
+      timeout_secs: ${XATU_SINK_TIMEOUT_SECS:-30}
       headers:
         Content-Type: application/json
         Authorization: "Basic ${XATU_AUTH}"
     batch:
       max_events: ${XATU_BATCH_MAX_EVENTS:-5000}
       timeout_secs: ${XATU_BATCH_TIMEOUT_SECS:-5}
+    buffer:
+      type: disk
+      max_size: ${XATU_SINK_BUFFER_MAX_SIZE:-1073741824}
+      when_full: ${XATU_SINK_BUFFER_WHEN_FULL:-block}
 
   # Debug sinks - uncomment for troubleshooting
   # debug_parsed:


### PR DESCRIPTION
Makes the sentry-logs Vector HTTP sink tunable from env vars without a new image: `XATU_SINK_CONCURRENCY`, `XATU_SINK_TIMEOUT_SECS`, and the buffer — `XATU_SINK_BUFFER_TYPE` (memory|disk), `XATU_SINK_BUFFER_SIZE`, `XATU_SINK_BUFFER_WHEN_FULL`. Defaults preserve current behaviour (in-memory buffer, adaptive concurrency); set type=disk for burst-heavy ingestion. `XATU_SINK_BUFFER_SIZE` is a `key: value` pair (`max_events: N` for memory, `max_size: <bytes>` for disk) because Vector's two buffer types require different size keys and reject a block containing both — verified with `vector validate`.