### PR TITLE
ci(cannon): cache the cryo build in a registry image, not GHA cache

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -93,8 +93,16 @@ jobs:
       # not fit goreleaser's copy-the-prebuilt-binary docker flow — and building
       # it inside goreleaser would force every PR's test-build to compile cryo.
       # We build it here, release-only. The cryo ref is pinned in ./Dockerfile
-      # (ARG CRYO_GIT_REF); that layer is cache-stable, so GHA layer cache means
-      # cryo only recompiles when the pinned ref changes.
+      # (ARG CRYO_GIT_REF); that layer is cache-stable, so it only recompiles
+      # when the pinned ref changes.
+      #
+      # Cache is a registry image (ethpandaops/xatu:cryo-buildcache), NOT GHA
+      # cache: GHA cache is scoped per git ref, and releases are tag-triggered,
+      # so a v1.18.2 run could not read the v1.18.1 run's cache (only its own
+      # ref + the default branch). Registry cache is ref-agnostic, so every
+      # release reuses the prior cryo-builder layer and skips the ~10 min Rust
+      # compile until CRYO_GIT_REF changes (which invalidates that layer and
+      # recompiles once, then re-warms the cache).
       #
       # amd64-only: EL cannon runs on amd64 servers, and compiling cryo for
       # arm64 under QEMU emulation takes 30-60+ min (it hung a release for
@@ -121,5 +129,5 @@ jobs:
           tags: |
             ethpandaops/xatu:${{ env.CRYO_IMAGE_VERSION }}-cryo
             ethpandaops/xatu:${{ env.RELEASE_SUFFIX && format('{0}-cryo-latest', env.RELEASE_SUFFIX) || 'cryo-latest' }}
-          cache-from: type=gha,scope=xatu-cryo
-          cache-to: type=gha,mode=max,scope=xatu-cryo
+          cache-from: type=registry,ref=ethpandaops/xatu:cryo-buildcache
+          cache-to: type=registry,ref=ethpandaops/xatu:cryo-buildcache,mode=max,ignore-error=true


### PR DESCRIPTION
## Problem

The cryo release-image step (#853) used `cache-to/from: type=gha` to reuse the expensive `cryo-builder` layer across releases. But **GHA cache is scoped per git ref**, and releases are tag-triggered: a `v1.18.2` run can only restore caches from its own ref or the default branch — never from `refs/tags/v1.18.1`. So every release got a **cache miss** and recompiled cryo from Rust source (~10 min). The v1.18.1 release confirmed this (cold ~11.7 min compile).

## Fix

Use **registry cache** instead — stored as an image in DockerHub, ref-agnostic, so every release can pull it:

```diff
-          cache-from: type=gha,scope=xatu-cryo
-          cache-to: type=gha,mode=max,scope=xatu-cryo
+          cache-from: type=registry,ref=ethpandaops/xatu:cryo-buildcache
+          cache-to: type=registry,ref=ethpandaops/xatu:cryo-buildcache,mode=max,ignore-error=true
```

Now each release reuses the prior `cryo-builder` layer and skips the Rust compile; a release becomes roughly Go build + image push (**~2-4 min**, dominated by the normal xatu compile, not cryo).

## Behaviour

- **First release after merge:** cold — full cryo compile (~10 min), then writes `cryo-buildcache`.
- **Every release after that (same cryo ref):** cache hit, cryo compile skipped.
- **Bumping `CRYO_GIT_REF` in `./Dockerfile`:** changes the `cryo-builder` RUN instruction → invalidates *that* layer → cryo recompiles **once** with the new ref → cache-to re-warms the buildcache → fast again.

## Notes

- `cache-to` uses `ignore-error=true` so a cache-export hiccup can never fail an actual release.
- A `cryo-buildcache` tag will appear in the `ethpandaops/xatu` DockerHub repo — that's the BuildKit cache manifest, **not a runnable image**.
- Requires the docker-container buildx driver (already set up in this job via `setup-buildx-action`) and DockerHub push auth (already logged in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)