### PR TITLE
ci(cannon): ship a cryo-bundled release image for EL cannon

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -87,3 +87,34 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e RELEASE_SUFFIX=${{ env.RELEASE_SUFFIX }} \
             goreleaser/goreleaser-cross:v1.26 release --clean --config .goreleaser.yaml.new
+
+      # The xatu+cryo image is the EL-cannon variant: it bundles the cryo binary
+      # alongside xatu. cryo is built from Rust source (./Dockerfile), so it does
+      # not fit goreleaser's copy-the-prebuilt-binary docker flow — and building
+      # it inside goreleaser would force every PR's test-build to compile cryo.
+      # We build it here, release-only. The cryo ref is pinned in ./Dockerfile
+      # (ARG CRYO_GIT_REF); that layer is cache-stable, so GHA layer cache means
+      # cryo only recompiles when the pinned ref changes.
+      - name: Derive cryo image version
+        run: |
+          echo "CRYO_GIT_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          # Match goreleaser's {{ .Version }} (tag with a single leading 'v' stripped).
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "CRYO_IMAGE_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+      - name: Build and push xatu+cryo image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          sbom: false
+          build-args: |
+            VERSION=${{ env.CRYO_IMAGE_VERSION }}
+            GIT_COMMIT=${{ env.CRYO_GIT_COMMIT }}
+          tags: |
+            ethpandaops/xatu:${{ env.CRYO_IMAGE_VERSION }}-cryo
+            ethpandaops/xatu:${{ env.RELEASE_SUFFIX && format('{0}-cryo-latest', env.RELEASE_SUFFIX) || 'cryo-latest' }}
+          cache-from: type=gha,scope=xatu-cryo
+          cache-to: type=gha,mode=max,scope=xatu-cryo

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,21 @@ WORKDIR /src
 COPY go.sum go.mod ./
 RUN go mod download
 COPY . .
-RUN go build -o /bin/app .
+# Version metadata is injected at release time (see .github/workflows/goreleaser.yaml);
+# local/CI builds fall back to dev defaults. GOOS/GOARCH come from BuildKit's
+# predefined platform args so the multi-arch release build stamps the right
+# values under QEMU emulation.
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+RUN go build \
+  -ldflags="-s -w \
+  -X github.com/ethpandaops/xatu/pkg/proto/xatu.Release=${VERSION} \
+  -X github.com/ethpandaops/xatu/pkg/proto/xatu.GitCommit=${GIT_COMMIT} \
+  -X github.com/ethpandaops/xatu/pkg/proto/xatu.GOOS=${TARGETOS} \
+  -X github.com/ethpandaops/xatu/pkg/proto/xatu.GOARCH=${TARGETARCH}" \
+  -o /bin/app .
 
 # cryo is the execution-layer extractor used by EL cannon. We build from git
 # (matching ethpandaops/base-images clickhouse-tools, the source of the legacy
@@ -11,7 +25,10 @@ RUN go build -o /bin/app .
 # 0.3.2 crates.io release omits. cryo's column output is the schema contract for
 # the canonical_execution_* routes, and the state-read datasets' semantics vary
 # across cryo versions, so we PIN to a specific commit for reproducible builds
-# and stable data. Override CRYO_GIT_REF at build time to bump it deliberately.
+# and stable data. This ARG line is the single place the cryo ref is pinned:
+# every build path (docker build, docker compose, `make docker`, and the
+# release cryo image) builds this Dockerfile, so bump it here to upgrade cryo
+# everywhere. Override with --build-arg CRYO_GIT_REF=<ref> for ad-hoc testing.
 FROM rust:1-bookworm AS cryo-builder
 ARG CRYO_GIT_REF=559b65455d7ef6b03e8e9e96a0e50fd4fe8a9c86
 RUN cargo install --git https://github.com/paradigmxyz/cryo --rev "${CRYO_GIT_REF}" --locked cryo_cli

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@ clickhouse-routes:
 	@echo "Generating ClickHouse route code (requires Docker)..."
 	go run ./pkg/clickhouse/route/cmd/generate
 
+.PHONY: docker
+# Build the local all-in-one image (xatu + cryo, for EL cannon). The cryo git
+# ref is pinned in the Dockerfile (ARG CRYO_GIT_REF); override with
+# --build-arg CRYO_GIT_REF=<ref> to test a different cryo build.
+docker:
+	docker build -t ethpandaops/xatu:local .
+
 proto:
 	@echo "Buf generate:" ; \
 	echo "-----------------" ; \


### PR DESCRIPTION
## Problem

EL cannon shells out to the third-party [`cryo`](https://github.com/paradigmxyz/cryo) binary at runtime (`pkg/cryo/cryo.go` — `exec.CommandContext`, `BinaryPath` defaults to `"cryo"` on `$PATH`), but **the goreleaser-published images never contained it.**

The cannon PR (#850) only added cryo to the local `Dockerfile`. goreleaser builds its images from `goreleaser-scratch.Dockerfile` (distroless) and `goreleaser-debian.Dockerfile` — neither bundles cryo. So EL cannon fails the moment it execs cryo in any released image:

```
cryo: executable file not found in $PATH
```

## What this does

Adds a **third release image variant — xatu + cryo** — built release-only.

| Tag | Base | cryo? | For |
|-----|------|-------|-----|
| `:VERSION`, `:latest` | distroless scratch | ❌ | everything non-cannon (unchanged) |
| `:VERSION-debian`, `:debian-latest` | debian | ❌ | unchanged |
| **`:VERSION-cryo`, `:cryo-latest`** | debian + cryo | ✅ | **EL cannon** |

> ⚠️ **Operators must point EL cannon at the `-cryo` tag** (`:cryo-latest` / `:VERSION-cryo`). `:latest` deliberately stays cryo-free and lean.

## Design decisions

**Why a separate `build-push-action` step instead of a `.goreleaser.yaml` docker entry:**

1. **distroless can't carry cryo.** The scratch image (`gcr.io/distroless/cc-debian12`, behind `:latest`) lacks the `libssl`/`libcrypto` cryo links against; debian can carry it cleanly.
2. **`dockers.skip` isn't a valid goreleaser field** (verified — errors even on v2.16), so a cryo entry in `.goreleaser.yaml` couldn't be gated. It would build on **every PR** via `test-build.yaml`, compiling cryo from Rust source (incl. `arm64`-under-QEMU) and adding **30–60 min** to PR CI.

So the cryo image is built in `goreleaser.yaml` (**tag/release only**), reusing `./Dockerfile` (which already does Go-build + cryo-build). The pinned cryo layer is cache-stable → GHA layer cache compiles cryo **once** and reuses it across releases until the pinned ref changes.

**Single source of truth for the cryo ref:** `./Dockerfile` is the *only* Dockerfile that builds cryo, and every path builds it — `docker build`, `docker compose up`, `make docker`, the smoke tests, and the release image. So the **`ARG CRYO_GIT_REF` default in that one file** is the single place to bump cryo.

> 🔁 An earlier revision of this PR moved the ref into a `.cryo-version` file injected as a build-arg. That broke `docker compose up`: `docker-compose.yml` builds the xatu image (3 services) from `./Dockerfile` **without** passing the arg, so a no-default Dockerfile tripped a guard. The `ARG` default is the robust single source that works for every path, including compose.

**Version parity:** `./Dockerfile` now stamps version ldflags (`Release`/`GitCommit`/`GOOS`/`GOARCH`) via `VERSION`/`GIT_COMMIT`/`TARGET*` build-args, so the released cryo image reports its tag like the other images (defaults `dev`/`unknown` for local/CI/compose builds).

## Files (net diff vs `master`: 3 files)

- `.github/workflows/goreleaser.yaml` — release-only multi-arch cryo build + push
- `Dockerfile` — version ldflags; the cryo `ARG CRYO_GIT_REF` default is **unchanged from master**, so compose/smoke-tests behave exactly as before
- `Makefile` — `make docker` convenience target

## Testing

Verified locally via `make docker` (**no build-arg — the same path `docker compose up` uses**):

- ✅ Image builds (exit 0, **248 MB**)
- ✅ cryo compiles at the pinned ref → `cryo 559b654`
- ✅ cryo on `$PATH` (`/usr/local/bin/cryo`); `libssl.so.3` + `libcrypto.so.3` resolve in-image
- ✅ Version ldflags inject → `Xatu/dev-unknown/linux/amd64`
- ✅ `xatu cannon` and `xatu version` subcommands work
- ✅ Release-tag computation simulated for plain / suffix / no-`v` tags → `:0.0.44-cryo`+`:cryo-latest`, `:0.0.45-dencun-cryo`+`:dencun-cryo-latest`

**Not covered locally** (CI-only): the `arm64`-under-QEMU compile (release builds both arches; local is native amd64), the goreleaser workflow run itself, and cross-release GHA cache behavior.

## History

The first push of this PR added a `.cryo-version` single-source file + a Dockerfile guard, which **broke the cannon/sentry smoke tests** because `docker compose up` builds the xatu image without that build-arg. Reverted to the `ARG` default approach (see the 🔁 note above); the smoke tests and `.cryo-version` are back to `master` state.

## Heads-up

- **First release after merge is slow** (cryo compiles fresh for amd64 + arm64/QEMU); subsequent releases hit the layer cache. The amd64 cryo compile was ~80 s locally; arm64/QEMU is the long pole. If cannon never runs on arm64, dropping `linux/arm64` from that one `platforms:` line roughly halves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
