### PR TITLE
fix(cryo): capture cryo's stdout so failures report the actual error

### DIFF
--- a/pkg/cryo/cryo.go
+++ b/pkg/cryo/cryo.go
@@ -140,10 +140,14 @@ func (r *Runner) Collect(ctx context.Context, dataset string, from, to uint64, c
 		args = append(args, columns...)
 	}
 
-	var stderr bytes.Buffer
+	// cryo reports failures on stdout (its stderr is typically empty), so capture
+	// both and surface them in the error — otherwise a failed run logs only the
+	// opaque "exit status 1" with no cause.
+	var stdout, stderr bytes.Buffer
 
 	//nolint:gosec // cryo binary path and args derive from operator config, not untrusted user input.
 	cmd := exec.CommandContext(ctx, r.cfg.BinaryPath, args...)
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	r.log.WithFields(logrus.Fields{
@@ -155,7 +159,7 @@ func (r *Runner) Collect(ctx context.Context, dataset string, from, to uint64, c
 	if runErr := cmd.Run(); runErr != nil {
 		_ = os.RemoveAll(dir)
 
-		return nil, fmt.Errorf("cryo %s [%d:%d] failed: %w: %s", dataset, from, to, runErr, stderr.String())
+		return nil, fmt.Errorf("cryo %s [%d:%d] failed: %w: %s", dataset, from, to, runErr, cryoOutput(&stdout, &stderr))
 	}
 
 	files, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
@@ -166,6 +170,23 @@ func (r *Runner) Collect(ctx context.Context, dataset string, from, to uint64, c
 	}
 
 	return &Collection{Dir: dir, Files: files}, nil
+}
+
+// cryoOutput combines cryo's stdout and stderr for error reporting. cryo writes
+// its failure message to stdout, so that comes first; stderr is appended only
+// when non-empty. Either buffer may be empty.
+func cryoOutput(stdout, stderr *bytes.Buffer) string {
+	out := strings.TrimSpace(stdout.String())
+	errOut := strings.TrimSpace(stderr.String())
+
+	switch {
+	case out != "" && errOut != "":
+		return out + "; stderr: " + errOut
+	case errOut != "":
+		return errOut
+	default:
+		return out
+	}
 }
 
 // ReadParquet reads every supplied parquet file into a slice of T. T must be a

--- a/pkg/cryo/cryo_test.go
+++ b/pkg/cryo/cryo_test.go
@@ -1,0 +1,49 @@
+package cryo
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCryoOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "stdout only (cryo's normal failure path)",
+			stdout: "Failed to get block: error sending request\n",
+			stderr: "",
+			want:   "Failed to get block: error sending request",
+		},
+		{
+			name:   "stderr only",
+			stdout: "",
+			stderr: "some stderr message\n",
+			want:   "some stderr message",
+		},
+		{
+			name:   "both populated",
+			stdout: "stdout cause",
+			stderr: "stderr detail",
+			want:   "stdout cause; stderr: stderr detail",
+		},
+		{
+			name:   "both empty",
+			stdout: "",
+			stderr: "  \n",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cryoOutput(bytes.NewBufferString(tt.stdout), bytes.NewBufferString(tt.stderr))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The EL cannon was logging useless errors for the trace-based datasets:

```
cryo storage_reads [25385378:25385427] failed: exit status 1:
cryo balance_diffs [25385428:25385428] failed: exit status 1:
cryo nonce_reads   [25385378:25385427] failed: exit status 1:
```

— `exit status 1:` with **no message**, making the failures undiagnosable in production.

Root cause: **cryo writes its failure message to stdout, not stderr.** Confirmed against the built image:

```
$ cryo storage_reads --blocks ... --rpc http://127.0.0.1:9999 ...
exit=1
STDOUT (76 bytes): Failed to get block: error sending request for url (http://127.0.0.1:9999/)
STDERR (0 bytes):
```

`Collect` only captured `cmd.Stderr` (empty), so the real cause was discarded.

## Fix

Capture stdout alongside stderr and surface both in the wrapped error, via a small `cryoOutput` helper (stdout first — that's where cryo's error lands — stderr appended only when non-empty). cryo's parquet output goes to `--output-dir` files, so its stdout is just bounded progress/error text and is safe to buffer.

```go
var stdout, stderr bytes.Buffer
cmd.Stdout = &stdout
cmd.Stderr = &stderr
...
return nil, fmt.Errorf("cryo %s [%d:%d] failed: %w: %s", dataset, from, to, runErr, cryoOutput(&stdout, &stderr))
```

## Context / why it matters

While debugging the live `xatu-cannon-mainnet-el` pod: the EL node (reth, full trace support) and cryo are both fine — the failing datasets succeed standalone (the exact failing 50-block `storage_reads` range returns 131k rows, exit 0). The pod failures are **transient RPC contention** from fanning out all the heavy state-read/diff derivers at one shared reth. But that was only diagnosable *after* seeing cryo's real error — which this PR makes possible. Follow-up tuning (`requestsPerSecond` / `maxConcurrentChunks` / dedicated RPC) can then be driven by the actual surfaced errors.

## Tests

- `go build`, `go vet`, `go test -race` ✓
- `golangci-lint run --new-from-rev=origin/master` → 0 issues
- Added a table-driven test for `cryoOutput` (stdout-only / stderr-only / both / empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)