### PR TITLE
ci(clickhouse): lint migrations for database-agnosticism + syntax

### DIFF
--- a/.github/workflows/clickhouse-migrations-lint.yaml
+++ b/.github/workflows/clickhouse-migrations-lint.yaml
@@ -1,0 +1,49 @@
+name: ClickHouse Migrations Lint
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/migrations/clickhouse/**'
+      - '.github/workflows/clickhouse-migrations-lint.yaml'
+  workflow_dispatch:
+    branches: [ '**' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # ClickHouse image used for the syntax check; matches docker-compose's CHVER default.
+  CHVER: latest
+
+jobs:
+  # Enforce the database-agnostic rules (no CREATE DATABASE, no db-qualified
+  # identifiers, Distributed() uses currentDatabase()). Pure bash, no dependencies.
+  database-agnostic:
+    name: database-agnostic lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Lint migrations are database-agnostic
+        run: ./deploy/migrations/clickhouse/lint.sh deploy/migrations/clickhouse
+
+  # Validate every migration parses with the real ClickHouse parser. Runs in
+  # parallel with the lint job (no `needs`).
+  syntax:
+    name: clickhouse syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Validate migrations parse (clickhouse format)
+        run: |
+          docker run --rm \
+            -e GITHUB_ACTIONS=true \
+            -v "$PWD":/work -w /work \
+            --entrypoint /bin/bash \
+            "clickhouse/clickhouse-server:${CHVER:-latest}" \
+            deploy/migrations/clickhouse/check-syntax.sh deploy/migrations/clickhouse

--- a/deploy/migrations/clickhouse/check-syntax.sh
+++ b/deploy/migrations/clickhouse/check-syntax.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Validate that every ClickHouse migration parses with the real ClickHouse parser.
+#
+# Runs `clickhouse format` (parse + reformat, no server needed) over each *.sql file
+# in check-only mode. This is a syntax gate, complementary to lint.sh: lint.sh
+# enforces the database-agnostic rules, this catches malformed SQL before it ever
+# reaches the migrator.
+#
+#   --multiquery     files contain many `;`-separated statements
+#   --quiet          only report on failure (no reformatted output on success)
+#   --max_query_size the parser caps a query at 256 KiB by default; the xatu set is
+#                    larger than that, so raise it well past any single file.
+#
+# Requires the `clickhouse` binary on PATH (override with CLICKHOUSE_BIN). In CI this
+# runs inside the clickhouse/clickhouse-server image; locally any clickhouse works.
+#
+# Usage: check-syntax.sh [MIGRATIONS_DIR]   (default: dir of this script)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="${1:-$SCRIPT_DIR}"
+CH="${CLICKHOUSE_BIN:-clickhouse}"
+MAX_QUERY_SIZE="${MAX_QUERY_SIZE:-1073741824}"   # 1 GiB; files are well under this.
+
+CI_ANNOTATE=0
+[ "${GITHUB_ACTIONS:-}" = "true" ] && CI_ANNOTATE=1
+
+shopt -s nullglob
+files=("$MIGRATIONS_DIR"/*/*.sql)
+if [ ${#files[@]} -eq 0 ]; then
+  echo "no migration .sql files found under ${MIGRATIONS_DIR}" >&2
+  exit 1
+fi
+
+status=0
+for file in "${files[@]}"; do
+  if err=$("$CH" format --multiquery --quiet --max_query_size "$MAX_QUERY_SIZE" < "$file" 2>&1); then
+    echo "OK   $file"
+  else
+    msg=$(printf '%s' "$err" | head -1)
+    echo "FAIL $file :: $msg" >&2
+    [ "$CI_ANNOTATE" -eq 1 ] && echo "::error file=${file}::ClickHouse failed to parse this migration: ${msg}"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "ClickHouse migration syntax check failed." >&2
+  exit 1
+fi
+
+echo "ClickHouse migration syntax check passed (${#files[@]} files)."

--- a/deploy/migrations/clickhouse/lint.sh
+++ b/deploy/migrations/clickhouse/lint.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Lint the ClickHouse migration sets for database-agnosticism.
+#
+# The migration sets under deploy/migrations/clickhouse/<set>/ are applied into a
+# database chosen at apply time (golang-migrate `database=`), so the SQL must never
+# pin a database itself. This linter enforces three invariants on every *.sql file:
+#
+#   1. No `CREATE DATABASE`            -- databases are provisioned by the migrator.
+#   2. No database-qualified idents    -- e.g. `default.foo`; tables are unqualified
+#                                         and resolved via the connection's database=.
+#   3. Distributed() uses currentDatabase() as its database (2nd) argument, never a
+#      hardcoded db name, a string literal, or the {database} macro.
+#
+# Rules 1 and 2 are evaluated against a sanitized view of each file in which `--` /
+# `/* */` comments and single-quoted string literals are blanked out (line numbers
+# preserved), so legitimate dotted text inside COMMENT '...' (e.g. 'ethseer.io')
+# never trips the qualifier check. Rule 3 reconstructs statements by splitting the
+# sanitized text on `;`.
+#
+# Usage: lint.sh [MIGRATIONS_DIR]   (default: dir of this script)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="${1:-$SCRIPT_DIR}"
+
+# Emit GitHub Actions inline annotations when running in CI.
+CI_ANNOTATE=0
+[ "${GITHUB_ACTIONS:-}" = "true" ] && CI_ANNOTATE=1
+
+shopt -s nullglob
+files=("$MIGRATIONS_DIR"/*/*.sql)
+if [ ${#files[@]} -eq 0 ]; then
+  echo "no migration .sql files found under ${MIGRATIONS_DIR}" >&2
+  exit 1
+fi
+
+status=0
+for file in "${files[@]}"; do
+  if ! awk -v file="$file" -v ci="$CI_ANNOTATE" '
+    BEGIN { Q = sprintf("%c", 39) }                             # single-quote char
+    # --- Sanitize one line, carrying string/block-comment state across lines. ---
+    # Blanks out comments and the *contents* of single-quoted strings (quotes kept),
+    # so dotted text inside literals/comments cannot be mistaken for a db qualifier.
+    function sanitize(line,    i, n, c, c2, out) {
+      out = ""; i = 1; n = length(line)
+      while (i <= n) {
+        c = substr(line, i, 1); c2 = substr(line, i + 1, 1)
+        if (in_block) {
+          if (c == "*" && c2 == "/") { in_block = 0; out = out "  "; i += 2; continue }
+          out = out " "; i++; continue
+        }
+        if (in_string) {
+          if (c == "\\") { out = out "  "; i += 2; continue }   # backslash-escaped char
+          if (c == Q)    { in_string = 0; out = out Q; i++; continue }
+          out = out " "; i++; continue                          # blank string content
+        }
+        if (c == "-" && c2 == "-") break                        # -- line comment: drop rest
+        if (c == "/" && c2 == "*") { in_block = 1; out = out "  "; i += 2; continue }
+        if (c == Q) { in_string = 1; out = out Q; i++; continue }
+        out = out c; i++
+      }
+      return out
+    }
+    function report(line, msg) {
+      printf "%s:%d: %s\n", file, line, msg
+      if (ci) printf "::error file=%s,line=%d::%s\n", file, line, msg
+      violations++
+    }
+    function check_stmt(stmt, line,    low) {
+      gsub(/[ \t]+/, " ", stmt)                                 # collapse whitespace
+      low = tolower(stmt)
+      if (low ~ /distributed[ \t]*\(/ &&
+          low !~ /distributed[ \t]*\([^,]*,[ \t]*currentdatabase\(\)/)
+        report(line, "Distributed() must use currentDatabase() as its database argument")
+    }
+    {
+      raw[NR] = $0
+      san[NR] = sanitize($0)
+    }
+    END {
+      violations = 0
+      for (k = 1; k <= NR; k++) {
+        s = san[k]
+        # Rule 1: no CREATE DATABASE.
+        if (tolower(s) ~ /create[ \t]+database/)
+          report(k, "CREATE DATABASE is not allowed (databases are provisioned by the migrator)")
+        # Rule 2: no database-qualified identifiers (db.table).
+        if (match(s, /[A-Za-z_][A-Za-z0-9_]*[ \t]*\.[ \t]*[A-Za-z_]/)) {
+          tok = substr(s, RSTART, RLENGTH)
+          gsub(/[ \t]/, "", tok)
+          report(k, "database-qualified identifier \"" tok "...\" is not allowed (use an unqualified name; the database is chosen at apply time)")
+        }
+      }
+      # Rule 3: reconstruct statements (split on `;`) and check each Distributed().
+      stmt = ""; start = 0
+      for (k = 1; k <= NR; k++) {
+        rest = san[k]
+        while ((p = index(rest, ";")) > 0) {
+          seg = substr(rest, 1, p - 1)
+          if (start == 0 && seg ~ /[^ \t]/) start = k
+          if (start > 0) check_stmt(stmt " " seg, start)
+          stmt = ""; start = 0
+          rest = substr(rest, p + 1)
+        }
+        if (start == 0 && rest ~ /[^ \t]/) start = k
+        stmt = stmt " " rest
+      }
+      if (stmt ~ /[^ \t]/ && start > 0) check_stmt(stmt, start)   # trailing stmt, no `;`
+      exit (violations > 0)
+    }
+  ' "$file"; then
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "ClickHouse migration lint failed: migrations must be database-agnostic." >&2
+  echo "See deploy/migrations/clickhouse/lint.sh for the rules." >&2
+  exit 1
+fi
+
+echo "ClickHouse migration lint passed (${#files[@]} files)."


### PR DESCRIPTION
## Summary

[#847](https://github.com/ethpandaops/xatu/pull/847) split the ClickHouse migrations into per-schema sets that are applied into a database **chosen at apply time** (golang-migrate `database=`). The SQL must therefore stay database-agnostic — never pin a database itself. Nothing currently guards that invariant: a new migration with a hardcoded `default.` qualifier, a stray `CREATE DATABASE`, or a `Distributed` engine pointing at a literal db would sail through CI and only surface later as data landing in the wrong database.

This adds a dedicated, path-filtered workflow (`deploy/migrations/clickhouse/**`) that enforces the invariant on every PR. It runs **two jobs in parallel**:

### 1. `database-agnostic lint` — `deploy/migrations/clickhouse/lint.sh`
Pure bash/awk, **zero dependencies**. Enforces three rules over every `*.sql`:
1. **No `CREATE DATABASE`** — databases are provisioned out-of-band by the migrator.
2. **No database-qualified identifiers** — e.g. `default.foo`; tables are unqualified and resolved via the connection's `database=`.
3. **Every `Distributed(...)` uses `currentDatabase()`** as its database (2nd) argument — never a hardcoded db, a string literal, or the `{database}` macro.

Rules 1–2 run against a **sanitized view** of each file in which `--` / `/* */` comments and single-quoted string *contents* are blanked out (line numbers preserved). This is the key to avoiding false positives: legitimate dotted text inside `COMMENT '...'` (e.g. `'ethseer.io'`, `'(e.g., V1, V2)'`) and the `{database}` macro inside Replicated ZooKeeper paths never trip the qualifier check. Rule 3 reconstructs statements by splitting the sanitized text on `;`. Emits GitHub `::error` inline annotations in CI.

### 2. `clickhouse syntax check` — `deploy/migrations/clickhouse/check-syntax.sh`
Validates every migration parses with the **real ClickHouse parser** via `clickhouse format --multiquery --quiet`, run inside the `clickhouse/clickhouse-server` image (version via `CHVER`, matching docker-compose). Catches malformed SQL before it ever reaches the migrator.

> Note: raises `--max_query_size` past the 256 KiB parser default, which otherwise rejects the valid 364 KiB `xatu/001_init.up.sql`.

## Why two approaches?
A real SQL parser makes the qualifier rule bulletproof but third-party CH parsers lag real ClickHouse syntax (`CODEC`, `MATERIALIZED`, `{cluster}` macros) and would fail-false on valid files. The bash linter is the right weight for three pattern-based rules and matches the repo's existing migration tooling (already bash under `deploy/local/docker-compose/`). The syntax job layers the genuine parser on top purely as a validity gate — best of both.

## Testing
- ✅ Lint + syntax **pass** on all 10 current migration files — locally **and** via the exact `docker run` the workflow uses.
- ✅ Negative tests: lint catches all three violations with correct line numbers, and does **not** false-trip on dotted text in comments/strings or the `{database}` macro in Replicated paths.
- ✅ Syntax check rejects malformed SQL (unbalanced parens) with a `::error` annotation and exit 1.
- ✅ `shellcheck` clean on both scripts; workflow YAML parses.

Both scripts accept an optional `MIGRATIONS_DIR` arg and run locally (`clickhouse` on PATH, override with `CLICKHOUSE_BIN`), so devs can check before pushing:
```sh
./deploy/migrations/clickhouse/lint.sh
./deploy/migrations/clickhouse/check-syntax.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)