### PR TITLE
ci(cannon): migrate smoke-test config to nested derivers/ethereum schema

### DIFF
--- a/.github/workflows/cannon-smoke-test.yaml
+++ b/.github/workflows/cannon-smoke-test.yaml
@@ -232,38 +232,52 @@ jobs:
         labels:
           ethpandaops: rocks
 
-        # Only enable derivers for event types we're testing
+        # Derivers are grouped by layer (consensus/execution). Consensus
+        # derivers default to enabled:true, so every deriver this test does NOT
+        # assert must be explicitly disabled. Execution (cryo) derivers default
+        # to enabled:false and are omitted entirely — this test is consensus-only,
+        # so no ethereum.execution / EL RPC is required.
         derivers:
-          attesterSlashing:
-            enabled: false
-          blsToExecutionChange:
-            enabled: false
-          deposit:
-            enabled: false
-          withdrawal:
-            enabled: true
-          executionTransaction:
-            enabled: true
-          proposerSlashing:
-            enabled: false
-          voluntaryExit:
-            enabled: false
-          beaconBlock:
-            enabled: true
-          beaconBlobSidecar:
-            enabled: true
-          proposerDuty:
-            enabled: true
-          beaconCommittee:
-            enabled: true
+          consensus:
+            withdrawal:
+              enabled: true
+            executionTransaction:
+              enabled: true
+            beaconBlock:
+              enabled: true
+            beaconBlobSidecar:
+              enabled: true
+            proposerDuty:
+              enabled: true
+            beaconCommittee:
+              enabled: true
+            attesterSlashing:
+              enabled: false
+            proposerSlashing:
+              enabled: false
+            blsToExecutionChange:
+              enabled: false
+            deposit:
+              enabled: false
+            voluntaryExit:
+              enabled: false
+            elaboratedAttestation:
+              enabled: false
+            beaconValidators:
+              enabled: false
+            beaconSyncCommittee:
+              enabled: false
+            beaconBlockSyncAggregate:
+              enabled: false
 
         ntpServer: time.google.com
 
         ethereum:
-          beaconNodeAddress: "https://mainnet-archive-lb-bn.utility.production.platform.ethpandaops.io"
-          beaconNodeHeaders:
-            Authorization: "AUTH_HEADER"
           overrideNetworkName: "$NETWORK_NAME"
+          beacon:
+            address: "https://mainnet-archive-lb-bn.utility.production.platform.ethpandaops.io"
+            headers:
+              Authorization: "AUTH_HEADER"
         coordinator:
           address: xatu-server:8080
 


### PR DESCRIPTION
## Problem

cannon-smoke-test has been **failing on every PR** since the breaking cannon refactors landed on master:
- `70a3e07e refactor(cannon)!: nest ethereum config into beacon/execution`
- `d59d4b1e refactor(cannon)!: group derivers by layer`

Those renamed cannon config keys, but `cannon-smoke-test.yaml`'s inline config still used the **old flat keys**, so cannon fataled at startup:

```
{"level":"fatal","msg":"ethereum.beacon.address is required"}
xatu-cannon  Exited (1)
```

→ 0 rows ever reached ClickHouse → `Verify Clickhouse has data` timed out at 15 min. master doesn't run the smoke test (`pull_request` only), so nothing caught the regression — it's been failing on `feat/cannon-fulu-data`, `feat/execution-cannon`, and every other recent branch.

## Fix — migrate the embedded cannon config

- **`derivers.*` → `derivers.consensus.*`** (layer grouping). Consensus derivers default to `enabled:true` (confirmed in the structs: `` `yaml:"enabled" default:"true"` ``), so every deriver the test does *not* assert is now **explicitly disabled** — including the new ones (`elaboratedAttestation`, `beaconValidators`, `beaconSyncCommittee`, `beaconBlockSyncAggregate`). The six enabled derivers still match `seeding.yaml` exactly.
- **`derivers.execution` omitted entirely** — execution derivers default to `enabled:false`, so `AnyEnabled()` stays false and **no `ethereum.execution.address` / cryo / EL RPC is required** (this test is consensus-only).
- **`ethereum.beaconNodeAddress` → `ethereum.beacon.address`** and **`ethereum.beaconNodeHeaders` → `ethereum.beacon.headers`**.

## Verification

Ran the built image's cannon against the migrated config locally:

```
✓ Loaded config
✓ Routing engine initialized (clickhouse)
✓ Overriding network name "mainnet"
✓ Starting Xatu in cannon mode 💣
✗ fatal: dial tcp: lookup xatu-clickhouse-01 ... no such host   ← expected, no stack in a standalone run
```

No config fatal — the `ethereum.beacon.address is required` startup crash is gone; it now proceeds to real startup.

## Scope

- Touches only `cannon-smoke-test.yaml` (the inline config). No app/Go changes.
- This is the master-level blocker for **all** PRs' cannon-smoke-test, independent of the recent cryo image/cache PRs (#853–#856).

🤖 Generated with [Claude Code](https://claude.com/claude-code)