### PR TITLE
ci: reuse the cryo registry buildcache in the smoke tests

### DIFF
--- a/.github/workflows/cannon-smoke-test.yaml
+++ b/.github/workflows/cannon-smoke-test.yaml
@@ -49,7 +49,12 @@ jobs:
         context: .
         load: true
         tags: ethpandaops/xatu:local
-        cache-from: type=gha
+        # Pull the cryo-builder layer from the release pipeline's registry
+        # buildcache so a cold PR branch reuses the prebuilt cryo instead of
+        # recompiling it (~10 min). Read-only: PRs keep writing only gha cache.
+        cache-from: |
+          type=gha
+          type=registry,ref=ethpandaops/xatu:cryo-buildcache
         cache-to: type=gha,mode=max
     - name: Fetch finalized epoch from beacon node
       id: beacon

--- a/.github/workflows/sentry-smoke-test.yaml
+++ b/.github/workflows/sentry-smoke-test.yaml
@@ -70,7 +70,12 @@ jobs:
         context: .
         load: true
         tags: ethpandaops/xatu:local
-        cache-from: type=gha
+        # Pull the cryo-builder layer from the release pipeline's registry
+        # buildcache so a cold PR branch reuses the prebuilt cryo instead of
+        # recompiling it (~10 min). Read-only: PRs keep writing only gha cache.
+        cache-from: |
+          type=gha
+          type=registry,ref=ethpandaops/xatu:cryo-buildcache
         cache-to: type=gha,mode=max
     - name: Build sentry-logs image
       if: steps.canary.outputs.skip != 'true'


### PR DESCRIPTION
## Context

Follow-up to #855. The release pipeline now caches the expensive `cryo-builder` layer in a registry image (`ethpandaops/xatu:cryo-buildcache`). But the **cannon** and **sentry** smoke tests build the same `./Dockerfile` with only `cache-from: type=gha` — their own per-branch GitHub Actions cache, separate from that registry buildcache.

Result: the **first smoke-test run on each new PR branch recompiles cryo from Rust source (~10 min)**, because a fresh branch's gha cache is cold (and master doesn't run smoke tests to seed it).

## Change

Add the registry buildcache as a **read-only** `cache-from` source on both xatu image builds:

```diff
-        cache-from: type=gha
+        cache-from: |
+          type=gha
+          type=registry,ref=ethpandaops/xatu:cryo-buildcache
         cache-to: type=gha,mode=max
```

Now a smoke test pulls the prebuilt `cryo-builder` layer from the registry and skips the compile. `type=gha` is kept first so the fast-changing Go-builder layer still caches per-branch across pushes; the registry source supplies the stable cryo layer.

## Safety / scope

- **Read-only:** `cache-to` is unchanged (still gha only). PRs never write the shared release buildcache — no risk of a PR poisoning it, and fork PRs need no auth (the cache image is public, pull-only).
- **Correctness on ref bump:** if a PR changes `CRYO_GIT_REF`, the `cryo-builder` layer's cache key no longer matches the registry cache → it correctly recompiles with the new ref.
- The **sentry-logs** image build is untouched (different Dockerfile, no cryo).

## Caveat

The benefit only applies once `cryo-buildcache` exists for the current cryo ref — which it now does (populated by the v1.18.2 release). If `CRYO_GIT_REF` is bumped, the first PR/release on the new ref recompiles once and re-warms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)