### PR TITLE
consumoor: drop invalid events instead of halting the partition

### DIFF
--- a/pkg/consumoor/source/benthos_test.go
+++ b/pkg/consumoor/source/benthos_test.go
@@ -386,6 +386,35 @@ func TestWriteBatchRejectSinkFailureMakesMessageRetry(t *testing.T) {
 	assert.Equal(t, []int{0}, failedIndexesFromBatchError(t, msgs, err))
 }
 
+func TestRejectMessageNoDLQDropsInvalidEventsButHaltsRecoverable(t *testing.T) {
+	output := &xatuClickHouseOutput{
+		log:        logrus.New(),
+		metrics:    newTestMetrics(),
+		logSampler: telemetry.NewLogSampler(time.Minute),
+		rejectSink: nil,
+	}
+
+	// Permanently unstorable events (unrouted or unflattenable) are dropped
+	// and acked rather than halting the partition on data we cannot fix.
+	for _, reason := range []string{rejectReasonRouteRejected, rejectReasonInvalidEvent} {
+		err := output.rejectMessage(context.Background(), &rejectedRecord{
+			Reason: reason,
+			Err:    "permanently unstorable",
+		})
+		require.NoError(t, err, "reason %q should drop+ack without a DLQ", reason)
+	}
+
+	// Potentially-recoverable failures still fail the message so Kafka
+	// redelivers rather than silently dropping data we might yet store.
+	for _, reason := range []string{rejectReasonDecode, rejectReasonWritePermanent} {
+		err := output.rejectMessage(context.Background(), &rejectedRecord{
+			Reason: reason,
+			Err:    "recoverable failure",
+		})
+		require.Error(t, err, "reason %q should fail-fast without a DLQ", reason)
+	}
+}
+
 func TestWriteBatchTraceScopeDoesNotInheritBatchSpanWithoutHeader(t *testing.T) {
 	recorder := setupConsumoorTraceTest(t)
 	output := newTraceTestOutput(t)

--- a/pkg/consumoor/source/output.go
+++ b/pkg/consumoor/source/output.go
@@ -535,17 +535,19 @@ func (o *xatuClickHouseOutput) rejectMessage(
 	if o.rejectSink == nil {
 		o.metrics.MessagesRejected().WithLabelValues(record.Reason).Inc()
 
-		// Route rejections are intentional — the event type simply isn't
-		// routed to any table. Safe to ack without a DLQ.
-		if record.Reason == rejectReasonRouteRejected {
+		// Route rejections and invalid events are permanent: the event is
+		// either unrouted or unflattenable (malformed / missing required
+		// fields) and will never become storable by being redelivered. Drop
+		// and ack — the MessagesRejected metric keeps them observable — rather
+		// than halting the partition on data we cannot fix.
+		if record.Reason == rejectReasonRouteRejected || record.Reason == rejectReasonInvalidEvent {
 			return nil
 		}
 
-		// For all other reasons (decode errors, permanent write failures,
-		// invalid events) failing the message forces Kafka to redeliver
-		// rather than silently dropping data when no DLQ is configured.
-		// Invalid events may become valid after a rolling deploy where a
-		// newer version adds support for new fields or event subtypes.
+		// Decode and write failures may be recoverable — a newer decoder
+		// version, or a sink/migration that has since caught up, can handle
+		// them — so fail the message to force Kafka redelivery rather than
+		// silently dropping data we might yet store.
 		return fmt.Errorf("no DLQ configured for rejected message (%s): %s", record.Reason, record.Err)
 	}
 


### PR DESCRIPTION
When no DLQ is configured, invalid (permanently unflattenable) events fell into the same fail-the-message path as recoverable decode/write errors, forcing Kafka to redeliver them forever — a single malformed event halted the whole partition on data that can never become storable. This aligns rejectMessage with the route layer's own `route.ErrInvalidEvent` contract ("permanently unflattenable, should be dropped rather than retried"): invalid events now drop and ack like route rejections, tracked by the MessagesRejected metric, while recoverable decode/write failures still fail-fast for redelivery. Companion to the route-validation work in #860 that surfaces these invalid events.