### PR TITLE
fix(route): drop silent zero fallbacks for absent required fields

### DIFF
--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_beacon_blob.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_beacon_blob.go
@@ -81,27 +81,11 @@ func (b *beaconApiEthV1BeaconBlobBatch) appendRuntime(event *xatu.DecoratedEvent
 
 func (b *beaconApiEthV1BeaconBlobBatch) appendPayload(event *xatu.DecoratedEvent) {
 	blob := event.GetEthV1BeaconBlob()
-	if slot := blob.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(blob.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.BlockRoot.Append([]byte(blob.GetBlockRoot()))
 	b.BlockParentRoot.Append([]byte(blob.GetBlockParentRoot()))
-
-	if proposerIndex := blob.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue())) //nolint:gosec // proposer index fits uint32
-	} else {
-		b.ProposerIndex.Append(0)
-	}
-
-	if index := blob.GetIndex(); index != nil {
-		b.BlobIndex.Append(index.GetValue())
-	} else {
-		b.BlobIndex.Append(0)
-	}
-
+	b.ProposerIndex.Append(uint32(blob.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
+	b.BlobIndex.Append(blob.GetIndex().GetValue())
 	b.KzgCommitment.Append([]byte(blob.GetKzgCommitment()))
 	b.VersionedHash.Append([]byte(blob.GetVersionedHash()))
 }

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_beacon_committee.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_beacon_committee.go
@@ -71,6 +71,10 @@ func (b *beaconApiEthV1BeaconCommitteeBatch) validate(event *xatu.DecoratedEvent
 		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetIndex() == nil {
+		return fmt.Errorf("nil Index: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 
@@ -86,17 +90,8 @@ func (b *beaconApiEthV1BeaconCommitteeBatch) appendRuntime(event *xatu.Decorated
 
 func (b *beaconApiEthV1BeaconCommitteeBatch) appendPayload(event *xatu.DecoratedEvent) {
 	committee := event.GetEthV1BeaconCommittee()
-	if slot := committee.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if committeeIndex := committee.GetIndex(); committeeIndex != nil {
-		b.CommitteeIndex.Append(strconv.FormatUint(committeeIndex.GetValue(), 10))
-	} else {
-		b.CommitteeIndex.Append("")
-	}
+	b.Slot.Append(uint32(committee.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
+	b.CommitteeIndex.Append(strconv.FormatUint(committee.GetIndex().GetValue(), 10))
 
 	validators := committee.GetValidators()
 	if len(validators) > 0 {

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_attestation.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_attestation.go
@@ -66,16 +66,18 @@ func (b *beaconApiEthV1EventsAttestationBatch) validate(event *xatu.DecoratedEve
 		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
 	}
 
-	if source := data.GetSource(); source != nil {
-		if source.GetEpoch() == nil {
-			return fmt.Errorf("nil SourceEpoch: %w", route.ErrInvalidEvent)
-		}
+	if data.GetIndex() == nil {
+		return fmt.Errorf("nil CommitteeIndex: %w", route.ErrInvalidEvent)
 	}
 
-	if target := data.GetTarget(); target != nil {
-		if target.GetEpoch() == nil {
-			return fmt.Errorf("nil TargetEpoch: %w", route.ErrInvalidEvent)
-		}
+	source := data.GetSource()
+	if source == nil || source.GetEpoch() == nil {
+		return fmt.Errorf("nil SourceEpoch: %w", route.ErrInvalidEvent)
+	}
+
+	target := data.GetTarget()
+	if target == nil || target.GetEpoch() == nil {
+		return fmt.Errorf("nil TargetEpoch: %w", route.ErrInvalidEvent)
 	}
 
 	return nil
@@ -96,57 +98,17 @@ func (b *beaconApiEthV1EventsAttestationBatch) appendPayload(event *xatu.Decorat
 	b.AggregationBits.Append(attestationV2.GetAggregationBits())
 
 	data := attestationV2.GetData()
-	if data == nil {
-		b.Slot.Append(0)
-		b.CommitteeIndex.Append("")
-		b.BeaconBlockRoot.Append(nil)
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-
-		return
-	}
-
-	if slot := data.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if committeeIndex := data.GetIndex(); committeeIndex != nil {
-		b.CommitteeIndex.Append(strconv.FormatUint(committeeIndex.GetValue(), 10))
-	} else {
-		b.CommitteeIndex.Append("")
-	}
-
+	b.Slot.Append(uint32(data.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
+	b.CommitteeIndex.Append(strconv.FormatUint(data.GetIndex().GetValue(), 10))
 	b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
 
-	if source := data.GetSource(); source != nil {
-		if sourceEpoch := source.GetEpoch(); sourceEpoch != nil {
-			b.SourceEpoch.Append(uint32(sourceEpoch.GetValue())) //nolint:gosec // epoch fits uint32
-		} else {
-			b.SourceEpoch.Append(0)
-		}
+	source := data.GetSource()
+	b.SourceEpoch.Append(uint32(source.GetEpoch().GetValue())) //nolint:gosec // epoch fits uint32
+	b.SourceRoot.Append([]byte(source.GetRoot()))
 
-		b.SourceRoot.Append([]byte(source.GetRoot()))
-	} else {
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-	}
-
-	if target := data.GetTarget(); target != nil {
-		if targetEpoch := target.GetEpoch(); targetEpoch != nil {
-			b.TargetEpoch.Append(uint32(targetEpoch.GetValue())) //nolint:gosec // epoch fits uint32
-		} else {
-			b.TargetEpoch.Append(0)
-		}
-
-		b.TargetRoot.Append([]byte(target.GetRoot()))
-	} else {
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-	}
+	target := data.GetTarget()
+	b.TargetEpoch.Append(uint32(target.GetEpoch().GetValue())) //nolint:gosec // epoch fits uint32
+	b.TargetRoot.Append([]byte(target.GetRoot()))
 }
 
 func (b *beaconApiEthV1EventsAttestationBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_blob_sidecar.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_blob_sidecar.go
@@ -79,20 +79,9 @@ func (b *beaconApiEthV1EventsBlobSidecarBatch) appendRuntime(event *xatu.Decorat
 
 func (b *beaconApiEthV1EventsBlobSidecarBatch) appendPayload(event *xatu.DecoratedEvent) {
 	sidecar := event.GetEthV1EventsBlobSidecar()
-	if slot := sidecar.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(sidecar.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.BlockRoot.Append([]byte(sidecar.GetBlockRoot()))
-
-	if index := sidecar.GetIndex(); index != nil {
-		b.BlobIndex.Append(index.GetValue())
-	} else {
-		b.BlobIndex.Append(0)
-	}
-
+	b.BlobIndex.Append(sidecar.GetIndex().GetValue())
 	b.KzgCommitment.Append([]byte(sidecar.GetKzgCommitment()))
 	b.VersionedHash.Append([]byte(sidecar.GetVersionedHash()))
 }

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_block.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_block.go
@@ -75,12 +75,7 @@ func (b *beaconApiEthV1EventsBlockBatch) appendRuntime(event *xatu.DecoratedEven
 
 func (b *beaconApiEthV1EventsBlockBatch) appendPayload(event *xatu.DecoratedEvent) {
 	blockV2 := event.GetEthV1EventsBlockV2()
-	if slot := blockV2.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(blockV2.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.Block.Append([]byte(blockV2.GetBlock()))
 	b.ExecutionOptimistic.Append(blockV2.GetExecutionOptimistic())
 }

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_block_gossip.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_block_gossip.go
@@ -75,12 +75,7 @@ func (b *beaconApiEthV1EventsBlockGossipBatch) appendRuntime(event *xatu.Decorat
 
 func (b *beaconApiEthV1EventsBlockGossipBatch) appendPayload(event *xatu.DecoratedEvent) {
 	gossip := event.GetEthV1EventsBlockGossip()
-	if slot := gossip.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(gossip.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.Block.Append([]byte(gossip.GetBlock()))
 }
 

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_chain_reorg.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_chain_reorg.go
@@ -79,18 +79,8 @@ func (b *beaconApiEthV1EventsChainReorgBatch) appendRuntime(event *xatu.Decorate
 
 func (b *beaconApiEthV1EventsChainReorgBatch) appendPayload(event *xatu.DecoratedEvent) {
 	chainReorgV2 := event.GetEthV1EventsChainReorgV2()
-	if slot := chainReorgV2.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if depth := chainReorgV2.GetDepth(); depth != nil {
-		b.Depth.Append(uint16(depth.GetValue())) //nolint:gosec // depth fits uint16
-	} else {
-		b.Depth.Append(0)
-	}
-
+	b.Slot.Append(uint32(chainReorgV2.GetSlot().GetValue()))   //nolint:gosec // slot fits uint32
+	b.Depth.Append(uint16(chainReorgV2.GetDepth().GetValue())) //nolint:gosec // depth fits uint16
 	b.OldHeadBlock.Append([]byte(chainReorgV2.GetOldHeadBlock()))
 	b.NewHeadBlock.Append([]byte(chainReorgV2.GetNewHeadBlock()))
 	b.OldHeadState.Append([]byte(chainReorgV2.GetOldHeadState()))

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_contribution_and_proof.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_contribution_and_proof.go
@@ -68,10 +68,17 @@ func (b *beaconApiEthV1EventsContributionAndProofBatch) validate(
 		return fmt.Errorf("nil AggregatorIndex: %w", route.ErrInvalidEvent)
 	}
 
-	if contribution := message.GetContribution(); contribution != nil {
-		if contribution.GetSlot() == nil {
-			return fmt.Errorf("nil ContributionSlot: %w", route.ErrInvalidEvent)
-		}
+	contribution := message.GetContribution()
+	if contribution == nil {
+		return fmt.Errorf("nil Contribution: %w", route.ErrInvalidEvent)
+	}
+
+	if contribution.GetSlot() == nil {
+		return fmt.Errorf("nil ContributionSlot: %w", route.ErrInvalidEvent)
+	}
+
+	if contribution.GetSubcommitteeIndex() == nil {
+		return fmt.Errorf("nil ContributionSubcommitteeIndex: %w", route.ErrInvalidEvent)
 	}
 
 	return nil
@@ -92,51 +99,13 @@ func (b *beaconApiEthV1EventsContributionAndProofBatch) appendPayload(event *xat
 	b.Signature.Append(eventContributionV2.GetSignature())
 
 	message := eventContributionV2.GetMessage()
-	if message == nil {
-		b.AggregatorIndex.Append(0)
-		b.SelectionProof.Append("")
-		b.ContributionSlot.Append(0)
-		b.ContributionBeaconBlockRoot.Append(nil)
-		b.ContributionSubcommitteeIndex.Append("")
-		b.ContributionAggregationBits.Append("")
-		b.ContributionSignature.Append("")
-
-		return
-	}
-
-	if aggregatorIndex := message.GetAggregatorIndex(); aggregatorIndex != nil {
-		b.AggregatorIndex.Append(uint32(aggregatorIndex.GetValue())) //nolint:gosec // aggregator index fits uint32
-	} else {
-		b.AggregatorIndex.Append(0)
-	}
-
+	b.AggregatorIndex.Append(uint32(message.GetAggregatorIndex().GetValue())) //nolint:gosec // aggregator index fits uint32
 	b.SelectionProof.Append(message.GetSelectionProof())
 
 	contribution := message.GetContribution()
-	if contribution == nil {
-		b.ContributionSlot.Append(0)
-		b.ContributionBeaconBlockRoot.Append(nil)
-		b.ContributionSubcommitteeIndex.Append("")
-		b.ContributionAggregationBits.Append("")
-		b.ContributionSignature.Append("")
-
-		return
-	}
-
-	if slot := contribution.GetSlot(); slot != nil {
-		b.ContributionSlot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.ContributionSlot.Append(0)
-	}
-
+	b.ContributionSlot.Append(uint32(contribution.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.ContributionBeaconBlockRoot.Append([]byte(contribution.GetBeaconBlockRoot()))
-
-	if subcommitteeIndex := contribution.GetSubcommitteeIndex(); subcommitteeIndex != nil {
-		b.ContributionSubcommitteeIndex.Append(strconv.FormatUint(subcommitteeIndex.GetValue(), 10))
-	} else {
-		b.ContributionSubcommitteeIndex.Append("")
-	}
-
+	b.ContributionSubcommitteeIndex.Append(strconv.FormatUint(contribution.GetSubcommitteeIndex().GetValue(), 10))
 	b.ContributionAggregationBits.Append(contribution.GetAggregationBits())
 	b.ContributionSignature.Append(contribution.GetSignature())
 }

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_contribution_and_proof_test.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_contribution_and_proof_test.go
@@ -26,6 +26,10 @@ func TestSnapshot_beacon_api_eth_v1_events_contribution_and_proof(t *testing.T) 
 			EthV1EventsContributionAndProofV2: &ethv1.EventContributionAndProofV2{
 				Message: &ethv1.ContributionAndProofV2{
 					AggregatorIndex: wrapperspb.UInt64(99),
+					Contribution: &ethv1.SyncCommitteeContributionV2{
+						Slot:              wrapperspb.UInt64(100),
+						SubcommitteeIndex: wrapperspb.UInt64(3),
+					},
 				},
 			},
 		},

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_data_column_sidecar.go
@@ -85,25 +85,10 @@ func (b *beaconApiEthV1EventsDataColumnSidecarBatch) appendRuntime(event *xatu.D
 
 func (b *beaconApiEthV1EventsDataColumnSidecarBatch) appendPayload(event *xatu.DecoratedEvent) {
 	sidecar := event.GetEthV1EventsDataColumnSidecar()
-	if slot := sidecar.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(sidecar.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.BlockRoot.Append([]byte(sidecar.GetBlockRoot()))
-
-	if index := sidecar.GetIndex(); index != nil {
-		b.ColumnIndex.Append(index.GetValue())
-	} else {
-		b.ColumnIndex.Append(0)
-	}
-
-	if kzgCommitmentsCount := sidecar.GetKzgCommitmentsCount(); kzgCommitmentsCount != nil {
-		b.KzgCommitmentsCount.Append(kzgCommitmentsCount.GetValue())
-	} else {
-		b.KzgCommitmentsCount.Append(0)
-	}
+	b.ColumnIndex.Append(sidecar.GetIndex().GetValue())
+	b.KzgCommitmentsCount.Append(sidecar.GetKzgCommitmentsCount().GetValue())
 }
 
 func (b *beaconApiEthV1EventsDataColumnSidecarBatch) appendAdditionalData(

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_fast_confirmation.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_fast_confirmation.go
@@ -97,12 +97,7 @@ func (b *beaconApiEthV1EventsFastConfirmationBatch) appendRuntime(event *xatu.De
 
 func (b *beaconApiEthV1EventsFastConfirmationBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetEthV1EventsFastConfirmation()
-	if slot := payload.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(payload.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.Block.Append([]byte(payload.GetBlock()))
 }
 

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_finalized_checkpoint.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_finalized_checkpoint.go
@@ -79,13 +79,7 @@ func (b *beaconApiEthV1EventsFinalizedCheckpointBatch) appendPayload(event *xatu
 	checkpointV2 := event.GetEthV1EventsFinalizedCheckpointV2()
 	b.Block.Append([]byte(checkpointV2.GetBlock()))
 	b.State.Append([]byte(checkpointV2.GetState()))
-
-	if epoch := checkpointV2.GetEpoch(); epoch != nil {
-		b.Epoch.Append(uint32(epoch.GetValue())) //nolint:gosec // epoch fits uint32
-	} else {
-		b.Epoch.Append(0)
-	}
-
+	b.Epoch.Append(uint32(checkpointV2.GetEpoch().GetValue())) //nolint:gosec // epoch fits uint32
 	b.ExecutionOptimistic.Append(false)
 }
 

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_head.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_head.go
@@ -75,12 +75,7 @@ func (b *beaconApiEthV1EventsHeadBatch) appendRuntime(event *xatu.DecoratedEvent
 
 func (b *beaconApiEthV1EventsHeadBatch) appendPayload(event *xatu.DecoratedEvent) {
 	headV2 := event.GetEthV1EventsHeadV2()
-	if slot := headV2.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.Slot.Append(uint32(headV2.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 	b.Block.Append([]byte(headV2.GetBlock()))
 	b.EpochTransition.Append(headV2.GetEpochTransition())
 	b.ExecutionOptimistic.Append(false)

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_voluntary_exit.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_voluntary_exit.go
@@ -87,24 +87,8 @@ func (b *beaconApiEthV1EventsVoluntaryExitBatch) appendPayload(event *xatu.Decor
 	b.Signature.Append(voluntaryExitV2.GetSignature())
 
 	message := voluntaryExitV2.GetMessage()
-	if message == nil {
-		b.ValidatorIndex.Append(0)
-		b.Epoch.Append(0)
-
-		return
-	}
-
-	if validatorIndex := message.GetValidatorIndex(); validatorIndex != nil {
-		b.ValidatorIndex.Append(uint32(validatorIndex.GetValue())) //nolint:gosec // validator index fits uint32
-	} else {
-		b.ValidatorIndex.Append(0)
-	}
-
-	if epoch := message.GetEpoch(); epoch != nil {
-		b.Epoch.Append(uint32(epoch.GetValue())) //nolint:gosec // epoch fits uint32
-	} else {
-		b.Epoch.Append(0)
-	}
+	b.ValidatorIndex.Append(uint32(message.GetValidatorIndex().GetValue())) //nolint:gosec // validator index fits uint32
+	b.Epoch.Append(uint32(message.GetEpoch().GetValue()))                   //nolint:gosec // epoch fits uint32
 }
 
 func (b *beaconApiEthV1EventsVoluntaryExitBatch) appendAdditionalData(

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_proposer_duty.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_proposer_duty.go
@@ -91,18 +91,8 @@ func (b *beaconApiEthV1ProposerDutyBatch) appendRuntime(event *xatu.DecoratedEve
 
 func (b *beaconApiEthV1ProposerDutyBatch) appendPayload(event *xatu.DecoratedEvent) {
 	duty := event.GetEthV1ProposerDuty()
-	if slot := duty.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if validatorIndex := duty.GetValidatorIndex(); validatorIndex != nil {
-		b.ProposerValidatorIndex.Append(uint32(validatorIndex.GetValue())) //nolint:gosec // validator index fits uint32
-	} else {
-		b.ProposerValidatorIndex.Append(0)
-	}
-
+	b.Slot.Append(uint32(duty.GetSlot().GetValue()))                             //nolint:gosec // slot fits uint32
+	b.ProposerValidatorIndex.Append(uint32(duty.GetValidatorIndex().GetValue())) //nolint:gosec // validator index fits uint32
 	b.ProposerPubkey.Append(duty.GetPubkey())
 }
 

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_validator_attestation_data.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_validator_attestation_data.go
@@ -63,16 +63,18 @@ func (b *beaconApiEthV1ValidatorAttestationDataBatch) validate(
 		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
 	}
 
-	if source := payload.GetSource(); source != nil {
-		if source.GetEpoch() == nil {
-			return fmt.Errorf("nil SourceEpoch: %w", route.ErrInvalidEvent)
-		}
+	if payload.GetIndex() == nil {
+		return fmt.Errorf("nil CommitteeIndex: %w", route.ErrInvalidEvent)
 	}
 
-	if target := payload.GetTarget(); target != nil {
-		if target.GetEpoch() == nil {
-			return fmt.Errorf("nil TargetEpoch: %w", route.ErrInvalidEvent)
-		}
+	source := payload.GetSource()
+	if source == nil || source.GetEpoch() == nil {
+		return fmt.Errorf("nil SourceEpoch: %w", route.ErrInvalidEvent)
+	}
+
+	target := payload.GetTarget()
+	if target == nil || target.GetEpoch() == nil {
+		return fmt.Errorf("nil TargetEpoch: %w", route.ErrInvalidEvent)
 	}
 
 	return nil
@@ -90,45 +92,17 @@ func (b *beaconApiEthV1ValidatorAttestationDataBatch) appendRuntime(event *xatu.
 
 func (b *beaconApiEthV1ValidatorAttestationDataBatch) appendPayload(event *xatu.DecoratedEvent) {
 	attestationData := event.GetEthV1ValidatorAttestationData()
-	if slot := attestationData.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if committeeIndex := attestationData.GetIndex(); committeeIndex != nil {
-		b.CommitteeIndex.Append(strconv.FormatUint(committeeIndex.GetValue(), 10))
-	} else {
-		b.CommitteeIndex.Append("")
-	}
-
+	b.Slot.Append(uint32(attestationData.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
+	b.CommitteeIndex.Append(strconv.FormatUint(attestationData.GetIndex().GetValue(), 10))
 	b.BeaconBlockRoot.Append([]byte(attestationData.GetBeaconBlockRoot()))
 
-	if source := attestationData.GetSource(); source != nil {
-		if sourceEpoch := source.GetEpoch(); sourceEpoch != nil {
-			b.SourceEpoch.Append(uint32(sourceEpoch.GetValue())) //nolint:gosec // epoch fits uint32
-		} else {
-			b.SourceEpoch.Append(0)
-		}
+	source := attestationData.GetSource()
+	b.SourceEpoch.Append(uint32(source.GetEpoch().GetValue())) //nolint:gosec // epoch fits uint32
+	b.SourceRoot.Append([]byte(source.GetRoot()))
 
-		b.SourceRoot.Append([]byte(source.GetRoot()))
-	} else {
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-	}
-
-	if target := attestationData.GetTarget(); target != nil {
-		if targetEpoch := target.GetEpoch(); targetEpoch != nil {
-			b.TargetEpoch.Append(uint32(targetEpoch.GetValue())) //nolint:gosec // epoch fits uint32
-		} else {
-			b.TargetEpoch.Append(0)
-		}
-
-		b.TargetRoot.Append([]byte(target.GetRoot()))
-	} else {
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-	}
+	target := attestationData.GetTarget()
+	b.TargetEpoch.Append(uint32(target.GetEpoch().GetValue())) //nolint:gosec // epoch fits uint32
+	b.TargetRoot.Append([]byte(target.GetRoot()))
 }
 
 func (b *beaconApiEthV1ValidatorAttestationDataBatch) appendAdditionalData(

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_validator_attestation_data_test.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_validator_attestation_data_test.go
@@ -27,8 +27,10 @@ func TestSnapshot_beacon_api_eth_v1_validator_attestation_data(t *testing.T) {
 		}),
 		Data: &xatu.DecoratedEvent_EthV1ValidatorAttestationData{
 			EthV1ValidatorAttestationData: &ethv1.AttestationDataV2{
-				Slot:  wrapperspb.UInt64(100),
-				Index: wrapperspb.UInt64(8),
+				Slot:   wrapperspb.UInt64(100),
+				Index:  wrapperspb.UInt64(8),
+				Source: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(2)},
+				Target: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(3)},
 			},
 		},
 	}, 1, map[string]any{

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v2_beacon_block.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v2_beacon_block.go
@@ -97,21 +97,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	eventBlock *ethv2.EventBlockV2,
 ) error {
 	if phase0Block := eventBlock.GetPhase0Block(); phase0Block != nil {
-		if slot := phase0Block.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(phase0Block.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(phase0Block.GetParentRoot()))
 		b.StateRoot.Append([]byte(phase0Block.GetStateRoot()))
-
-		if pi := phase0Block.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
-
+		b.ProposerIndex.Append(uint32(phase0Block.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 		b.appendEth1Data(phase0Block.GetBody().GetEth1Data())
 		b.appendNoExecutionPayload()
 
@@ -119,21 +108,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if altairBlock := eventBlock.GetAltairBlock(); altairBlock != nil {
-		if slot := altairBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(altairBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(altairBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(altairBlock.GetStateRoot()))
-
-		if pi := altairBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
-
+		b.ProposerIndex.Append(uint32(altairBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 		b.appendEth1Data(altairBlock.GetBody().GetEth1Data())
 		b.appendNoExecutionPayload()
 
@@ -141,20 +119,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if bellatrixBlock := eventBlock.GetBellatrixBlock(); bellatrixBlock != nil {
-		if slot := bellatrixBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(bellatrixBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(bellatrixBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(bellatrixBlock.GetStateRoot()))
-
-		if pi := bellatrixBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
+		b.ProposerIndex.Append(uint32(bellatrixBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 
 		body := bellatrixBlock.GetBody()
 		b.appendEth1Data(body.GetEth1Data())
@@ -163,20 +131,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if capellaBlock := eventBlock.GetCapellaBlock(); capellaBlock != nil {
-		if slot := capellaBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(capellaBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(capellaBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(capellaBlock.GetStateRoot()))
-
-		if pi := capellaBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
+		b.ProposerIndex.Append(uint32(capellaBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 
 		body := capellaBlock.GetBody()
 		b.appendEth1Data(body.GetEth1Data())
@@ -185,20 +143,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if denebBlock := eventBlock.GetDenebBlock(); denebBlock != nil {
-		if slot := denebBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(denebBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(denebBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(denebBlock.GetStateRoot()))
-
-		if pi := denebBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
+		b.ProposerIndex.Append(uint32(denebBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 
 		body := denebBlock.GetBody()
 		b.appendEth1Data(body.GetEth1Data())
@@ -207,20 +155,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if electraBlock := eventBlock.GetElectraBlock(); electraBlock != nil {
-		if slot := electraBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(electraBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(electraBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(electraBlock.GetStateRoot()))
-
-		if pi := electraBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
+		b.ProposerIndex.Append(uint32(electraBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 
 		body := electraBlock.GetBody()
 		b.appendEth1Data(body.GetEth1Data())
@@ -229,20 +167,10 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 	}
 
 	if fuluBlock := eventBlock.GetFuluBlock(); fuluBlock != nil {
-		if slot := fuluBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(fuluBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.ParentRoot.Append([]byte(fuluBlock.GetParentRoot()))
 		b.StateRoot.Append([]byte(fuluBlock.GetStateRoot()))
-
-		if pi := fuluBlock.GetProposerIndex(); pi != nil {
-			b.ProposerIndex.Append(uint32(pi.GetValue())) //nolint:gosec // proposer index fits uint32
-		} else {
-			b.ProposerIndex.Append(0)
-		}
+		b.ProposerIndex.Append(uint32(fuluBlock.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
 
 		body := fuluBlock.GetBody()
 		b.appendEth1Data(body.GetEth1Data())
@@ -250,15 +178,7 @@ func (b *beaconApiEthV2BeaconBlockBatch) appendPayloadFromEventBlockV2(
 		return b.appendExecutionPayloadElectra(body.GetExecutionPayload())
 	}
 
-	// Unknown block type: append zero values.
-	b.Slot.Append(0)
-	b.ParentRoot.Append(nil)
-	b.StateRoot.Append(nil)
-	b.ProposerIndex.Append(0)
-	b.appendEth1Data(nil)
-	b.appendNoExecutionPayload()
-
-	return nil
+	return fmt.Errorf("unknown block version: %w", route.ErrInvalidEvent)
 }
 
 func (b *beaconApiEthV2BeaconBlockBatch) appendEth1Data(eth1Data *ethv1.Eth1Data) {

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v3_validator_block.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v3_validator_block.go
@@ -109,84 +109,50 @@ func (b *beaconApiEthV3ValidatorBlockBatch) appendPayloadFromEventBlockV2(
 	eventBlock *ethv2.EventBlockV2,
 ) error {
 	if phase0Block := eventBlock.GetPhase0Block(); phase0Block != nil {
-		if slot := phase0Block.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(phase0Block.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.appendNoExecutionPayload()
 
 		return nil
 	}
 
 	if altairBlock := eventBlock.GetAltairBlock(); altairBlock != nil {
-		if slot := altairBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
-
+		b.Slot.Append(uint32(altairBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 		b.appendNoExecutionPayload()
 
 		return nil
 	}
 
 	if bellatrixBlock := eventBlock.GetBellatrixBlock(); bellatrixBlock != nil {
-		if slot := bellatrixBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
+		b.Slot.Append(uint32(bellatrixBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 
 		return b.appendExecutionPayloadV2(bellatrixBlock.GetBody().GetExecutionPayload())
 	}
 
 	if capellaBlock := eventBlock.GetCapellaBlock(); capellaBlock != nil {
-		if slot := capellaBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
+		b.Slot.Append(uint32(capellaBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 
 		return b.appendExecutionPayloadCapellaV2(capellaBlock.GetBody().GetExecutionPayload())
 	}
 
 	if denebBlock := eventBlock.GetDenebBlock(); denebBlock != nil {
-		if slot := denebBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
+		b.Slot.Append(uint32(denebBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 
 		return b.appendExecutionPayloadDeneb(denebBlock.GetBody().GetExecutionPayload())
 	}
 
 	if electraBlock := eventBlock.GetElectraBlock(); electraBlock != nil {
-		if slot := electraBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
+		b.Slot.Append(uint32(electraBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 
 		return b.appendExecutionPayloadElectra(electraBlock.GetBody().GetExecutionPayload())
 	}
 
 	if fuluBlock := eventBlock.GetFuluBlock(); fuluBlock != nil {
-		if slot := fuluBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot fits uint32
-		} else {
-			b.Slot.Append(0)
-		}
+		b.Slot.Append(uint32(fuluBlock.GetSlot().GetValue())) //nolint:gosec // slot fits uint32
 
 		return b.appendExecutionPayloadElectra(fuluBlock.GetBody().GetExecutionPayload())
 	}
 
-	// Unknown block type.
-	b.Slot.Append(0)
-	b.appendNoExecutionPayload()
-
-	return nil
+	return fmt.Errorf("unknown block version: %w", route.ErrInvalidEvent)
 }
 
 func (b *beaconApiEthV3ValidatorBlockBatch) appendNoExecutionPayload() {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar.go
@@ -75,26 +75,16 @@ func (b *canonicalBeaconBlobSidecarBatch) appendRuntime(_ *xatu.DecoratedEvent) 
 	b.UpdatedDateTime.Append(time.Now())
 }
 
+//nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlobSidecarBatch) appendPayload(event *xatu.DecoratedEvent) {
 	blob := event.GetEthV1BeaconBlockBlobSidecar()
 
 	b.BlockRoot.Append([]byte(blob.GetBlockRoot()))
 	b.BlockParentRoot.Append([]byte(blob.GetBlockParentRoot()))
-
-	if proposerIndex := blob.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue())) //nolint:gosec // G115
-	} else {
-		b.ProposerIndex.Append(0)
-	}
-
+	b.ProposerIndex.Append(uint32(blob.GetProposerIndex().GetValue()))
 	b.KzgCommitment.Append([]byte(blob.GetKzgCommitment()))
 	b.KzgProof.Append([]byte(blob.GetKzgProof()))
-
-	if index := blob.GetIndex(); index != nil {
-		b.BlobIndex.Append(index.GetValue())
-	} else {
-		b.BlobIndex.Append(0)
-	}
+	b.BlobIndex.Append(blob.GetIndex().GetValue())
 }
 
 func (b *canonicalBeaconBlobSidecarBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/ch-go/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
@@ -88,19 +89,10 @@ func (b *canonicalBeaconBlockBatch) appendPayload(event *xatu.DecoratedEvent) er
 	return b.appendPayloadFromEventBlockV2(eventBlock)
 }
 
-//nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *ethv2.EventBlockV2) error {
 	if phase0Block := eventBlock.GetPhase0Block(); phase0Block != nil {
-		if slot := phase0Block.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := phase0Block.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(phase0Block.GetSlot(), phase0Block.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(phase0Block.GetParentRoot()))
@@ -112,16 +104,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if altairBlock := eventBlock.GetAltairBlock(); altairBlock != nil {
-		if slot := altairBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := altairBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(altairBlock.GetSlot(), altairBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(altairBlock.GetParentRoot()))
@@ -133,16 +117,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if bellatrixBlock := eventBlock.GetBellatrixBlock(); bellatrixBlock != nil {
-		if slot := bellatrixBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := bellatrixBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(bellatrixBlock.GetSlot(), bellatrixBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(bellatrixBlock.GetParentRoot()))
@@ -155,16 +131,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if capellaBlock := eventBlock.GetCapellaBlock(); capellaBlock != nil {
-		if slot := capellaBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := capellaBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(capellaBlock.GetSlot(), capellaBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(capellaBlock.GetParentRoot()))
@@ -177,16 +145,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if denebBlock := eventBlock.GetDenebBlock(); denebBlock != nil {
-		if slot := denebBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := denebBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(denebBlock.GetSlot(), denebBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(denebBlock.GetParentRoot()))
@@ -199,16 +159,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if electraBlock := eventBlock.GetElectraBlock(); electraBlock != nil {
-		if slot := electraBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := electraBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(electraBlock.GetSlot(), electraBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(electraBlock.GetParentRoot()))
@@ -221,16 +173,8 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 	}
 
 	if fuluBlock := eventBlock.GetFuluBlock(); fuluBlock != nil {
-		if slot := fuluBlock.GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-
-		if proposerIndex := fuluBlock.GetProposerIndex(); proposerIndex != nil {
-			b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-		} else {
-			b.ProposerIndex.Append(0)
+		if err := b.appendSlotProposer(fuluBlock.GetSlot(), fuluBlock.GetProposerIndex()); err != nil {
+			return err
 		}
 
 		b.ParentRoot.Append([]byte(fuluBlock.GetParentRoot()))
@@ -242,14 +186,25 @@ func (b *canonicalBeaconBlockBatch) appendPayloadFromEventBlockV2(eventBlock *et
 		return b.appendExecutionPayloadElectra(body.GetExecutionPayload())
 	}
 
-	// Unknown block version - append zeros.
-	b.Slot.Append(0)
-	b.ProposerIndex.Append(0)
-	b.ParentRoot.Append(nil)
-	b.StateRoot.Append(nil)
-	b.Eth1DataBlockHash.Append(nil)
-	b.Eth1DataDepositRoot.Append(nil)
-	b.appendNullExecutionPayload()
+	return fmt.Errorf("unknown beacon block version: %w", route.ErrInvalidEvent)
+}
+
+// appendSlotProposer appends the required slot and proposer_index, returning
+// route.ErrInvalidEvent when either wrapper is absent rather than fabricating a
+// zero value (slot 0 and validator index 0 are both real values).
+//
+//nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
+func (b *canonicalBeaconBlockBatch) appendSlotProposer(slot, proposerIndex *wrapperspb.UInt64Value) error {
+	if slot == nil {
+		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
+	}
+
+	if proposerIndex == nil {
+		return fmt.Errorf("nil ProposerIndex: %w", route.ErrInvalidEvent)
+	}
+
+	b.Slot.Append(uint32(slot.GetValue()))
+	b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing.go
@@ -42,6 +42,10 @@ func (b *canonicalBeaconBlockAttesterSlashingBatch) FlattenTo(event *xatu.Decora
 		return fmt.Errorf("nil eth_v2_beacon_block_attester_slashing payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
@@ -49,6 +53,16 @@ func (b *canonicalBeaconBlockAttesterSlashingBatch) FlattenTo(event *xatu.Decora
 	b.rows++
 
 	return nil
+}
+
+func (b *canonicalBeaconBlockAttesterSlashingBatch) validate(event *xatu.DecoratedEvent) error {
+	slashing := event.GetEthV2BeaconBlockAttesterSlashing()
+
+	if err := validateIndexedAttestation("Attestation_1", slashing.GetAttestation_1()); err != nil {
+		return err
+	}
+
+	return validateIndexedAttestation("Attestation_2", slashing.GetAttestation_2())
 }
 
 func (b *canonicalBeaconBlockAttesterSlashingBatch) appendRuntime(_ *xatu.DecoratedEvent) {
@@ -63,150 +77,40 @@ func (b *canonicalBeaconBlockAttesterSlashingBatch) appendPayload(event *xatu.De
 
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlockAttesterSlashingBatch) appendIndexedAttestation1(att *ethv1.IndexedAttestationV2) {
-	if att == nil {
-		b.appendNullIndexedAttestation1()
-
-		return
-	}
-
 	b.Attestation1AttestingIndices.Append(wrappedUint64SliceToUint32(att.GetAttestingIndices()))
 	b.Attestation1Signature.Append(att.GetSignature())
 
-	if data := att.GetData(); data != nil {
-		b.Attestation1DataBeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	data := att.GetData()
+	b.Attestation1DataBeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	b.Attestation1DataSlot.Append(uint32(data.GetSlot().GetValue()))
+	b.Attestation1DataIndex.Append(uint32(data.GetIndex().GetValue()))
 
-		if slot := data.GetSlot(); slot != nil {
-			b.Attestation1DataSlot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Attestation1DataSlot.Append(0)
-		}
+	source := data.GetSource()
+	b.Attestation1DataSourceEpoch.Append(uint32(source.GetEpoch().GetValue()))
+	b.Attestation1DataSourceRoot.Append([]byte(source.GetRoot()))
 
-		if index := data.GetIndex(); index != nil {
-			b.Attestation1DataIndex.Append(uint32(index.GetValue()))
-		} else {
-			b.Attestation1DataIndex.Append(0)
-		}
-
-		if source := data.GetSource(); source != nil {
-			if epoch := source.GetEpoch(); epoch != nil {
-				b.Attestation1DataSourceEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.Attestation1DataSourceEpoch.Append(0)
-			}
-
-			b.Attestation1DataSourceRoot.Append([]byte(source.GetRoot()))
-		} else {
-			b.Attestation1DataSourceEpoch.Append(0)
-			b.Attestation1DataSourceRoot.Append(nil)
-		}
-
-		if target := data.GetTarget(); target != nil {
-			if epoch := target.GetEpoch(); epoch != nil {
-				b.Attestation1DataTargetEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.Attestation1DataTargetEpoch.Append(0)
-			}
-
-			b.Attestation1DataTargetRoot.Append([]byte(target.GetRoot()))
-		} else {
-			b.Attestation1DataTargetEpoch.Append(0)
-			b.Attestation1DataTargetRoot.Append(nil)
-		}
-	} else {
-		b.Attestation1DataBeaconBlockRoot.Append(nil)
-		b.Attestation1DataSlot.Append(0)
-		b.Attestation1DataIndex.Append(0)
-		b.Attestation1DataSourceEpoch.Append(0)
-		b.Attestation1DataSourceRoot.Append(nil)
-		b.Attestation1DataTargetEpoch.Append(0)
-		b.Attestation1DataTargetRoot.Append(nil)
-	}
-}
-
-func (b *canonicalBeaconBlockAttesterSlashingBatch) appendNullIndexedAttestation1() {
-	b.Attestation1AttestingIndices.Append([]uint32{})
-	b.Attestation1Signature.Append("")
-	b.Attestation1DataBeaconBlockRoot.Append(nil)
-	b.Attestation1DataSlot.Append(0)
-	b.Attestation1DataIndex.Append(0)
-	b.Attestation1DataSourceEpoch.Append(0)
-	b.Attestation1DataSourceRoot.Append(nil)
-	b.Attestation1DataTargetEpoch.Append(0)
-	b.Attestation1DataTargetRoot.Append(nil)
+	target := data.GetTarget()
+	b.Attestation1DataTargetEpoch.Append(uint32(target.GetEpoch().GetValue()))
+	b.Attestation1DataTargetRoot.Append([]byte(target.GetRoot()))
 }
 
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlockAttesterSlashingBatch) appendIndexedAttestation2(att *ethv1.IndexedAttestationV2) {
-	if att == nil {
-		b.appendNullIndexedAttestation2()
-
-		return
-	}
-
 	b.Attestation2AttestingIndices.Append(wrappedUint64SliceToUint32(att.GetAttestingIndices()))
 	b.Attestation2Signature.Append(att.GetSignature())
 
-	if data := att.GetData(); data != nil {
-		b.Attestation2DataBeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	data := att.GetData()
+	b.Attestation2DataBeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	b.Attestation2DataSlot.Append(uint32(data.GetSlot().GetValue()))
+	b.Attestation2DataIndex.Append(uint32(data.GetIndex().GetValue()))
 
-		if slot := data.GetSlot(); slot != nil {
-			b.Attestation2DataSlot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Attestation2DataSlot.Append(0)
-		}
+	source := data.GetSource()
+	b.Attestation2DataSourceEpoch.Append(uint32(source.GetEpoch().GetValue()))
+	b.Attestation2DataSourceRoot.Append([]byte(source.GetRoot()))
 
-		if index := data.GetIndex(); index != nil {
-			b.Attestation2DataIndex.Append(uint32(index.GetValue()))
-		} else {
-			b.Attestation2DataIndex.Append(0)
-		}
-
-		if source := data.GetSource(); source != nil {
-			if epoch := source.GetEpoch(); epoch != nil {
-				b.Attestation2DataSourceEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.Attestation2DataSourceEpoch.Append(0)
-			}
-
-			b.Attestation2DataSourceRoot.Append([]byte(source.GetRoot()))
-		} else {
-			b.Attestation2DataSourceEpoch.Append(0)
-			b.Attestation2DataSourceRoot.Append(nil)
-		}
-
-		if target := data.GetTarget(); target != nil {
-			if epoch := target.GetEpoch(); epoch != nil {
-				b.Attestation2DataTargetEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.Attestation2DataTargetEpoch.Append(0)
-			}
-
-			b.Attestation2DataTargetRoot.Append([]byte(target.GetRoot()))
-		} else {
-			b.Attestation2DataTargetEpoch.Append(0)
-			b.Attestation2DataTargetRoot.Append(nil)
-		}
-	} else {
-		b.Attestation2DataBeaconBlockRoot.Append(nil)
-		b.Attestation2DataSlot.Append(0)
-		b.Attestation2DataIndex.Append(0)
-		b.Attestation2DataSourceEpoch.Append(0)
-		b.Attestation2DataSourceRoot.Append(nil)
-		b.Attestation2DataTargetEpoch.Append(0)
-		b.Attestation2DataTargetRoot.Append(nil)
-	}
-}
-
-func (b *canonicalBeaconBlockAttesterSlashingBatch) appendNullIndexedAttestation2() {
-	b.Attestation2AttestingIndices.Append([]uint32{})
-	b.Attestation2Signature.Append("")
-	b.Attestation2DataBeaconBlockRoot.Append(nil)
-	b.Attestation2DataSlot.Append(0)
-	b.Attestation2DataIndex.Append(0)
-	b.Attestation2DataSourceEpoch.Append(0)
-	b.Attestation2DataSourceRoot.Append(nil)
-	b.Attestation2DataTargetEpoch.Append(0)
-	b.Attestation2DataTargetRoot.Append(nil)
+	target := data.GetTarget()
+	b.Attestation2DataTargetEpoch.Append(uint32(target.GetEpoch().GetValue()))
+	b.Attestation2DataTargetRoot.Append([]byte(target.GetRoot()))
 }
 
 func (b *canonicalBeaconBlockAttesterSlashingBatch) appendAdditionalData(event *xatu.DecoratedEvent) {
@@ -224,6 +128,40 @@ func (b *canonicalBeaconBlockAttesterSlashingBatch) appendAdditionalData(event *
 
 	appendBlockIdentifier(additional.GetBlock(),
 		&b.Slot, &b.SlotStartDateTime, &b.Epoch, &b.EpochStartDateTime, &b.BlockVersion, &b.BlockRoot)
+}
+
+// validateIndexedAttestation returns route.ErrInvalidEvent when a required field
+// of an indexed attestation is absent, so the slashing is dropped rather than
+// written with fabricated zero slot/index/epoch values.
+func validateIndexedAttestation(name string, att *ethv1.IndexedAttestationV2) error {
+	if att == nil {
+		return fmt.Errorf("nil %s: %w", name, route.ErrInvalidEvent)
+	}
+
+	data := att.GetData()
+	if data == nil {
+		return fmt.Errorf("nil %s.Data: %w", name, route.ErrInvalidEvent)
+	}
+
+	if data.GetSlot() == nil {
+		return fmt.Errorf("nil %s.Data.Slot: %w", name, route.ErrInvalidEvent)
+	}
+
+	if data.GetIndex() == nil {
+		return fmt.Errorf("nil %s.Data.Index: %w", name, route.ErrInvalidEvent)
+	}
+
+	source := data.GetSource()
+	if source == nil || source.GetEpoch() == nil {
+		return fmt.Errorf("nil %s.Data.Source: %w", name, route.ErrInvalidEvent)
+	}
+
+	target := data.GetTarget()
+	if target == nil || target.GetEpoch() == nil {
+		return fmt.Errorf("nil %s.Data.Target: %w", name, route.ErrInvalidEvent)
+	}
+
+	return nil
 }
 
 // wrappedUint64SliceToUint32 converts a slice of wrapperspb.UInt64Value to []uint32.

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing_test.go
@@ -3,10 +3,24 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
+
+func indexedAttestationFixture() *ethv1.IndexedAttestationV2 {
+	return &ethv1.IndexedAttestationV2{
+		AttestingIndices: []*wrapperspb.UInt64Value{wrapperspb.UInt64(1), wrapperspb.UInt64(2)},
+		Data: &ethv1.AttestationDataV2{
+			Slot:   wrapperspb.UInt64(100),
+			Index:  wrapperspb.UInt64(3),
+			Source: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(4)},
+			Target: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(5)},
+		},
+	}
+}
 
 func TestSnapshot_canonical_beacon_block_attester_slashing(t *testing.T) {
 	testfixture.AssertSnapshot(t, newcanonicalBeaconBlockAttesterSlashingBatch(), &xatu.DecoratedEvent{
@@ -25,7 +39,10 @@ func TestSnapshot_canonical_beacon_block_attester_slashing(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockAttesterSlashing{
-			EthV2BeaconBlockAttesterSlashing: &ethv1.AttesterSlashingV2{},
+			EthV2BeaconBlockAttesterSlashing: &ethv1.AttesterSlashingV2{
+				Attestation_1: indexedAttestationFixture(),
+				Attestation_2: indexedAttestationFixture(),
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change.go
@@ -38,11 +38,28 @@ func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) FlattenTo(event *xatu.De
 		return fmt.Errorf("nil eth_v2_beacon_block_bls_to_execution_change payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) validate(event *xatu.DecoratedEvent) error {
+	msg := event.GetEthV2BeaconBlockBlsToExecutionChange().GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetValidatorIndex() == nil {
+		return fmt.Errorf("nil Message.ValidatorIndex: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }
@@ -56,20 +73,10 @@ func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) appendPayload(event *xat
 	change := event.GetEthV2BeaconBlockBlsToExecutionChange()
 	b.ExchangingSignature.Append(change.GetSignature())
 
-	if msg := change.GetMessage(); msg != nil {
-		if validatorIndex := msg.GetValidatorIndex(); validatorIndex != nil {
-			b.ExchangingMessageValidatorIndex.Append(uint32(validatorIndex.GetValue()))
-		} else {
-			b.ExchangingMessageValidatorIndex.Append(0)
-		}
-
-		b.ExchangingMessageFromBlsPubkey.Append(msg.GetFromBlsPubkey())
-		b.ExchangingMessageToExecutionAddress.Append([]byte(msg.GetToExecutionAddress()))
-	} else {
-		b.ExchangingMessageValidatorIndex.Append(0)
-		b.ExchangingMessageFromBlsPubkey.Append("")
-		b.ExchangingMessageToExecutionAddress.Append(nil)
-	}
+	msg := change.GetMessage()
+	b.ExchangingMessageValidatorIndex.Append(uint32(msg.GetValidatorIndex().GetValue()))
+	b.ExchangingMessageFromBlsPubkey.Append(msg.GetFromBlsPubkey())
+	b.ExchangingMessageToExecutionAddress.Append([]byte(msg.GetToExecutionAddress()))
 }
 
 func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv2 "github.com/ethpandaops/xatu/pkg/proto/eth/v2"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -25,7 +27,11 @@ func TestSnapshot_canonical_beacon_block_bls_to_execution_change(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockBlsToExecutionChange{
-			EthV2BeaconBlockBlsToExecutionChange: &ethv2.SignedBLSToExecutionChangeV2{},
+			EthV2BeaconBlockBlsToExecutionChange: &ethv2.SignedBLSToExecutionChangeV2{
+				Message: &ethv2.BLSToExecutionChangeV2{
+					ValidatorIndex: wrapperspb.UInt64(42),
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit.go
@@ -39,6 +39,10 @@ func (b *canonicalBeaconBlockDepositBatch) FlattenTo(event *xatu.DecoratedEvent)
 		return fmt.Errorf("nil eth_v2_beacon_block_deposit payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 
@@ -52,6 +56,19 @@ func (b *canonicalBeaconBlockDepositBatch) FlattenTo(event *xatu.DecoratedEvent)
 	return nil
 }
 
+func (b *canonicalBeaconBlockDepositBatch) validate(event *xatu.DecoratedEvent) error {
+	data := event.GetEthV2BeaconBlockDeposit().GetData()
+	if data == nil {
+		return fmt.Errorf("nil Data: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetAmount() == nil {
+		return fmt.Errorf("nil Data.Amount: %w", route.ErrInvalidEvent)
+	}
+
+	return nil
+}
+
 func (b *canonicalBeaconBlockDepositBatch) appendRuntime(_ *xatu.DecoratedEvent) {
 	b.UpdatedDateTime.Append(time.Now())
 }
@@ -60,37 +77,17 @@ func (b *canonicalBeaconBlockDepositBatch) appendPayload(event *xatu.DecoratedEv
 	deposit := event.GetEthV2BeaconBlockDeposit()
 	b.DepositProof.Append(deposit.GetProof())
 
-	if data := deposit.GetData(); data != nil {
-		b.DepositDataPubkey.Append(data.GetPubkey())
-		b.DepositDataWithdrawalCredentials.Append([]byte(data.GetWithdrawalCredentials()))
-		b.DepositDataSignature.Append(data.GetSignature())
+	data := deposit.GetData()
+	b.DepositDataPubkey.Append(data.GetPubkey())
+	b.DepositDataWithdrawalCredentials.Append([]byte(data.GetWithdrawalCredentials()))
+	b.DepositDataSignature.Append(data.GetSignature())
 
-		if amount := data.GetAmount(); amount != nil {
-			parsedAmount, err := route.ParseUInt128(strconv.FormatUint(amount.GetValue(), 10))
-			if err != nil {
-				return fmt.Errorf("parsing deposit_data_amount: %w", err)
-			}
-
-			b.DepositDataAmount.Append(parsedAmount)
-		} else {
-			zeroAmount, err := route.ParseUInt128("0")
-			if err != nil {
-				return fmt.Errorf("parsing deposit_data_amount: %w", err)
-			}
-
-			b.DepositDataAmount.Append(zeroAmount)
-		}
-	} else {
-		zeroAmount, err := route.ParseUInt128("0")
-		if err != nil {
-			return fmt.Errorf("parsing deposit_data_amount: %w", err)
-		}
-
-		b.DepositDataPubkey.Append("")
-		b.DepositDataWithdrawalCredentials.Append(nil)
-		b.DepositDataSignature.Append("")
-		b.DepositDataAmount.Append(zeroAmount)
+	parsedAmount, err := route.ParseUInt128(strconv.FormatUint(data.GetAmount().GetValue(), 10))
+	if err != nil {
+		return fmt.Errorf("parsing deposit_data_amount: %w", err)
 	}
+
+	b.DepositDataAmount.Append(parsedAmount)
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -25,7 +27,12 @@ func TestSnapshot_canonical_beacon_block_deposit(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockDeposit{
-			EthV2BeaconBlockDeposit: &ethv1.DepositV2{},
+			EthV2BeaconBlockDeposit: &ethv1.DepositV2{
+				Data: &ethv1.DepositV2_Data{
+					Pubkey: "0xpubkey",
+					Amount: wrapperspb.UInt64(32000000000),
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction.go
@@ -141,24 +141,9 @@ func (b *canonicalBeaconBlockExecutionTransactionBatch) appendPayload(event *xat
 	}
 
 	b.BlobHashes.Append(tx.GetBlobHashes())
-
-	if nonce := tx.GetNonce(); nonce != nil {
-		b.Nonce.Append(nonce.GetValue())
-	} else {
-		b.Nonce.Append(0)
-	}
-
-	if gas := tx.GetGas(); gas != nil {
-		b.Gas.Append(gas.GetValue())
-	} else {
-		b.Gas.Append(0)
-	}
-
-	if txType := tx.GetType(); txType != nil {
-		b.Type.Append(uint8(txType.GetValue())) //nolint:gosec // G115
-	} else {
-		b.Type.Append(0)
-	}
+	b.Nonce.Append(tx.GetNonce().GetValue())
+	b.Gas.Append(tx.GetGas().GetValue())
+	b.Type.Append(uint8(tx.GetType().GetValue())) //nolint:gosec // G115
 
 	if blobGas := tx.GetBlobGas(); blobGas != nil {
 		b.BlobGas.Append(proto.NewNullable[uint64](blobGas.GetValue()))

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing.go
@@ -39,6 +39,10 @@ func (b *canonicalBeaconBlockProposerSlashingBatch) FlattenTo(event *xatu.Decora
 		return fmt.Errorf("nil eth_v2_beacon_block_proposer_slashing payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
@@ -46,6 +50,16 @@ func (b *canonicalBeaconBlockProposerSlashingBatch) FlattenTo(event *xatu.Decora
 	b.rows++
 
 	return nil
+}
+
+func (b *canonicalBeaconBlockProposerSlashingBatch) validate(event *xatu.DecoratedEvent) error {
+	slashing := event.GetEthV2BeaconBlockProposerSlashing()
+
+	if err := validateSignedHeader("SignedHeader_1", slashing.GetSignedHeader_1()); err != nil {
+		return err
+	}
+
+	return validateSignedHeader("SignedHeader_2", slashing.GetSignedHeader_2())
 }
 
 func (b *canonicalBeaconBlockProposerSlashingBatch) appendRuntime(_ *xatu.DecoratedEvent) {
@@ -58,90 +72,52 @@ func (b *canonicalBeaconBlockProposerSlashingBatch) appendPayload(event *xatu.De
 	b.appendSignedHeader2(slashing.GetSignedHeader_2())
 }
 
+//nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlockProposerSlashingBatch) appendSignedHeader1(header *ethv1.SignedBeaconBlockHeaderV2) {
-	if header == nil {
-		b.appendNullSignedHeader1()
-
-		return
-	}
-
 	b.SignedHeader1Signature.Append(header.GetSignature())
 
-	if msg := header.GetMessage(); msg != nil {
-		if slot := msg.GetSlot(); slot != nil {
-			b.SignedHeader1MessageSlot.Append(uint32(slot.GetValue())) //nolint:gosec // G115
-		} else {
-			b.SignedHeader1MessageSlot.Append(0)
-		}
-
-		if proposerIndex := msg.GetProposerIndex(); proposerIndex != nil {
-			b.SignedHeader1MessageProposerIndex.Append(uint32(proposerIndex.GetValue())) //nolint:gosec // G115
-		} else {
-			b.SignedHeader1MessageProposerIndex.Append(0)
-		}
-
-		b.SignedHeader1MessageBodyRoot.Append([]byte(msg.GetBodyRoot()))
-		b.SignedHeader1MessageParentRoot.Append([]byte(msg.GetParentRoot()))
-		b.SignedHeader1MessageStateRoot.Append([]byte(msg.GetStateRoot()))
-	} else {
-		b.SignedHeader1MessageSlot.Append(0)
-		b.SignedHeader1MessageProposerIndex.Append(0)
-		b.SignedHeader1MessageBodyRoot.Append(nil)
-		b.SignedHeader1MessageParentRoot.Append(nil)
-		b.SignedHeader1MessageStateRoot.Append(nil)
-	}
+	msg := header.GetMessage()
+	b.SignedHeader1MessageSlot.Append(uint32(msg.GetSlot().GetValue()))
+	b.SignedHeader1MessageProposerIndex.Append(uint32(msg.GetProposerIndex().GetValue()))
+	b.SignedHeader1MessageBodyRoot.Append([]byte(msg.GetBodyRoot()))
+	b.SignedHeader1MessageParentRoot.Append([]byte(msg.GetParentRoot()))
+	b.SignedHeader1MessageStateRoot.Append([]byte(msg.GetStateRoot()))
 }
 
-func (b *canonicalBeaconBlockProposerSlashingBatch) appendNullSignedHeader1() {
-	b.SignedHeader1Signature.Append("")
-	b.SignedHeader1MessageSlot.Append(0)
-	b.SignedHeader1MessageProposerIndex.Append(0)
-	b.SignedHeader1MessageBodyRoot.Append(nil)
-	b.SignedHeader1MessageParentRoot.Append(nil)
-	b.SignedHeader1MessageStateRoot.Append(nil)
-}
-
+//nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema
 func (b *canonicalBeaconBlockProposerSlashingBatch) appendSignedHeader2(header *ethv1.SignedBeaconBlockHeaderV2) {
-	if header == nil {
-		b.appendNullSignedHeader2()
-
-		return
-	}
-
 	b.SignedHeader2Signature.Append(header.GetSignature())
 
-	if msg := header.GetMessage(); msg != nil {
-		if slot := msg.GetSlot(); slot != nil {
-			b.SignedHeader2MessageSlot.Append(uint32(slot.GetValue())) //nolint:gosec // G115
-		} else {
-			b.SignedHeader2MessageSlot.Append(0)
-		}
-
-		if proposerIndex := msg.GetProposerIndex(); proposerIndex != nil {
-			b.SignedHeader2MessageProposerIndex.Append(uint32(proposerIndex.GetValue())) //nolint:gosec // G115
-		} else {
-			b.SignedHeader2MessageProposerIndex.Append(0)
-		}
-
-		b.SignedHeader2MessageBodyRoot.Append([]byte(msg.GetBodyRoot()))
-		b.SignedHeader2MessageParentRoot.Append([]byte(msg.GetParentRoot()))
-		b.SignedHeader2MessageStateRoot.Append([]byte(msg.GetStateRoot()))
-	} else {
-		b.SignedHeader2MessageSlot.Append(0)
-		b.SignedHeader2MessageProposerIndex.Append(0)
-		b.SignedHeader2MessageBodyRoot.Append(nil)
-		b.SignedHeader2MessageParentRoot.Append(nil)
-		b.SignedHeader2MessageStateRoot.Append(nil)
-	}
+	msg := header.GetMessage()
+	b.SignedHeader2MessageSlot.Append(uint32(msg.GetSlot().GetValue()))
+	b.SignedHeader2MessageProposerIndex.Append(uint32(msg.GetProposerIndex().GetValue()))
+	b.SignedHeader2MessageBodyRoot.Append([]byte(msg.GetBodyRoot()))
+	b.SignedHeader2MessageParentRoot.Append([]byte(msg.GetParentRoot()))
+	b.SignedHeader2MessageStateRoot.Append([]byte(msg.GetStateRoot()))
 }
 
-func (b *canonicalBeaconBlockProposerSlashingBatch) appendNullSignedHeader2() {
-	b.SignedHeader2Signature.Append("")
-	b.SignedHeader2MessageSlot.Append(0)
-	b.SignedHeader2MessageProposerIndex.Append(0)
-	b.SignedHeader2MessageBodyRoot.Append(nil)
-	b.SignedHeader2MessageParentRoot.Append(nil)
-	b.SignedHeader2MessageStateRoot.Append(nil)
+// validateSignedHeader returns route.ErrInvalidEvent when a required field of a
+// signed block header is absent, so the slashing is dropped rather than written
+// with fabricated zero slot/proposer_index values.
+func validateSignedHeader(name string, header *ethv1.SignedBeaconBlockHeaderV2) error {
+	if header == nil {
+		return fmt.Errorf("nil %s: %w", name, route.ErrInvalidEvent)
+	}
+
+	msg := header.GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil %s.Message: %w", name, route.ErrInvalidEvent)
+	}
+
+	if msg.GetSlot() == nil {
+		return fmt.Errorf("nil %s.Message.Slot: %w", name, route.ErrInvalidEvent)
+	}
+
+	if msg.GetProposerIndex() == nil {
+		return fmt.Errorf("nil %s.Message.ProposerIndex: %w", name, route.ErrInvalidEvent)
+	}
+
+	return nil
 }
 
 func (b *canonicalBeaconBlockProposerSlashingBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -25,7 +27,20 @@ func TestSnapshot_canonical_beacon_block_proposer_slashing(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockProposerSlashing{
-			EthV2BeaconBlockProposerSlashing: &ethv1.ProposerSlashingV2{},
+			EthV2BeaconBlockProposerSlashing: &ethv1.ProposerSlashingV2{
+				SignedHeader_1: &ethv1.SignedBeaconBlockHeaderV2{
+					Message: &ethv1.BeaconBlockHeaderV2{
+						Slot:          wrapperspb.UInt64(100),
+						ProposerIndex: wrapperspb.UInt64(42),
+					},
+				},
+				SignedHeader_2: &ethv1.SignedBeaconBlockHeaderV2{
+					Message: &ethv1.BeaconBlockHeaderV2{
+						Slot:          wrapperspb.UInt64(100),
+						ProposerIndex: wrapperspb.UInt64(42),
+					},
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate.go
@@ -80,12 +80,7 @@ func (b *canonicalBeaconBlockSyncAggregateBatch) appendPayload(event *xatu.Decor
 	b.SyncCommitteeSignature.Append(aggregate.GetSyncCommitteeSignature())
 	b.ValidatorsParticipated.Append(syncAggregateWrappedUint32Slice(aggregate.GetValidatorsParticipated()))
 	b.ValidatorsMissed.Append(syncAggregateWrappedUint32Slice(aggregate.GetValidatorsMissed()))
-
-	if participationCount := aggregate.GetParticipationCount(); participationCount != nil {
-		b.ParticipationCount.Append(uint16(participationCount.GetValue()))
-	} else {
-		b.ParticipationCount.Append(0)
-	}
+	b.ParticipationCount.Append(uint16(aggregate.GetParticipationCount().GetValue()))
 }
 
 func (b *canonicalBeaconBlockSyncAggregateBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit.go
@@ -38,11 +38,32 @@ func (b *canonicalBeaconBlockVoluntaryExitBatch) FlattenTo(event *xatu.Decorated
 		return fmt.Errorf("nil eth_v2_beacon_block_voluntary_exit payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockVoluntaryExitBatch) validate(event *xatu.DecoratedEvent) error {
+	msg := event.GetEthV2BeaconBlockVoluntaryExit().GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetEpoch() == nil {
+		return fmt.Errorf("nil Message.Epoch: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetValidatorIndex() == nil {
+		return fmt.Errorf("nil Message.ValidatorIndex: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }
@@ -56,22 +77,9 @@ func (b *canonicalBeaconBlockVoluntaryExitBatch) appendPayload(event *xatu.Decor
 	exit := event.GetEthV2BeaconBlockVoluntaryExit()
 	b.VoluntaryExitSignature.Append(exit.GetSignature())
 
-	if msg := exit.GetMessage(); msg != nil {
-		if epoch := msg.GetEpoch(); epoch != nil {
-			b.VoluntaryExitMessageEpoch.Append(uint32(epoch.GetValue()))
-		} else {
-			b.VoluntaryExitMessageEpoch.Append(0)
-		}
-
-		if validatorIndex := msg.GetValidatorIndex(); validatorIndex != nil {
-			b.VoluntaryExitMessageValidatorIndex.Append(uint32(validatorIndex.GetValue()))
-		} else {
-			b.VoluntaryExitMessageValidatorIndex.Append(0)
-		}
-	} else {
-		b.VoluntaryExitMessageEpoch.Append(0)
-		b.VoluntaryExitMessageValidatorIndex.Append(0)
-	}
+	msg := exit.GetMessage()
+	b.VoluntaryExitMessageEpoch.Append(uint32(msg.GetEpoch().GetValue()))
+	b.VoluntaryExitMessageValidatorIndex.Append(uint32(msg.GetValidatorIndex().GetValue()))
 }
 
 func (b *canonicalBeaconBlockVoluntaryExitBatch) appendAdditionalData(event *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -25,7 +27,12 @@ func TestSnapshot_canonical_beacon_block_voluntary_exit(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockVoluntaryExit{
-			EthV2BeaconBlockVoluntaryExit: &ethv1.SignedVoluntaryExitV2{},
+			EthV2BeaconBlockVoluntaryExit: &ethv1.SignedVoluntaryExitV2{
+				Message: &ethv1.VoluntaryExitV2{
+					Epoch:          wrapperspb.UInt64(100),
+					ValidatorIndex: wrapperspb.UInt64(42),
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_withdrawal.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_withdrawal.go
@@ -82,34 +82,15 @@ func (b *canonicalBeaconBlockWithdrawalBatch) appendRuntime(_ *xatu.DecoratedEve
 func (b *canonicalBeaconBlockWithdrawalBatch) appendPayload(event *xatu.DecoratedEvent) error {
 	withdrawal := event.GetEthV2BeaconBlockWithdrawal()
 	b.WithdrawalAddress.Append([]byte(withdrawal.GetAddress()))
+	b.WithdrawalIndex.Append(uint32(withdrawal.GetIndex().GetValue()))
+	b.WithdrawalValidatorIndex.Append(uint32(withdrawal.GetValidatorIndex().GetValue()))
 
-	if index := withdrawal.GetIndex(); index != nil {
-		b.WithdrawalIndex.Append(uint32(index.GetValue()))
-	} else {
-		b.WithdrawalIndex.Append(0)
+	parsedAmount, err := route.ParseUInt128(strconv.FormatUint(withdrawal.GetAmount().GetValue(), 10))
+	if err != nil {
+		return fmt.Errorf("parsing withdrawal_amount: %w", err)
 	}
 
-	if validatorIndex := withdrawal.GetValidatorIndex(); validatorIndex != nil {
-		b.WithdrawalValidatorIndex.Append(uint32(validatorIndex.GetValue()))
-	} else {
-		b.WithdrawalValidatorIndex.Append(0)
-	}
-
-	if amount := withdrawal.GetAmount(); amount != nil {
-		parsedAmount, err := route.ParseUInt128(strconv.FormatUint(amount.GetValue(), 10))
-		if err != nil {
-			return fmt.Errorf("parsing withdrawal_amount: %w", err)
-		}
-
-		b.WithdrawalAmount.Append(parsedAmount)
-	} else {
-		zeroAmount, err := route.ParseUInt128("0")
-		if err != nil {
-			return fmt.Errorf("parsing withdrawal_amount: %w", err)
-		}
-
-		b.WithdrawalAmount.Append(zeroAmount)
-	}
+	b.WithdrawalAmount.Append(parsedAmount)
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_committee.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_committee.go
@@ -51,11 +51,29 @@ func (b *canonicalBeaconCommitteeBatch) FlattenTo(event *xatu.DecoratedEvent) er
 		return fmt.Errorf("nil eth_v1_beacon_committee payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconCommitteeBatch) validate(event *xatu.DecoratedEvent) error {
+	committee := event.GetEthV1BeaconCommittee()
+
+	if committee.GetSlot() == nil {
+		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
+	}
+
+	if committee.GetIndex() == nil {
+		return fmt.Errorf("nil Index: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }
@@ -66,19 +84,8 @@ func (b *canonicalBeaconCommitteeBatch) appendRuntime(_ *xatu.DecoratedEvent) {
 
 func (b *canonicalBeaconCommitteeBatch) appendPayload(event *xatu.DecoratedEvent) {
 	committee := event.GetEthV1BeaconCommittee()
-
-	if slot := committee.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // G115
-	} else {
-		b.Slot.Append(0)
-	}
-
-	if index := committee.GetIndex(); index != nil {
-		b.CommitteeIndex.Append(strconv.FormatUint(index.GetValue(), 10))
-	} else {
-		b.CommitteeIndex.Append("")
-	}
-
+	b.Slot.Append(uint32(committee.GetSlot().GetValue())) //nolint:gosec // G115
+	b.CommitteeIndex.Append(strconv.FormatUint(committee.GetIndex().GetValue(), 10))
 	b.Validators.Append(wrappedUint64SliceToUint32(committee.GetValidators()))
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation.go
@@ -1,6 +1,7 @@
 package canonical
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -34,10 +35,43 @@ func (b *canonicalBeaconElaboratedAttestationBatch) FlattenTo(event *xatu.Decora
 		return nil
 	}
 
+	if event.GetEthV2BeaconBlockElaboratedAttestation() == nil {
+		return fmt.Errorf("nil eth_v2_beacon_block_elaborated_attestation payload: %w", route.ErrInvalidEvent)
+	}
+
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendRow(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconElaboratedAttestationBatch) validate(event *xatu.DecoratedEvent) error {
+	data := event.GetEthV2BeaconBlockElaboratedAttestation().GetData()
+	if data == nil {
+		return fmt.Errorf("nil Data: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSlot() == nil {
+		return fmt.Errorf("nil Data.Slot: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetIndex() == nil {
+		return fmt.Errorf("nil Data.Index: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSource() == nil || data.GetSource().GetEpoch() == nil {
+		return fmt.Errorf("nil Data.Source: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetTarget() == nil || data.GetTarget().GetEpoch() == nil {
+		return fmt.Errorf("nil Data.Target: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }
@@ -53,72 +87,23 @@ func (b *canonicalBeaconElaboratedAttestationBatch) appendRuntime(_ *xatu.Decora
 func (b *canonicalBeaconElaboratedAttestationBatch) appendRow(event *xatu.DecoratedEvent) {
 	attestation := event.GetEthV2BeaconBlockElaboratedAttestation()
 
-	// Payload fields.
-	if attestation != nil {
-		b.Validators.Append(wrappedUint64SliceToUint32(attestation.GetValidatorIndexes()))
+	// Payload fields. Required fields are guaranteed non-nil by validate().
+	b.Validators.Append(wrappedUint64SliceToUint32(attestation.GetValidatorIndexes()))
 
-		if data := attestation.GetData(); data != nil {
-			b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	data := attestation.GetData()
+	b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+	b.CommitteeIndex.Append(strconv.FormatUint(data.GetIndex().GetValue(), 10))
 
-			if index := data.GetIndex(); index != nil {
-				b.CommitteeIndex.Append(strconv.FormatUint(index.GetValue(), 10))
-			} else {
-				b.CommitteeIndex.Append("")
-			}
+	source := data.GetSource()
+	b.SourceEpoch.Append(uint32(source.GetEpoch().GetValue()))
+	b.SourceRoot.Append([]byte(source.GetRoot()))
 
-			if source := data.GetSource(); source != nil {
-				if epoch := source.GetEpoch(); epoch != nil {
-					b.SourceEpoch.Append(uint32(epoch.GetValue()))
-				} else {
-					b.SourceEpoch.Append(0)
-				}
-
-				b.SourceRoot.Append([]byte(source.GetRoot()))
-			} else {
-				b.SourceEpoch.Append(0)
-				b.SourceRoot.Append(nil)
-			}
-
-			if target := data.GetTarget(); target != nil {
-				if epoch := target.GetEpoch(); epoch != nil {
-					b.TargetEpoch.Append(uint32(epoch.GetValue()))
-				} else {
-					b.TargetEpoch.Append(0)
-				}
-
-				b.TargetRoot.Append([]byte(target.GetRoot()))
-			} else {
-				b.TargetEpoch.Append(0)
-				b.TargetRoot.Append(nil)
-			}
-		} else {
-			b.BeaconBlockRoot.Append(nil)
-			b.CommitteeIndex.Append("")
-			b.SourceEpoch.Append(0)
-			b.SourceRoot.Append(nil)
-			b.TargetEpoch.Append(0)
-			b.TargetRoot.Append(nil)
-		}
-	} else {
-		b.Validators.Append([]uint32{})
-		b.BeaconBlockRoot.Append(nil)
-		b.CommitteeIndex.Append("")
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-	}
+	target := data.GetTarget()
+	b.TargetEpoch.Append(uint32(target.GetEpoch().GetValue()))
+	b.TargetRoot.Append([]byte(target.GetRoot()))
 
 	// Slot from payload (matching Vector: .slot = .data.data.slot).
-	if attestation != nil && attestation.GetData() != nil {
-		if slot := attestation.GetData().GetSlot(); slot != nil {
-			b.Slot.Append(uint32(slot.GetValue()))
-		} else {
-			b.Slot.Append(0)
-		}
-	} else {
-		b.Slot.Append(0)
-	}
+	b.Slot.Append(uint32(data.GetSlot().GetValue()))
 
 	// Additional data fields.
 	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockElaboratedAttestation()

--- a/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation_test.go
@@ -26,6 +26,12 @@ func TestSnapshot_canonical_beacon_elaborated_attestation(t *testing.T) {
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockElaboratedAttestation{
 			EthV2BeaconBlockElaboratedAttestation: &ethv1.ElaboratedAttestation{
+				Data: &ethv1.AttestationDataV2{
+					Slot:   wrapperspb.UInt64(100),
+					Index:  wrapperspb.UInt64(3),
+					Source: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(4)},
+					Target: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(5)},
+				},
 				ValidatorIndexes: []*wrapperspb.UInt64Value{
 					wrapperspb.UInt64(11),
 					wrapperspb.UInt64(22),

--- a/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty.go
@@ -81,12 +81,7 @@ func (b *canonicalBeaconProposerDutyBatch) appendRuntime(_ *xatu.DecoratedEvent)
 func (b *canonicalBeaconProposerDutyBatch) appendPayload(event *xatu.DecoratedEvent) {
 	duty := event.GetEthV1ProposerDuty()
 	b.ProposerPubkey.Append(duty.GetPubkey())
-
-	if validatorIndex := duty.GetValidatorIndex(); validatorIndex != nil {
-		b.ProposerValidatorIndex.Append(uint32(validatorIndex.GetValue()))
-	} else {
-		b.ProposerValidatorIndex.Append(0)
-	}
+	b.ProposerValidatorIndex.Append(uint32(duty.GetValidatorIndex().GetValue()))
 }
 
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema

--- a/pkg/clickhouse/route/canonical/canonical_beacon_validators_pubkeys.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_validators_pubkeys.go
@@ -73,17 +73,17 @@ func (b *canonicalBeaconValidatorsPubkeysBatch) FlattenTo(event *xatu.DecoratedE
 			continue
 		}
 
+		data := validator.GetData()
+		if data == nil || data.GetPubkey() == nil {
+			continue
+		}
+
 		b.UpdatedDateTime.Append(now)
 		b.Epoch.Append(epoch)
 		b.EpochStartDateTime.Append(epochStartTime)
 
 		b.Index.Append(uint32(validator.GetIndex().GetValue()))
-
-		if data := validator.GetData(); data != nil && data.GetPubkey() != nil {
-			b.Pubkey.Append(data.GetPubkey().GetValue())
-		} else {
-			b.Pubkey.Append("")
-		}
+		b.Pubkey.Append(data.GetPubkey().GetValue())
 
 		b.appendMetadata(event)
 		b.rows++

--- a/pkg/clickhouse/route/canonical/canonical_beacon_validators_withdrawal_credentials.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_validators_withdrawal_credentials.go
@@ -73,17 +73,17 @@ func (b *canonicalBeaconValidatorsWithdrawalCredentialsBatch) FlattenTo(event *x
 			continue
 		}
 
+		data := validator.GetData()
+		if data == nil || data.GetWithdrawalCredentials() == nil {
+			continue
+		}
+
 		b.UpdatedDateTime.Append(now)
 		b.Epoch.Append(epoch)
 		b.EpochStartDateTime.Append(epochStartTime)
 
 		b.Index.Append(uint32(validator.GetIndex().GetValue()))
-
-		if data := validator.GetData(); data != nil && data.GetWithdrawalCredentials() != nil {
-			b.WithdrawalCredentials.Append(data.GetWithdrawalCredentials().GetValue())
-		} else {
-			b.WithdrawalCredentials.Append("")
-		}
+		b.WithdrawalCredentials.Append(data.GetWithdrawalCredentials().GetValue())
 
 		b.appendMetadata(event)
 		b.rows++

--- a/pkg/clickhouse/route/cmd/generate/scaffold.go
+++ b/pkg/clickhouse/route/cmd/generate/scaffold.go
@@ -45,13 +45,41 @@ func (b *{{.BatchName}}) FlattenTo(
 	// TODO: Implement this method to flatten the event into columnar batch columns.
 	// The generated .gen.go file contains the available column fields for this table.
 	//
+	// DATA-CORRECTNESS RULES (do not deviate):
+	//   - For a REQUIRED field (one where 0, "", or a zero-hash is itself a valid
+	//     value: validator/proposer index, slot, epoch, amount, reward, position,
+	//     gas, nonce, block_hash, pubkeys, etc.), nil-check the wrapper in
+	//     validate() and return route.ErrInvalidEvent when it is absent. Then in
+	//     appendPayload append the value DIRECTLY with NO else-zero fallback.
+	//     A silent else-zero fabricates data indistinguishable from a real value.
+	//   - For a GENUINELY-OPTIONAL field (sometimes absent by protocol), make the
+	//     column Nullable(T) in the migration / *proto.ColNullable[T] in the gen,
+	//     and append proto.NewNullable / proto.Nullable{} (writing NULL when absent).
+	//   - proto3 SCALAR fields (plain uint64/string, not wrapperspb) cannot be
+	//     nil-checked; only wrapper fields can. Do not synthesize a scalar nil-check.
+	//
 	// Typical structure:
+	//   if err := b.validate(event); err != nil {
+	//       return err
+	//   }
 	//   b.appendRuntime(event)
 	//   b.appendMetadata(event)
-	//   b.appendPayload(event)
+	//   if err := b.appendPayload(event); err != nil {
+	//       return err
+	//   }
 	//   b.rows++
 	//   return nil
 	return fmt.Errorf("{{.TypeName}}: FlattenTo not implemented")
+}
+
+// validate returns route.ErrInvalidEvent when a required field is absent, so the
+// event is dropped rather than written with fabricated zero values.
+func (b *{{.BatchName}}) validate(event *xatu.DecoratedEvent) error {
+	// TODO: nil-check each required wrapper field on the payload and return
+	// fmt.Errorf("nil <field>: %w", route.ErrInvalidEvent) when absent.
+	_ = event
+
+	return nil
 }
 `))
 

--- a/pkg/clickhouse/route/execution/consensus_engine_api_get_blobs.go
+++ b/pkg/clickhouse/route/execution/consensus_engine_api_get_blobs.go
@@ -93,26 +93,11 @@ func (b *consensusEngineApiGetBlobsBatch) appendPayload(event *xatu.DecoratedEve
 		b.RequestedDateTime.Append(time.Time{})
 	}
 
-	if durationMs := payload.GetDurationMs(); durationMs != nil {
-		b.DurationMs.Append(durationMs.GetValue())
-	} else {
-		b.DurationMs.Append(0)
-	}
-
-	if slot := payload.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot values fit uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.DurationMs.Append(payload.GetDurationMs().GetValue())
+	b.Slot.Append(uint32(payload.GetSlot().GetValue())) //nolint:gosec // slot values fit uint32
 	b.BlockRoot.Append([]byte(payload.GetBlockRoot()))
 	b.ParentBlockRoot.Append([]byte(payload.GetParentBlockRoot()))
-
-	if requestedCount := payload.GetRequestedCount(); requestedCount != nil {
-		b.RequestedCount.Append(requestedCount.GetValue())
-	} else {
-		b.RequestedCount.Append(0)
-	}
+	b.RequestedCount.Append(payload.GetRequestedCount().GetValue())
 
 	hashes := payload.GetVersionedHashes()
 
@@ -123,12 +108,7 @@ func (b *consensusEngineApiGetBlobsBatch) appendPayload(event *xatu.DecoratedEve
 
 	b.VersionedHashes.Append(hashBytes)
 
-	if returnedCount := payload.GetReturnedCount(); returnedCount != nil {
-		b.ReturnedCount.Append(returnedCount.GetValue())
-	} else {
-		b.ReturnedCount.Append(0)
-	}
-
+	b.ReturnedCount.Append(payload.GetReturnedCount().GetValue())
 	b.Status.Append(payload.GetStatus())
 
 	if errMsg := payload.GetErrorMessage(); errMsg != "" {

--- a/pkg/clickhouse/route/execution/consensus_engine_api_new_payload.go
+++ b/pkg/clickhouse/route/execution/consensus_engine_api_new_payload.go
@@ -109,60 +109,18 @@ func (b *consensusEngineApiNewPayloadBatch) appendPayload(event *xatu.DecoratedE
 		b.RequestedDateTime.Append(time.Time{})
 	}
 
-	if durationMs := payload.GetDurationMs(); durationMs != nil {
-		b.DurationMs.Append(durationMs.GetValue())
-	} else {
-		b.DurationMs.Append(0)
-	}
-
-	if slot := payload.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // slot values fit uint32
-	} else {
-		b.Slot.Append(0)
-	}
-
+	b.DurationMs.Append(payload.GetDurationMs().GetValue())
+	b.Slot.Append(uint32(payload.GetSlot().GetValue())) //nolint:gosec // slot values fit uint32
 	b.BlockRoot.Append([]byte(payload.GetBlockRoot()))
 	b.ParentBlockRoot.Append([]byte(payload.GetParentBlockRoot()))
-
-	if proposerIndex := payload.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue())) //nolint:gosec // proposer index fits uint32
-	} else {
-		b.ProposerIndex.Append(0)
-	}
-
-	if blockNumber := payload.GetBlockNumber(); blockNumber != nil {
-		b.BlockNumber.Append(blockNumber.GetValue())
-	} else {
-		b.BlockNumber.Append(0)
-	}
-
+	b.ProposerIndex.Append(uint32(payload.GetProposerIndex().GetValue())) //nolint:gosec // proposer index fits uint32
+	b.BlockNumber.Append(payload.GetBlockNumber().GetValue())
 	b.BlockHash.Append([]byte(payload.GetBlockHash()))
 	b.ParentHash.Append([]byte(payload.GetParentHash()))
-
-	if gasUsed := payload.GetGasUsed(); gasUsed != nil {
-		b.GasUsed.Append(gasUsed.GetValue())
-	} else {
-		b.GasUsed.Append(0)
-	}
-
-	if gasLimit := payload.GetGasLimit(); gasLimit != nil {
-		b.GasLimit.Append(gasLimit.GetValue())
-	} else {
-		b.GasLimit.Append(0)
-	}
-
-	if txCount := payload.GetTxCount(); txCount != nil {
-		b.TxCount.Append(txCount.GetValue())
-	} else {
-		b.TxCount.Append(0)
-	}
-
-	if blobCount := payload.GetBlobCount(); blobCount != nil {
-		b.BlobCount.Append(blobCount.GetValue())
-	} else {
-		b.BlobCount.Append(0)
-	}
-
+	b.GasUsed.Append(payload.GetGasUsed().GetValue())
+	b.GasLimit.Append(payload.GetGasLimit().GetValue())
+	b.TxCount.Append(payload.GetTxCount().GetValue())
+	b.BlobCount.Append(payload.GetBlobCount().GetValue())
 	b.Status.Append(payload.GetStatus())
 
 	if lvh := payload.GetLatestValidHash(); lvh != "" {

--- a/pkg/clickhouse/route/execution/execution_block_metrics.go
+++ b/pkg/clickhouse/route/execution/execution_block_metrics.go
@@ -81,27 +81,10 @@ func (b *executionBlockMetricsBatch) appendRuntime(event *xatu.DecoratedEvent) {
 func (b *executionBlockMetricsBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetExecutionBlockMetrics()
 	b.Source.Append(payload.GetSource())
-
-	if blockNumber := payload.GetBlockNumber(); blockNumber != nil {
-		b.BlockNumber.Append(blockNumber.GetValue())
-	} else {
-		b.BlockNumber.Append(0)
-	}
-
+	b.BlockNumber.Append(payload.GetBlockNumber().GetValue())
 	b.BlockHash.Append([]byte(payload.GetBlockHash()))
-
-	if gasUsed := payload.GetGasUsed(); gasUsed != nil {
-		b.GasUsed.Append(gasUsed.GetValue())
-	} else {
-		b.GasUsed.Append(0)
-	}
-
-	if txCount := payload.GetTxCount(); txCount != nil {
-		b.TxCount.Append(txCount.GetValue())
-	} else {
-		b.TxCount.Append(0)
-	}
-
+	b.GasUsed.Append(payload.GetGasUsed().GetValue())
+	b.TxCount.Append(payload.GetTxCount().GetValue())
 	b.appendPayloadTiming(payload)
 	b.appendPayloadStateIO(payload)
 	b.appendPayloadCaches(payload)

--- a/pkg/clickhouse/route/execution/execution_engine_get_blobs.go
+++ b/pkg/clickhouse/route/execution/execution_engine_get_blobs.go
@@ -90,17 +90,8 @@ func (b *executionEngineGetBlobsBatch) appendPayload(event *xatu.DecoratedEvent)
 		b.RequestedDateTime.Append(time.Time{})
 	}
 
-	if durationMs := payload.GetDurationMs(); durationMs != nil {
-		b.DurationMs.Append(durationMs.GetValue())
-	} else {
-		b.DurationMs.Append(0)
-	}
-
-	if requestedCount := payload.GetRequestedCount(); requestedCount != nil {
-		b.RequestedCount.Append(requestedCount.GetValue())
-	} else {
-		b.RequestedCount.Append(0)
-	}
+	b.DurationMs.Append(payload.GetDurationMs().GetValue())
+	b.RequestedCount.Append(payload.GetRequestedCount().GetValue())
 
 	strs := payload.GetVersionedHashes()
 
@@ -111,11 +102,7 @@ func (b *executionEngineGetBlobsBatch) appendPayload(event *xatu.DecoratedEvent)
 
 	b.VersionedHashes.Append(vhBytes)
 
-	if returnedCount := payload.GetReturnedCount(); returnedCount != nil {
-		b.ReturnedCount.Append(returnedCount.GetValue())
-	} else {
-		b.ReturnedCount.Append(0)
-	}
+	b.ReturnedCount.Append(payload.GetReturnedCount().GetValue())
 
 	indexes := payload.GetReturnedBlobIndexes()
 	if len(indexes) > 0 {

--- a/pkg/clickhouse/route/execution/execution_engine_new_payload.go
+++ b/pkg/clickhouse/route/execution/execution_engine_new_payload.go
@@ -102,45 +102,14 @@ func (b *executionEngineNewPayloadBatch) appendPayload(event *xatu.DecoratedEven
 		b.RequestedDateTime.Append(time.Time{})
 	}
 
-	if durationMs := payload.GetDurationMs(); durationMs != nil {
-		b.DurationMs.Append(durationMs.GetValue())
-	} else {
-		b.DurationMs.Append(0)
-	}
-
-	if blockNumber := payload.GetBlockNumber(); blockNumber != nil {
-		b.BlockNumber.Append(blockNumber.GetValue())
-	} else {
-		b.BlockNumber.Append(0)
-	}
-
+	b.DurationMs.Append(payload.GetDurationMs().GetValue())
+	b.BlockNumber.Append(payload.GetBlockNumber().GetValue())
 	b.BlockHash.Append([]byte(payload.GetBlockHash()))
 	b.ParentHash.Append([]byte(payload.GetParentHash()))
-
-	if gasUsed := payload.GetGasUsed(); gasUsed != nil {
-		b.GasUsed.Append(gasUsed.GetValue())
-	} else {
-		b.GasUsed.Append(0)
-	}
-
-	if gasLimit := payload.GetGasLimit(); gasLimit != nil {
-		b.GasLimit.Append(gasLimit.GetValue())
-	} else {
-		b.GasLimit.Append(0)
-	}
-
-	if txCount := payload.GetTxCount(); txCount != nil {
-		b.TxCount.Append(txCount.GetValue())
-	} else {
-		b.TxCount.Append(0)
-	}
-
-	if blobCount := payload.GetBlobCount(); blobCount != nil {
-		b.BlobCount.Append(blobCount.GetValue())
-	} else {
-		b.BlobCount.Append(0)
-	}
-
+	b.GasUsed.Append(payload.GetGasUsed().GetValue())
+	b.GasLimit.Append(payload.GetGasLimit().GetValue())
+	b.TxCount.Append(payload.GetTxCount().GetValue())
+	b.BlobCount.Append(payload.GetBlobCount().GetValue())
 	b.Status.Append(payload.GetStatus())
 
 	if lvh := payload.GetLatestValidHash(); lvh != "" {

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_aggregate_and_proof.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_aggregate_and_proof.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
+	v1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
@@ -84,6 +85,33 @@ func (b *libp2pGossipsubAggregateAndProofBatch) validate(event *xatu.DecoratedEv
 		return fmt.Errorf("nil Propagation.SlotStartDiff: %w", route.ErrInvalidEvent)
 	}
 
+	return validateAggregateAndProofPayload(event.GetLibp2PTraceGossipsubAggregateAndProof())
+}
+
+func validateAggregateAndProofPayload(payload *v1.SignedAggregateAttestationAndProofV2) error {
+	msg := payload.GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
+	}
+
+	aggregate := msg.GetAggregate()
+	if aggregate == nil {
+		return fmt.Errorf("nil Aggregate: %w", route.ErrInvalidEvent)
+	}
+
+	data := aggregate.GetData()
+	if data == nil {
+		return fmt.Errorf("nil Data: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSource() == nil || data.GetSource().GetEpoch() == nil {
+		return fmt.Errorf("nil Data.Source.Epoch: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetTarget() == nil || data.GetTarget().GetEpoch() == nil {
+		return fmt.Errorf("nil Data.Target.Epoch: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 
@@ -101,76 +129,26 @@ func (b *libp2pGossipsubAggregateAndProofBatch) appendRuntime(event *xatu.Decora
 func (b *libp2pGossipsubAggregateAndProofBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetLibp2PTraceGossipsubAggregateAndProof()
 
-	msg := payload.GetMessage()
-	if msg == nil {
-		b.AggregationBits.Append("")
-		b.BeaconBlockRoot.Append(nil)
-		b.CommitteeIndex.Append("")
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-
-		return
-	}
-
-	aggregate := msg.GetAggregate()
-	if aggregate == nil {
-		b.AggregationBits.Append("")
-		b.BeaconBlockRoot.Append(nil)
-		b.CommitteeIndex.Append("")
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
-
-		return
-	}
-
+	aggregate := payload.GetMessage().GetAggregate()
 	b.AggregationBits.Append(aggregate.GetAggregationBits())
 
-	if data := aggregate.GetData(); data != nil {
-		if idx := data.GetIndex(); idx != nil {
-			b.CommitteeIndex.Append(strconv.FormatUint(idx.GetValue(), 10))
-		} else {
-			b.CommitteeIndex.Append("")
-		}
+	data := aggregate.GetData()
 
-		b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
-
-		if source := data.GetSource(); source != nil {
-			if epoch := source.GetEpoch(); epoch != nil {
-				b.SourceEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.SourceEpoch.Append(0)
-			}
-
-			b.SourceRoot.Append([]byte(source.GetRoot()))
-		} else {
-			b.SourceEpoch.Append(0)
-			b.SourceRoot.Append(nil)
-		}
-
-		if target := data.GetTarget(); target != nil {
-			if epoch := target.GetEpoch(); epoch != nil {
-				b.TargetEpoch.Append(uint32(epoch.GetValue()))
-			} else {
-				b.TargetEpoch.Append(0)
-			}
-
-			b.TargetRoot.Append([]byte(target.GetRoot()))
-		} else {
-			b.TargetEpoch.Append(0)
-			b.TargetRoot.Append(nil)
-		}
+	if idx := data.GetIndex(); idx != nil {
+		b.CommitteeIndex.Append(strconv.FormatUint(idx.GetValue(), 10))
 	} else {
-		b.BeaconBlockRoot.Append(nil)
 		b.CommitteeIndex.Append("")
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
 	}
+
+	b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+
+	source := data.GetSource()
+	b.SourceEpoch.Append(uint32(source.GetEpoch().GetValue()))
+	b.SourceRoot.Append([]byte(source.GetRoot()))
+
+	target := data.GetTarget()
+	b.TargetEpoch.Append(uint32(target.GetEpoch().GetValue()))
+	b.TargetRoot.Append([]byte(target.GetRoot()))
 }
 
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse uint32 column schema

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_aggregate_and_proof_test.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_aggregate_and_proof_test.go
@@ -41,7 +41,18 @@ func TestSnapshot_libp2p_gossipsub_aggregate_and_proof(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_Libp2PTraceGossipsubAggregateAndProof{
-			Libp2PTraceGossipsubAggregateAndProof: &ethv1.SignedAggregateAttestationAndProofV2{},
+			Libp2PTraceGossipsubAggregateAndProof: &ethv1.SignedAggregateAttestationAndProofV2{
+				Message: &ethv1.AggregateAttestationAndProofV2{
+					Aggregate: &ethv1.AttestationV2{
+						Data: &ethv1.AttestationDataV2{
+							Slot:   wrapperspb.UInt64(100),
+							Index:  wrapperspb.UInt64(3),
+							Source: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(9), Root: "0xsource"},
+							Target: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(10), Root: "0xtarget"},
+						},
+					},
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"peer_id_unique_key": expectedPeerIDKey,

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_attestation.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_attestation.go
@@ -86,6 +86,21 @@ func (b *libp2pGossipsubBeaconAttestationBatch) validate(event *xatu.DecoratedEv
 		return fmt.Errorf("nil Propagation.SlotStartDiff: %w", route.ErrInvalidEvent)
 	}
 
+	payload := event.GetLibp2PTraceGossipsubBeaconAttestation()
+
+	data := payload.GetData()
+	if data == nil {
+		return fmt.Errorf("nil Data: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSource() == nil {
+		return fmt.Errorf("nil Data.Source: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetTarget() == nil {
+		return fmt.Errorf("nil Data.Target: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 
@@ -104,38 +119,23 @@ func (b *libp2pGossipsubBeaconAttestationBatch) appendPayload(event *xatu.Decora
 	payload := event.GetLibp2PTraceGossipsubBeaconAttestation()
 	b.AggregationBits.Append(payload.GetAggregationBits())
 
-	if data := payload.GetData(); data != nil {
-		if idx := data.GetIndex(); idx != 0 {
-			b.CommitteeIndex.Append(strconv.FormatUint(idx, 10))
-		} else {
-			b.CommitteeIndex.Append("")
-		}
+	data := payload.GetData()
 
-		b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
-
-		if source := data.GetSource(); source != nil {
-			b.SourceEpoch.Append(uint32(source.GetEpoch()))
-			b.SourceRoot.Append([]byte(source.GetRoot()))
-		} else {
-			b.SourceEpoch.Append(0)
-			b.SourceRoot.Append(nil)
-		}
-
-		if target := data.GetTarget(); target != nil {
-			b.TargetEpoch.Append(uint32(target.GetEpoch()))
-			b.TargetRoot.Append([]byte(target.GetRoot()))
-		} else {
-			b.TargetEpoch.Append(0)
-			b.TargetRoot.Append(nil)
-		}
+	if idx := data.GetIndex(); idx != 0 {
+		b.CommitteeIndex.Append(strconv.FormatUint(idx, 10))
 	} else {
 		b.CommitteeIndex.Append("")
-		b.BeaconBlockRoot.Append(nil)
-		b.SourceEpoch.Append(0)
-		b.SourceRoot.Append(nil)
-		b.TargetEpoch.Append(0)
-		b.TargetRoot.Append(nil)
 	}
+
+	b.BeaconBlockRoot.Append([]byte(data.GetBeaconBlockRoot()))
+
+	source := data.GetSource()
+	b.SourceEpoch.Append(uint32(source.GetEpoch()))
+	b.SourceRoot.Append([]byte(source.GetRoot()))
+
+	target := data.GetTarget()
+	b.TargetEpoch.Append(uint32(target.GetEpoch()))
+	b.TargetRoot.Append([]byte(target.GetRoot()))
 }
 
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse column schema

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_attestation_test.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_attestation_test.go
@@ -43,7 +43,9 @@ func TestSnapshot_libp2p_gossipsub_beacon_attestation(t *testing.T) {
 		Data: &xatu.DecoratedEvent_Libp2PTraceGossipsubBeaconAttestation{
 			Libp2PTraceGossipsubBeaconAttestation: &ethv1.Attestation{
 				Data: &ethv1.AttestationData{
-					Slot: 100,
+					Slot:   100,
+					Source: &ethv1.Checkpoint{Epoch: 9, Root: "0xsource"},
+					Target: &ethv1.Checkpoint{Epoch: 10, Root: "0xtarget"},
 				},
 			},
 		},

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_block.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_beacon_block.go
@@ -106,12 +106,7 @@ func (b *libp2pGossipsubBeaconBlockBatch) appendRuntime(event *xatu.DecoratedEve
 func (b *libp2pGossipsubBeaconBlockBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetLibp2PTraceGossipsubBeaconBlock()
 	b.Block.Append([]byte(wrappedStringValue(payload.GetBlock())))
-
-	if proposerIndex := payload.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-	} else {
-		b.ProposerIndex.Append(0)
-	}
+	b.ProposerIndex.Append(uint32(payload.GetProposerIndex().GetValue()))
 }
 
 func (b *libp2pGossipsubBeaconBlockBatch) appendClientAdditionalData(

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_blob_sidecar.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_blob_sidecar.go
@@ -109,18 +109,8 @@ func (b *libp2pGossipsubBlobSidecarBatch) appendRuntime(event *xatu.DecoratedEve
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse column schema
 func (b *libp2pGossipsubBlobSidecarBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetLibp2PTraceGossipsubBlobSidecar()
-	if idx := payload.GetIndex(); idx != nil {
-		b.BlobIndex.Append(uint32(idx.GetValue()))
-	} else {
-		b.BlobIndex.Append(0)
-	}
-
-	if proposerIndex := payload.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-	} else {
-		b.ProposerIndex.Append(0)
-	}
-
+	b.BlobIndex.Append(uint32(payload.GetIndex().GetValue()))
+	b.ProposerIndex.Append(uint32(payload.GetProposerIndex().GetValue()))
 	b.StateRoot.Append([]byte(wrappedStringValue(payload.GetStateRoot())))
 	b.ParentRoot.Append([]byte(wrappedStringValue(payload.GetParentRoot())))
 	b.BeaconBlockRoot.Append([]byte(wrappedStringValue(payload.GetBlockRoot())))

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_data_column_sidecar.go
@@ -113,27 +113,12 @@ func (b *libp2pGossipsubDataColumnSidecarBatch) appendRuntime(event *xatu.Decora
 //nolint:gosec // G115: proto uint64 values are bounded by ClickHouse column schema
 func (b *libp2pGossipsubDataColumnSidecarBatch) appendPayload(event *xatu.DecoratedEvent) {
 	payload := event.GetLibp2PTraceGossipsubDataColumnSidecar()
-	if idx := payload.GetIndex(); idx != nil {
-		b.ColumnIndex.Append(idx.GetValue())
-	} else {
-		b.ColumnIndex.Append(0)
-	}
-
-	if proposerIndex := payload.GetProposerIndex(); proposerIndex != nil {
-		b.ProposerIndex.Append(uint32(proposerIndex.GetValue()))
-	} else {
-		b.ProposerIndex.Append(0)
-	}
-
+	b.ColumnIndex.Append(payload.GetIndex().GetValue())
+	b.ProposerIndex.Append(uint32(payload.GetProposerIndex().GetValue()))
 	b.StateRoot.Append([]byte(wrappedStringValue(payload.GetStateRoot())))
 	b.ParentRoot.Append([]byte(wrappedStringValue(payload.GetParentRoot())))
 	b.BeaconBlockRoot.Append([]byte(wrappedStringValue(payload.GetBlockRoot())))
-
-	if kzg := payload.GetKzgCommitmentsCount(); kzg != nil {
-		b.KzgCommitmentsCount.Append(kzg.GetValue())
-	} else {
-		b.KzgCommitmentsCount.Append(0)
-	}
+	b.KzgCommitmentsCount.Append(payload.GetKzgCommitmentsCount().GetValue())
 }
 
 func (b *libp2pGossipsubDataColumnSidecarBatch) appendClientAdditionalData(

--- a/pkg/clickhouse/route/mev/mev_relay_bid_trace.go
+++ b/pkg/clickhouse/route/mev/mev_relay_bid_trace.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/ch-go/proto"
-
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
@@ -64,8 +62,24 @@ func (b *mevRelayBidTraceBatch) validate(event *xatu.DecoratedEvent) error {
 		return fmt.Errorf("nil Slot: %w", route.ErrInvalidEvent)
 	}
 
-	if payload.GetBlockNumber() == nil {
-		return fmt.Errorf("nil BlockNumber: %w", route.ErrInvalidEvent)
+	if payload.GetParentHash() == nil {
+		return fmt.Errorf("nil ParentHash: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetBlockHash() == nil {
+		return fmt.Errorf("nil BlockHash: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetBuilderPubkey() == nil {
+		return fmt.Errorf("nil BuilderPubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetProposerPubkey() == nil {
+		return fmt.Errorf("nil ProposerPubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetProposerFeeRecipient() == nil {
+		return fmt.Errorf("nil ProposerFeeRecipient: %w", route.ErrInvalidEvent)
 	}
 
 	if payload.GetGasLimit() == nil {
@@ -76,8 +90,16 @@ func (b *mevRelayBidTraceBatch) validate(event *xatu.DecoratedEvent) error {
 		return fmt.Errorf("nil GasUsed: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetValue() == nil {
+		return fmt.Errorf("nil Value: %w", route.ErrInvalidEvent)
+	}
+
 	if payload.GetNumTx() == nil {
 		return fmt.Errorf("nil NumTx: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetBlockNumber() == nil {
+		return fmt.Errorf("nil BlockNumber: %w", route.ErrInvalidEvent)
 	}
 
 	if payload.GetTimestamp() == nil {
@@ -129,94 +151,27 @@ func (b *mevRelayBidTraceBatch) appendRuntime(event *xatu.DecoratedEvent) {
 
 func (b *mevRelayBidTraceBatch) appendPayload(event *xatu.DecoratedEvent) error {
 	payload := event.GetMevRelayBidTraceBuilderBlockSubmission()
-	if slot := payload.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // proto uint64 narrowed to uint32 target field
-	} else {
-		b.Slot.Append(0)
+
+	parsedValue, err := route.ParseUInt256(payload.GetValue().GetValue())
+	if err != nil {
+		return fmt.Errorf("parsing value: %w", err)
 	}
 
-	if parentHash := payload.GetParentHash(); parentHash != nil {
-		b.ParentHash.Append([]byte(parentHash.GetValue()))
-	} else {
-		b.ParentHash.Append(nil)
-	}
-
-	if blockNumber := payload.GetBlockNumber(); blockNumber != nil {
-		b.BlockNumber.Append(blockNumber.GetValue())
-	} else {
-		b.BlockNumber.Append(0)
-	}
-
-	if blockHash := payload.GetBlockHash(); blockHash != nil {
-		b.BlockHash.Append([]byte(blockHash.GetValue()))
-	} else {
-		b.BlockHash.Append(nil)
-	}
-
-	if builderPubkey := payload.GetBuilderPubkey(); builderPubkey != nil {
-		b.BuilderPubkey.Append(builderPubkey.GetValue())
-	} else {
-		b.BuilderPubkey.Append("")
-	}
-
-	if proposerPubkey := payload.GetProposerPubkey(); proposerPubkey != nil {
-		b.ProposerPubkey.Append(proposerPubkey.GetValue())
-	} else {
-		b.ProposerPubkey.Append("")
-	}
-
-	if proposerFeeRecipient := payload.GetProposerFeeRecipient(); proposerFeeRecipient != nil {
-		b.ProposerFeeRecipient.Append([]byte(proposerFeeRecipient.GetValue()))
-	} else {
-		b.ProposerFeeRecipient.Append(nil)
-	}
-
-	if gasLimit := payload.GetGasLimit(); gasLimit != nil {
-		b.GasLimit.Append(gasLimit.GetValue())
-	} else {
-		b.GasLimit.Append(0)
-	}
-
-	if gasUsed := payload.GetGasUsed(); gasUsed != nil {
-		b.GasUsed.Append(gasUsed.GetValue())
-	} else {
-		b.GasUsed.Append(0)
-	}
-
-	if value := payload.GetValue(); value != nil {
-		parsedValue, err := route.ParseUInt256(value.GetValue())
-		if err != nil {
-			return fmt.Errorf("parsing value: %w", err)
-		}
-
-		b.Value.Append(parsedValue)
-	} else {
-		b.Value.Append(proto.UInt256{})
-	}
-
-	if numTx := payload.GetNumTx(); numTx != nil {
-		b.NumTx.Append(uint32(numTx.GetValue())) //nolint:gosec // proto uint64 narrowed to uint32 target field
-	} else {
-		b.NumTx.Append(0)
-	}
-
-	if timestamp := payload.GetTimestamp(); timestamp != nil {
-		b.Timestamp.Append(timestamp.GetValue())
-	} else {
-		b.Timestamp.Append(0)
-	}
-
-	if timestampMs := payload.GetTimestampMs(); timestampMs != nil {
-		b.TimestampMs.Append(timestampMs.GetValue())
-	} else {
-		b.TimestampMs.Append(0)
-	}
-
-	if optimistic := payload.GetOptimisticSubmission(); optimistic != nil {
-		b.OptimisticSubmission.Append(optimistic.GetValue())
-	} else {
-		b.OptimisticSubmission.Append(false)
-	}
+	//nolint:gosec // G115: proto uint64 values narrowed to uint32 target columns
+	b.Slot.Append(uint32(payload.GetSlot().GetValue()))
+	b.ParentHash.Append([]byte(payload.GetParentHash().GetValue()))
+	b.BlockNumber.Append(payload.GetBlockNumber().GetValue())
+	b.BlockHash.Append([]byte(payload.GetBlockHash().GetValue()))
+	b.BuilderPubkey.Append(payload.GetBuilderPubkey().GetValue())
+	b.ProposerPubkey.Append(payload.GetProposerPubkey().GetValue())
+	b.ProposerFeeRecipient.Append([]byte(payload.GetProposerFeeRecipient().GetValue()))
+	b.GasLimit.Append(payload.GetGasLimit().GetValue())
+	b.GasUsed.Append(payload.GetGasUsed().GetValue())
+	b.Value.Append(parsedValue)
+	b.NumTx.Append(uint32(payload.GetNumTx().GetValue())) //nolint:gosec // G115
+	b.Timestamp.Append(payload.GetTimestamp().GetValue())
+	b.TimestampMs.Append(payload.GetTimestampMs().GetValue())
+	b.OptimisticSubmission.Append(payload.GetOptimisticSubmission().GetValue())
 
 	return nil
 }

--- a/pkg/clickhouse/route/mev/mev_relay_bid_trace_test.go
+++ b/pkg/clickhouse/route/mev/mev_relay_bid_trace_test.go
@@ -29,6 +29,8 @@ func TestSnapshot_mev_relay_bid_trace(t *testing.T) {
 		Data: &xatu.DecoratedEvent_MevRelayBidTraceBuilderBlockSubmission{
 			MevRelayBidTraceBuilderBlockSubmission: &mevrelay.BidTrace{
 				Slot:                 wrapperspb.UInt64(100),
+				ParentHash:           wrapperspb.String("0xparent"),
+				BlockHash:            wrapperspb.String("0xblock"),
 				BlockNumber:          wrapperspb.UInt64(1000),
 				BuilderPubkey:        wrapperspb.String("0xbuilder"),
 				ProposerPubkey:       wrapperspb.String("0xproposer"),

--- a/pkg/clickhouse/route/mev/mev_relay_proposer_payload_delivered.go
+++ b/pkg/clickhouse/route/mev/mev_relay_proposer_payload_delivered.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/ch-go/proto"
-
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
@@ -68,12 +66,32 @@ func (b *mevRelayProposerPayloadDeliveredBatch) validate(event *xatu.DecoratedEv
 		return fmt.Errorf("nil BlockNumber: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetBlockHash() == nil {
+		return fmt.Errorf("nil BlockHash: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetProposerPubkey() == nil {
+		return fmt.Errorf("nil ProposerPubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetBuilderPubkey() == nil {
+		return fmt.Errorf("nil BuilderPubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetProposerFeeRecipient() == nil {
+		return fmt.Errorf("nil ProposerFeeRecipient: %w", route.ErrInvalidEvent)
+	}
+
 	if payload.GetGasLimit() == nil {
 		return fmt.Errorf("nil GasLimit: %w", route.ErrInvalidEvent)
 	}
 
 	if payload.GetGasUsed() == nil {
 		return fmt.Errorf("nil GasUsed: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetValue() == nil {
+		return fmt.Errorf("nil Value: %w", route.ErrInvalidEvent)
 	}
 
 	if payload.GetNumTx() == nil {
@@ -117,70 +135,23 @@ func (b *mevRelayProposerPayloadDeliveredBatch) appendRuntime(event *xatu.Decora
 
 func (b *mevRelayProposerPayloadDeliveredBatch) appendPayload(event *xatu.DecoratedEvent) error {
 	payload := event.GetMevRelayPayloadDelivered()
-	if slot := payload.GetSlot(); slot != nil {
-		b.Slot.Append(uint32(slot.GetValue())) //nolint:gosec // proto uint64 narrowed to uint32 target field
-	} else {
-		b.Slot.Append(0)
+
+	parsedValue, err := route.ParseUInt256(payload.GetValue().GetValue())
+	if err != nil {
+		return fmt.Errorf("parsing value: %w", err)
 	}
 
-	if blockNumber := payload.GetBlockNumber(); blockNumber != nil {
-		b.BlockNumber.Append(blockNumber.GetValue())
-	} else {
-		b.BlockNumber.Append(0)
-	}
-
-	if blockHash := payload.GetBlockHash(); blockHash != nil {
-		b.BlockHash.Append([]byte(blockHash.GetValue()))
-	} else {
-		b.BlockHash.Append(nil)
-	}
-
-	if proposerPubkey := payload.GetProposerPubkey(); proposerPubkey != nil {
-		b.ProposerPubkey.Append(proposerPubkey.GetValue())
-	} else {
-		b.ProposerPubkey.Append("")
-	}
-
-	if builderPubkey := payload.GetBuilderPubkey(); builderPubkey != nil {
-		b.BuilderPubkey.Append(builderPubkey.GetValue())
-	} else {
-		b.BuilderPubkey.Append("")
-	}
-
-	if proposerFeeRecipient := payload.GetProposerFeeRecipient(); proposerFeeRecipient != nil {
-		b.ProposerFeeRecipient.Append([]byte(proposerFeeRecipient.GetValue()))
-	} else {
-		b.ProposerFeeRecipient.Append(nil)
-	}
-
-	if gasLimit := payload.GetGasLimit(); gasLimit != nil {
-		b.GasLimit.Append(gasLimit.GetValue())
-	} else {
-		b.GasLimit.Append(0)
-	}
-
-	if gasUsed := payload.GetGasUsed(); gasUsed != nil {
-		b.GasUsed.Append(gasUsed.GetValue())
-	} else {
-		b.GasUsed.Append(0)
-	}
-
-	if value := payload.GetValue(); value != nil {
-		parsedValue, err := route.ParseUInt256(value.GetValue())
-		if err != nil {
-			return fmt.Errorf("parsing value: %w", err)
-		}
-
-		b.Value.Append(parsedValue)
-	} else {
-		b.Value.Append(proto.UInt256{})
-	}
-
-	if numTx := payload.GetNumTx(); numTx != nil {
-		b.NumTx.Append(uint32(numTx.GetValue())) //nolint:gosec // proto uint64 narrowed to uint32 target field
-	} else {
-		b.NumTx.Append(0)
-	}
+	//nolint:gosec // G115: proto uint64 values narrowed to uint32 target columns
+	b.Slot.Append(uint32(payload.GetSlot().GetValue()))
+	b.BlockNumber.Append(payload.GetBlockNumber().GetValue())
+	b.BlockHash.Append([]byte(payload.GetBlockHash().GetValue()))
+	b.ProposerPubkey.Append(payload.GetProposerPubkey().GetValue())
+	b.BuilderPubkey.Append(payload.GetBuilderPubkey().GetValue())
+	b.ProposerFeeRecipient.Append([]byte(payload.GetProposerFeeRecipient().GetValue()))
+	b.GasLimit.Append(payload.GetGasLimit().GetValue())
+	b.GasUsed.Append(payload.GetGasUsed().GetValue())
+	b.Value.Append(parsedValue)
+	b.NumTx.Append(uint32(payload.GetNumTx().GetValue())) //nolint:gosec // G115
 
 	return nil
 }

--- a/pkg/clickhouse/route/mev/mev_relay_proposer_payload_delivered_test.go
+++ b/pkg/clickhouse/route/mev/mev_relay_proposer_payload_delivered_test.go
@@ -27,12 +27,16 @@ func TestSnapshot_mev_relay_proposer_payload_delivered(t *testing.T) {
 		}),
 		Data: &xatu.DecoratedEvent_MevRelayPayloadDelivered{
 			MevRelayPayloadDelivered: &mevrelay.ProposerPayloadDelivered{
-				Slot:          wrapperspb.UInt64(100),
-				BlockNumber:   wrapperspb.UInt64(1000),
-				BuilderPubkey: wrapperspb.String("0xbuilder"),
-				GasLimit:      wrapperspb.UInt64(30000000),
-				GasUsed:       wrapperspb.UInt64(15000000),
-				NumTx:         wrapperspb.UInt64(50),
+				Slot:                 wrapperspb.UInt64(100),
+				BlockNumber:          wrapperspb.UInt64(1000),
+				BlockHash:            wrapperspb.String("0xblock"),
+				BuilderPubkey:        wrapperspb.String("0xbuilder"),
+				ProposerPubkey:       wrapperspb.String("0xproposer"),
+				ProposerFeeRecipient: wrapperspb.String("0xfee"),
+				GasLimit:             wrapperspb.UInt64(30000000),
+				GasUsed:              wrapperspb.UInt64(15000000),
+				Value:                wrapperspb.String("1000000000000000000"),
+				NumTx:                wrapperspb.UInt64(50),
 			},
 		},
 	}, 1, map[string]any{

--- a/pkg/clickhouse/route/mev/mev_relay_validator_registration.go
+++ b/pkg/clickhouse/route/mev/mev_relay_validator_registration.go
@@ -54,14 +54,21 @@ func (b *mevRelayValidatorRegistrationBatch) FlattenTo(event *xatu.DecoratedEven
 func (b *mevRelayValidatorRegistrationBatch) validate(event *xatu.DecoratedEvent) error {
 	payload := event.GetMevRelayValidatorRegistration()
 
-	if msg := payload.GetMessage(); msg != nil {
-		if msg.GetTimestamp() == nil {
-			return fmt.Errorf("nil Timestamp: %w", route.ErrInvalidEvent)
-		}
+	msg := payload.GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
+	}
 
-		if msg.GetGasLimit() == nil {
-			return fmt.Errorf("nil GasLimit: %w", route.ErrInvalidEvent)
-		}
+	if msg.GetTimestamp() == nil {
+		return fmt.Errorf("nil Timestamp: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetGasLimit() == nil {
+		return fmt.Errorf("nil GasLimit: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetFeeRecipient() == nil {
+		return fmt.Errorf("nil FeeRecipient: %w", route.ErrInvalidEvent)
 	}
 
 	if client := event.GetMeta().GetClient(); client != nil {
@@ -110,32 +117,10 @@ func (b *mevRelayValidatorRegistrationBatch) appendRuntime(event *xatu.Decorated
 }
 
 func (b *mevRelayValidatorRegistrationBatch) appendPayload(event *xatu.DecoratedEvent) {
-	payload := event.GetMevRelayValidatorRegistration()
-
-	msg := payload.GetMessage()
-	if msg == nil {
-		b.appendZeroPayload()
-
-		return
-	}
-
-	if ts := msg.GetTimestamp(); ts != nil {
-		b.Timestamp.Append(int64(ts.GetValue())) //nolint:gosec // proto uint64 narrowed to int64 target field
-	} else {
-		b.Timestamp.Append(0)
-	}
-
-	if gasLimit := msg.GetGasLimit(); gasLimit != nil {
-		b.GasLimit.Append(gasLimit.GetValue())
-	} else {
-		b.GasLimit.Append(0)
-	}
-
-	if feeRecipient := msg.GetFeeRecipient(); feeRecipient != nil {
-		b.FeeRecipient.Append(feeRecipient.GetValue())
-	} else {
-		b.FeeRecipient.Append("")
-	}
+	msg := event.GetMevRelayValidatorRegistration().GetMessage()
+	b.Timestamp.Append(int64(msg.GetTimestamp().GetValue())) //nolint:gosec // G115: proto uint64 narrowed to int64 target column
+	b.GasLimit.Append(msg.GetGasLimit().GetValue())
+	b.FeeRecipient.Append(msg.GetFeeRecipient().GetValue())
 }
 
 func (b *mevRelayValidatorRegistrationBatch) appendAdditionalData(event *xatu.DecoratedEvent) {
@@ -237,12 +222,6 @@ func (b *mevRelayValidatorRegistrationBatch) appendAdditionalData(event *xatu.De
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 	}
-}
-
-func (b *mevRelayValidatorRegistrationBatch) appendZeroPayload() {
-	b.Timestamp.Append(0)
-	b.GasLimit.Append(0)
-	b.FeeRecipient.Append("")
 }
 
 func (b *mevRelayValidatorRegistrationBatch) appendZeroAdditionalData() {

--- a/pkg/clickhouse/route/mev/mev_relay_validator_registration_test.go
+++ b/pkg/clickhouse/route/mev/mev_relay_validator_registration_test.go
@@ -25,9 +25,16 @@ func TestSnapshot_mev_relay_validator_registration(t *testing.T) {
 			},
 		}),
 		Data: &xatu.DecoratedEvent_MevRelayValidatorRegistration{
-			MevRelayValidatorRegistration: &mevrelay.ValidatorRegistration{},
+			MevRelayValidatorRegistration: &mevrelay.ValidatorRegistration{
+				Message: &mevrelay.ValidatorRegistrationMessage{
+					FeeRecipient: wrapperspb.String("0xfee"),
+					GasLimit:     wrapperspb.UInt64(30000000),
+					Timestamp:    wrapperspb.UInt64(1705312800),
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_client_name": "test-client",
+		"fee_recipient":    "0xfee",
 	})
 }

--- a/pkg/clickhouse/route/node/node_record_consensus.go
+++ b/pkg/clickhouse/route/node/node_record_consensus.go
@@ -102,12 +102,8 @@ func (b *nodeRecordConsensusBatch) appendPayload(
 		b.PeerIDUniqueKey.Append(chProto.Nullable[int64]{})
 	}
 
-	// Timestamp.
-	if ts := consensus.GetTimestamp(); ts != nil {
-		b.Timestamp.Append(ts.GetValue())
-	} else {
-		b.Timestamp.Append(0)
-	}
+	// Timestamp (required, guaranteed non-nil by validate).
+	b.Timestamp.Append(consensus.GetTimestamp().GetValue())
 
 	// Name and parsed implementation/version.
 	name := nodeStringValue(consensus.GetName())
@@ -134,19 +130,13 @@ func (b *nodeRecordConsensusBatch) appendPayload(
 
 	b.FinalizedRoot.Append(nodeStringValue(consensus.GetFinalizedRoot()))
 
-	if finalizedEpoch := consensus.GetFinalizedEpoch(); finalizedEpoch != nil {
-		b.FinalizedEpoch.Append(finalizedEpoch.GetValue())
-	} else {
-		b.FinalizedEpoch.Append(0)
-	}
+	// FinalizedEpoch (required, guaranteed non-nil by validate).
+	b.FinalizedEpoch.Append(consensus.GetFinalizedEpoch().GetValue())
 
 	b.HeadRoot.Append(nodeStringValue(consensus.GetHeadRoot()))
 
-	if headSlot := consensus.GetHeadSlot(); headSlot != nil {
-		b.HeadSlot.Append(headSlot.GetValue())
-	} else {
-		b.HeadSlot.Append(0)
-	}
+	// HeadSlot (required, guaranteed non-nil by validate).
+	b.HeadSlot.Append(consensus.GetHeadSlot().GetValue())
 
 	// Cgc is Nullable[string].
 	cgc := nodeStringValue(consensus.GetCgc())

--- a/pkg/clickhouse/route/routes_test.go
+++ b/pkg/clickhouse/route/routes_test.go
@@ -290,6 +290,12 @@ func TestElaboratedAttestationAliasesValidatorIndexesToValidators(t *testing.T) 
 		},
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockElaboratedAttestation{
 			EthV2BeaconBlockElaboratedAttestation: &ethv1.ElaboratedAttestation{
+				Data: &ethv1.AttestationDataV2{
+					Slot:   wrapperspb.UInt64(100),
+					Index:  wrapperspb.UInt64(3),
+					Source: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(4)},
+					Target: &ethv1.CheckpointV2{Epoch: wrapperspb.UInt64(5)},
+				},
 				ValidatorIndexes: []*wrapperspb.UInt64Value{
 					wrapperspb.UInt64(11),
 					wrapperspb.UInt64(22),


### PR DESCRIPTION
The ClickHouse route flattener silently fell back to 0/""/zero-hash whenever a required proto wrapper field was absent (e.g. validator/proposer index, slot, epoch, committee index, amount, block_hash), fabricating data indistinguishable from a real value across ~378 sites in 57 of 114 route files. This converts the required-field if/else-zero blocks to the validate()+direct-append pattern (return route.ErrInvalidEvent and drop the event instead of writing a fake zero) across the canonical, beacon, mev, execution, libp2p, and node packages, fixes the generator scaffold so future routes follow the same pattern, makes unknown-block-version fallthroughs return ErrInvalidEvent, and updates the affected snapshot tests; the additional-data/enrichment zone and *_start_date_time derived-timestamp conventions are left unchanged. Remaining genuinely-optional fields on non-Nullable columns (HasIpv6, libp2p latency/size/seqnum, execution profiling + mempool nonce/gas, v3 block_number, validator status/slashed) are noted as needs-nullable follow-up since converting them requires a migration. Verified with go build ./..., go test ./pkg/clickhouse/route/... (incl. -race), and golangci-lint --new-from-rev=origin/master (0 issues).