### PR TITLE
ci(cannon): build the cryo release image amd64-only

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -95,6 +95,11 @@ jobs:
       # We build it here, release-only. The cryo ref is pinned in ./Dockerfile
       # (ARG CRYO_GIT_REF); that layer is cache-stable, so GHA layer cache means
       # cryo only recompiles when the pinned ref changes.
+      #
+      # amd64-only: EL cannon runs on amd64 servers, and compiling cryo for
+      # arm64 under QEMU emulation takes 30-60+ min (it hung a release for
+      # 35+ min). Native amd64 compiles in ~2-3 min. Add linux/arm64 back here
+      # only if cannon ever needs to run on arm64.
       - name: Derive cryo image version
         run: |
           echo "CRYO_GIT_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
@@ -106,7 +111,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           provenance: false
           sbom: false


### PR DESCRIPTION
## What happened

The cryo release-image step added in #853 builds with `platforms: linux/amd64,linux/arm64`. The `arm64` half compiles cryo from Rust source **under QEMU emulation**, which **hung the v1.18.1 release for 35+ min** on a cold cache.

Important: v1.18.1 itself shipped fine — goreleaser had already published the GitHub release and the `:v1.18.1` (scratch) and `:v1.18.1-debian` images (`Run GoReleaser in Docker` completed in ~6 min). Only the trailing `Build and push xatu+cryo image` step was stuck, and it was cancelled.

## Fix

Drop `linux/arm64` from the **cryo image only**:

```diff
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
```

EL cannon is a server-side data pipeline that runs on amd64, so the arm64 cryo image is dead weight. Native amd64 compiles cryo in ~2-3 min — no emulation, no hang. The other two variants (scratch, debian) stay multi-arch via goreleaser; only the cryo variant is amd64-only. Add `linux/arm64` back if cannon ever needs to run on arm64.

## Note on v1.18.1's cryo image

Because the step was cancelled, **no `:v1.18.1-cryo` / `:cryo-latest` image was published** for that release. After this merges, the next tagged release will produce them quickly. (If you want a cryo image for v1.18.1 specifically, cut a v1.18.2 — re-running the v1.18.1 workflow would have goreleaser collide with the existing GitHub release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)