### PR TITLE
canonical: strict validate + halt-on-invalid (never drop a backfilled row)

### DIFF
--- a/pkg/clickhouse/errors.go
+++ b/pkg/clickhouse/errors.go
@@ -45,6 +45,22 @@ type flattenError struct {
 func (e *flattenError) Error() string { return fmt.Sprintf("flatten failed: %v", e.cause) }
 func (e *flattenError) Unwrap() error { return e.cause }
 
+// invalidEventError wraps a route.ErrInvalidEvent for a CANONICAL table.
+// Unlike flattenError it is deliberately NOT classified permanent: canonical
+// (cannon-backfilled) data is authoritative, so a dropped row is a permanent
+// gap in history. Halting — cannon does not advance its checkpoint, consumoor
+// NAKs for redelivery — forces a retry against complete upstream data rather
+// than silently dropping. Non-canonical (live/sentry) invalid events are still
+// dropped (they are point-in-time and cannot be re-fetched).
+type invalidEventError struct {
+	cause error
+}
+
+func (e *invalidEventError) Error() string {
+	return fmt.Sprintf("invalid canonical event: %v", e.cause)
+}
+func (e *invalidEventError) Unwrap() error { return e.cause }
+
 // limiterRejectedError indicates the adaptive concurrency limiter rejected
 // the request. This is not retryable (doWithRetry exits immediately) and not
 // permanent — the table writer simply waits for the next flush cycle.

--- a/pkg/clickhouse/route/canonical/canonical_beacon_attestation_reward.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_attestation_reward.go
@@ -92,6 +92,14 @@ func (b *canonicalBeaconAttestationRewardBatch) validate(event *xatu.DecoratedEv
 		return fmt.Errorf("nil Epoch: %w", route.ErrInvalidEvent)
 	}
 
+	if additional.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil Epoch.StartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar.go
@@ -68,6 +68,59 @@ func (b *canonicalBeaconBlobSidecarBatch) validate(event *xatu.DecoratedEvent) e
 		return fmt.Errorf("nil Index: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetBlockRoot() == "" {
+		return fmt.Errorf("empty BlockRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetBlockParentRoot() == "" {
+		return fmt.Errorf("empty BlockParentRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetKzgCommitment() == "" {
+		return fmt.Errorf("empty KzgCommitment: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetKzgProof() == "" {
+		return fmt.Errorf("empty KzgProof: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV1BeaconBlobSidecar()
+	if additional == nil {
+		return fmt.Errorf("nil EthV1BeaconBlobSidecar additional data: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot() == nil {
+		return fmt.Errorf("nil additional Slot: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot().GetNumber() == nil {
+		return fmt.Errorf("nil additional Slot Number: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil additional Slot StartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch() == nil {
+		return fmt.Errorf("nil additional Epoch: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch().GetNumber() == nil {
+		return fmt.Errorf("nil additional Epoch Number: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil additional Epoch StartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetVersionedHash() == "" {
+		return fmt.Errorf("empty VersionedHash: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta network name: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_blob_sidecar_test.go
@@ -20,16 +20,21 @@ func TestSnapshot_canonical_beacon_blob_sidecar(t *testing.T) {
 		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
 			AdditionalData: &xatu.ClientMeta_EthV1BeaconBlobSidecar{
 				EthV1BeaconBlobSidecar: &xatu.ClientMeta_AdditionalEthV1BeaconBlobSidecarData{
-					Slot:  testfixture.SlotEpochAdditional(),
-					Epoch: testfixture.EpochAdditional(),
+					Slot:          testfixture.SlotEpochAdditional(),
+					Epoch:         testfixture.EpochAdditional(),
+					VersionedHash: "0x0100000000000000000000000000000000000000000000000000000000000001",
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV1BeaconBlockBlobSidecar{
 			EthV1BeaconBlockBlobSidecar: &ethv1.BlobSidecar{
-				Slot:          wrapperspb.UInt64(100),
-				ProposerIndex: wrapperspb.UInt64(5),
-				Index:         wrapperspb.UInt64(0),
+				Slot:            wrapperspb.UInt64(100),
+				ProposerIndex:   wrapperspb.UInt64(5),
+				Index:           wrapperspb.UInt64(0),
+				BlockRoot:       "0x1111111111111111111111111111111111111111111111111111111111111111",
+				BlockParentRoot: "0x2222222222222222222222222222222222222222222222222222222222222222",
+				KzgCommitment:   "0x" + "33" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				KzgProof:        "0x" + "44" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 			},
 		},
 	}, 1, map[string]any{

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block.go
@@ -75,7 +75,95 @@ func (b *canonicalBeaconBlockBatch) validate(event *xatu.DecoratedEvent) error {
 		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
 	}
 
+	parentRoot, stateRoot, eth1Data, ok := canonicalBeaconBlockIdentityFields(payload)
+	if !ok {
+		return fmt.Errorf("unknown block version: %w", route.ErrInvalidEvent)
+	}
+
+	if parentRoot == "" {
+		return fmt.Errorf("empty ParentRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if stateRoot == "" {
+		return fmt.Errorf("empty StateRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if eth1Data == nil {
+		return fmt.Errorf("nil Eth1Data: %w", route.ErrInvalidEvent)
+	}
+
+	if eth1Data.GetBlockHash() == "" {
+		return fmt.Errorf("empty Eth1DataBlockHash: %w", route.ErrInvalidEvent)
+	}
+
+	if eth1Data.GetDepositRoot() == "" {
+		return fmt.Errorf("empty Eth1DataDepositRoot: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockV2()
+	if additional == nil {
+		return fmt.Errorf("nil additional EthV2BeaconBlockV2 data: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetVersion() == "" {
+		return fmt.Errorf("empty BlockVersion: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetBlockRoot() == "" {
+		return fmt.Errorf("empty BlockRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil SlotStartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil EpochStartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
+}
+
+// canonicalBeaconBlockIdentityFields extracts the spec-required block identity
+// fields (parent_root, state_root, eth1_data) from whichever fork variant the
+// block message carries. ok is false when no known fork variant is set.
+func canonicalBeaconBlockIdentityFields(eventBlock *ethv2.EventBlockV2) (parentRoot, stateRoot string, eth1Data *ethv1.Eth1Data, ok bool) {
+	switch {
+	case eventBlock.GetPhase0Block() != nil:
+		blk := eventBlock.GetPhase0Block()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetAltairBlock() != nil:
+		blk := eventBlock.GetAltairBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetBellatrixBlock() != nil:
+		blk := eventBlock.GetBellatrixBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetCapellaBlock() != nil:
+		blk := eventBlock.GetCapellaBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetDenebBlock() != nil:
+		blk := eventBlock.GetDenebBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetElectraBlock() != nil:
+		blk := eventBlock.GetElectraBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	case eventBlock.GetFuluBlock() != nil:
+		blk := eventBlock.GetFuluBlock()
+
+		return blk.GetParentRoot(), blk.GetStateRoot(), blk.GetBody().GetEth1Data(), true
+	default:
+		return "", "", nil, false
+	}
 }
 
 func (b *canonicalBeaconBlockBatch) appendRuntime(_ *xatu.DecoratedEvent) {

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing.go
@@ -42,11 +42,82 @@ func (b *canonicalBeaconBlockAttesterSlashingBatch) FlattenTo(event *xatu.Decora
 		return fmt.Errorf("nil eth_v2_beacon_block_attester_slashing payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockAttesterSlashingBatch) validate(event *xatu.DecoratedEvent) error {
+	payload := event.GetEthV2BeaconBlockAttesterSlashing()
+
+	if err := b.validateIndexedAttestation(payload.GetAttestation_1(), "attestation_1"); err != nil {
+		return err
+	}
+
+	if err := b.validateIndexedAttestation(payload.GetAttestation_2(), "attestation_2"); err != nil {
+		return err
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockAttesterSlashing()
+	if additional == nil {
+		return fmt.Errorf("nil additional eth_v2_beacon_block_attester_slashing: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block_version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockAttesterSlashingBatch) validateIndexedAttestation(
+	att *ethv1.IndexedAttestationV2,
+	label string,
+) error {
+	if att == nil {
+		return fmt.Errorf("nil %s: %w", label, route.ErrInvalidEvent)
+	}
+
+	if att.GetSignature() == "" {
+		return fmt.Errorf("empty %s_signature: %w", label, route.ErrInvalidEvent)
+	}
+
+	if att.GetData() == nil {
+		return fmt.Errorf("nil %s_data: %w", label, route.ErrInvalidEvent)
+	}
+
+	if att.GetData().GetBeaconBlockRoot() == "" {
+		return fmt.Errorf("empty %s_data_beacon_block_root: %w", label, route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_attester_slashing_test.go
@@ -19,13 +19,29 @@ func TestSnapshot_canonical_beacon_block_attester_slashing(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockAttesterSlashing{
 				EthV2BeaconBlockAttesterSlashing: &xatu.ClientMeta_AdditionalEthV2BeaconBlockAttesterSlashingData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "deneb",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockAttesterSlashing{
-			EthV2BeaconBlockAttesterSlashing: &ethv1.AttesterSlashingV2{},
+			EthV2BeaconBlockAttesterSlashing: &ethv1.AttesterSlashingV2{
+				Attestation_1: &ethv1.IndexedAttestationV2{
+					Signature: "0xaaaa",
+					Data: &ethv1.AttestationDataV2{
+						BeaconBlockRoot: "0x2222222222222222222222222222222222222222222222222222222222222222",
+					},
+				},
+				Attestation_2: &ethv1.IndexedAttestationV2{
+					Signature: "0xbbbb",
+					Data: &ethv1.AttestationDataV2{
+						BeaconBlockRoot: "0x3333333333333333333333333333333333333333333333333333333333333333",
+					},
+				},
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change.go
@@ -38,11 +38,68 @@ func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) FlattenTo(event *xatu.De
 		return fmt.Errorf("nil eth_v2_beacon_block_bls_to_execution_change payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockBlsToExecutionChangeBatch) validate(event *xatu.DecoratedEvent) error {
+	payload := event.GetEthV2BeaconBlockBlsToExecutionChange()
+
+	msg := payload.GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil Message: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetFromBlsPubkey() == "" {
+		return fmt.Errorf("empty FromBlsPubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if msg.GetToExecutionAddress() == "" {
+		return fmt.Errorf("empty ToExecutionAddress: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetSignature() == "" {
+		return fmt.Errorf("empty Signature: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockBlsToExecutionChange()
+	if additional == nil {
+		return fmt.Errorf("nil additional EthV2BeaconBlockBlsToExecutionChange: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot start date time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch start date time: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta network name: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_bls_to_execution_change_test.go
@@ -19,15 +19,27 @@ func TestSnapshot_canonical_beacon_block_bls_to_execution_change(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockBlsToExecutionChange{
 				EthV2BeaconBlockBlsToExecutionChange: &xatu.ClientMeta_AdditionalEthV2BeaconBlockBLSToExecutionChangeData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "capella",
+						Root:    "0x0101010101010101010101010101010101010101010101010101010101010101",
 					},
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockBlsToExecutionChange{
-			EthV2BeaconBlockBlsToExecutionChange: &ethv2.SignedBLSToExecutionChangeV2{},
+			EthV2BeaconBlockBlsToExecutionChange: &ethv2.SignedBLSToExecutionChangeV2{
+				Message: &ethv2.BLSToExecutionChangeV2{
+					FromBlsPubkey:      "0xb02020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020",
+					ToExecutionAddress: "0x0303030303030303030303030303030303030303",
+				},
+				Signature: "0xc04040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040",
+			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",
+		"block_version":     "capella",
+		"block_root":        "0x0101010101010101010101010101010101010101010101010101010101010101",
+		"exchanging_message_to_execution_address": "0x0303030303030303030303030303030303030303",
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit.go
@@ -39,6 +39,10 @@ func (b *canonicalBeaconBlockDepositBatch) FlattenTo(event *xatu.DecoratedEvent)
 		return fmt.Errorf("nil eth_v2_beacon_block_deposit payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 
@@ -48,6 +52,67 @@ func (b *canonicalBeaconBlockDepositBatch) FlattenTo(event *xatu.DecoratedEvent)
 
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockDepositBatch) validate(event *xatu.DecoratedEvent) error {
+	payload := event.GetEthV2BeaconBlockDeposit()
+
+	if len(payload.GetProof()) == 0 {
+		return fmt.Errorf("empty deposit_proof: %w", route.ErrInvalidEvent)
+	}
+
+	data := payload.GetData()
+	if data == nil {
+		return fmt.Errorf("nil deposit_data: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetPubkey() == "" {
+		return fmt.Errorf("empty deposit_data_pubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetWithdrawalCredentials() == "" {
+		return fmt.Errorf("empty deposit_data_withdrawal_credentials: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSignature() == "" {
+		return fmt.Errorf("empty deposit_data_signature: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetAmount() == nil {
+		return fmt.Errorf("nil deposit_data_amount: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockDeposit()
+	if additional == nil {
+		return fmt.Errorf("nil eth_v2_beacon_block_deposit additional data: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block_version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_deposit_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -19,15 +21,27 @@ func TestSnapshot_canonical_beacon_block_deposit(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockDeposit{
 				EthV2BeaconBlockDeposit: &xatu.ClientMeta_AdditionalEthV2BeaconBlockDepositData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "phase0",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockDeposit{
-			EthV2BeaconBlockDeposit: &ethv1.DepositV2{},
+			EthV2BeaconBlockDeposit: &ethv1.DepositV2{
+				Proof: []string{"0x2222222222222222222222222222222222222222222222222222222222222222"},
+				Data: &ethv1.DepositV2_Data{
+					Pubkey:                "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95",
+					WithdrawalCredentials: "0x0033333333333333333333333333333333333333333333333333333333333333",
+					Amount:                wrapperspb.UInt64(32000000000),
+					Signature:             "0xa1b2c3",
+				},
+			},
 		},
 	}, 1, map[string]any{
-		"meta_network_name": "mainnet",
+		"meta_network_name":   "mainnet",
+		"deposit_data_amount": "32000000000",
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_request_consolidation.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_request_consolidation.go
@@ -71,6 +71,19 @@ func (b *canonicalBeaconBlockExecutionRequestConsolidationBatch) validate(event 
 		return fmt.Errorf("nil PositionInBlock: %w", route.ErrInvalidEvent)
 	}
 
+	block := additional.GetBlock()
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty BlockRoot: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty BlockVersion: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_request_consolidation_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_request_consolidation_test.go
@@ -21,7 +21,9 @@ func TestSnapshot_canonical_beacon_block_execution_request_consolidation(t *test
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockExecutionRequestConsolidation{
 				EthV2BeaconBlockExecutionRequestConsolidation: &xatu.ClientMeta_AdditionalEthV2BeaconBlockExecutionRequestConsolidationData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "electra",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
 					PositionInBlock: wrapperspb.UInt64(2),
 				},

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction.go
@@ -61,6 +61,18 @@ func (b *canonicalBeaconBlockExecutionTransactionBatch) FlattenTo(event *xatu.De
 func (b *canonicalBeaconBlockExecutionTransactionBatch) validate(event *xatu.DecoratedEvent) error {
 	payload := event.GetEthV2BeaconBlockExecutionTransaction()
 
+	if payload.GetHash() == "" {
+		return fmt.Errorf("empty hash: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetFrom() == "" {
+		return fmt.Errorf("empty from: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetGasPrice() == "" {
+		return fmt.Errorf("empty gas_price: %w", route.ErrInvalidEvent)
+	}
+
 	if payload.GetNonce() == nil {
 		return fmt.Errorf("nil Nonce: %w", route.ErrInvalidEvent)
 	}
@@ -71,6 +83,40 @@ func (b *canonicalBeaconBlockExecutionTransactionBatch) validate(event *xatu.Dec
 
 	if payload.GetType() == nil {
 		return fmt.Errorf("nil Type: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockExecutionTransaction()
+	if additional == nil {
+		return fmt.Errorf("nil eth_v2_beacon_block_execution_transaction additional data: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSize() == "" {
+		return fmt.Errorf("empty size: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block_version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
 	}
 
 	return nil

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_execution_transaction_test.go
@@ -21,19 +21,24 @@ func TestSnapshot_canonical_beacon_block_execution_transaction(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockExecutionTransaction{
 				EthV2BeaconBlockExecutionTransaction: &xatu.ClientMeta_AdditionalEthV2BeaconBlockExecutionTransactionData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "deneb",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
+					Size: "150",
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockExecutionTransaction{
 			EthV2BeaconBlockExecutionTransaction: &ethv1.Transaction{
-				Hash:  "0xtxhash",
-				From:  "0xfrom",
-				To:    "0xto",
-				Nonce: wrapperspb.UInt64(1),
-				Gas:   wrapperspb.UInt64(21000),
-				Type:  wrapperspb.UInt32(2),
+				Hash:     "0xtxhash",
+				From:     "0xfrom",
+				To:       "0xto",
+				Nonce:    wrapperspb.UInt64(1),
+				Gas:      wrapperspb.UInt64(21000),
+				Type:     wrapperspb.UInt32(2),
+				GasPrice: "1000000000",
 			},
 		},
 	}, 1, map[string]any{

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing.go
@@ -39,11 +39,59 @@ func (b *canonicalBeaconBlockProposerSlashingBatch) FlattenTo(event *xatu.Decora
 		return fmt.Errorf("nil eth_v2_beacon_block_proposer_slashing payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockProposerSlashingBatch) validate(event *xatu.DecoratedEvent) error {
+	slashing := event.GetEthV2BeaconBlockProposerSlashing()
+
+	if err := validateProposerSlashingHeader(slashing.GetSignedHeader_1(), "signed_header_1"); err != nil {
+		return err
+	}
+
+	if err := validateProposerSlashingHeader(slashing.GetSignedHeader_2(), "signed_header_2"); err != nil {
+		return err
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockProposerSlashing()
+	if additional == nil {
+		return fmt.Errorf("nil additional data: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block_version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }
@@ -159,4 +207,33 @@ func (b *canonicalBeaconBlockProposerSlashingBatch) appendAdditionalData(event *
 
 	appendBlockIdentifier(additional.GetBlock(),
 		&b.Slot, &b.SlotStartDateTime, &b.Epoch, &b.EpochStartDateTime, &b.BlockVersion, &b.BlockRoot)
+}
+
+func validateProposerSlashingHeader(header *ethv1.SignedBeaconBlockHeaderV2, name string) error {
+	if header == nil {
+		return fmt.Errorf("nil %s: %w", name, route.ErrInvalidEvent)
+	}
+
+	if header.GetSignature() == "" {
+		return fmt.Errorf("empty %s_signature: %w", name, route.ErrInvalidEvent)
+	}
+
+	msg := header.GetMessage()
+	if msg == nil {
+		return fmt.Errorf("nil %s_message: %w", name, route.ErrInvalidEvent)
+	}
+
+	if msg.GetBodyRoot() == "" {
+		return fmt.Errorf("empty %s_message_body_root: %w", name, route.ErrInvalidEvent)
+	}
+
+	if msg.GetParentRoot() == "" {
+		return fmt.Errorf("empty %s_message_parent_root: %w", name, route.ErrInvalidEvent)
+	}
+
+	if msg.GetStateRoot() == "" {
+		return fmt.Errorf("empty %s_message_state_root: %w", name, route.ErrInvalidEvent)
+	}
+
+	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_proposer_slashing_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -19,15 +21,44 @@ func TestSnapshot_canonical_beacon_block_proposer_slashing(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockProposerSlashing{
 				EthV2BeaconBlockProposerSlashing: &xatu.ClientMeta_AdditionalEthV2BeaconBlockProposerSlashingData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Version: "deneb",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockProposerSlashing{
-			EthV2BeaconBlockProposerSlashing: &ethv1.ProposerSlashingV2{},
+			EthV2BeaconBlockProposerSlashing: &ethv1.ProposerSlashingV2{
+				SignedHeader_1: &ethv1.SignedBeaconBlockHeaderV2{
+					Signature: "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9011",
+					Message: &ethv1.BeaconBlockHeaderV2{
+						Slot:          wrapperspb.UInt64(100),
+						ProposerIndex: wrapperspb.UInt64(42),
+						ParentRoot:    "0x2222222222222222222222222222222222222222222222222222222222222222",
+						StateRoot:     "0x3333333333333333333333333333333333333333333333333333333333333333",
+						BodyRoot:      "0x4444444444444444444444444444444444444444444444444444444444444444",
+					},
+				},
+				SignedHeader_2: &ethv1.SignedBeaconBlockHeaderV2{
+					Signature: "0xb1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9022",
+					Message: &ethv1.BeaconBlockHeaderV2{
+						Slot:          wrapperspb.UInt64(100),
+						ProposerIndex: wrapperspb.UInt64(42),
+						ParentRoot:    "0x5555555555555555555555555555555555555555555555555555555555555555",
+						StateRoot:     "0x6666666666666666666666666666666666666666666666666666666666666666",
+						BodyRoot:      "0x7777777777777777777777777777777777777777777777777777777777777777",
+					},
+				},
+			},
 		},
 	}, 1, map[string]any{
-		"meta_network_name": "mainnet",
+		"meta_network_name":                  "mainnet",
+		"block_root":                         "0x1111111111111111111111111111111111111111111111111111111111111111",
+		"block_version":                      "deneb",
+		"signed_header_1_signature":          "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9011",
+		"signed_header_1_message_body_root":  "0x4444444444444444444444444444444444444444444444444444444444444444",
+		"signed_header_2_message_state_root": "0x6666666666666666666666666666666666666666666666666666666666666666",
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate.go
@@ -60,6 +60,44 @@ func (b *canonicalBeaconBlockSyncAggregateBatch) validate(event *xatu.DecoratedE
 		return fmt.Errorf("nil ParticipationCount: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetSyncCommitteeBits() == "" {
+		return fmt.Errorf("empty SyncCommitteeBits: %w", route.ErrInvalidEvent)
+	}
+
+	if payload.GetSyncCommitteeSignature() == "" {
+		return fmt.Errorf("empty SyncCommitteeSignature: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta network name: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockSyncAggregate()
+	if additional == nil {
+		return fmt.Errorf("nil EthV2BeaconBlockSyncAggregate additional data: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot start date time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch start date time: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_sync_aggregate_test.go
@@ -16,13 +16,27 @@ func TestSnapshot_canonical_beacon_block_sync_aggregate(t *testing.T) {
 			DateTime: testfixture.TS(),
 			Id:       "cbsa-1",
 		},
-		Meta: testfixture.BaseMeta(),
+		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
+			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockSyncAggregate{
+				EthV2BeaconBlockSyncAggregate: &xatu.ClientMeta_AdditionalEthV2BeaconBlockSyncAggregateData{
+					Block: &xatu.BlockIdentifier{
+						Version: "deneb",
+						Root:    "0xdeadbeef000000000000000000000000000000000000000000000000deadbeef",
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+					},
+				},
+			},
+		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockSyncAggregate{
 			EthV2BeaconBlockSyncAggregate: &xatu.SyncAggregateData{
-				ParticipationCount: wrapperspb.UInt64(128),
+				ParticipationCount:     wrapperspb.UInt64(128),
+				SyncCommitteeBits:      "0xffffffffffffffffffffffffffffffff",
+				SyncCommitteeSignature: "0xb0b0b0b0",
 			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",
+		"block_version":     "deneb",
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_test.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
+	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	ethv2 "github.com/ethpandaops/xatu/pkg/proto/eth/v2"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
@@ -34,6 +35,14 @@ func TestSnapshot_canonical_beacon_block(t *testing.T) {
 					DenebBlock: &ethv2.BeaconBlockDeneb{
 						Slot:          wrapperspb.UInt64(100),
 						ProposerIndex: wrapperspb.UInt64(42),
+						ParentRoot:    "0xparentroot",
+						StateRoot:     "0xstateroot",
+						Body: &ethv2.BeaconBlockBodyDeneb{
+							Eth1Data: &ethv1.Eth1Data{
+								BlockHash:   "0xeth1blockhash",
+								DepositRoot: "0xeth1depositroot",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit.go
@@ -38,11 +38,55 @@ func (b *canonicalBeaconBlockVoluntaryExitBatch) FlattenTo(event *xatu.Decorated
 		return fmt.Errorf("nil eth_v2_beacon_block_voluntary_exit payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconBlockVoluntaryExitBatch) validate(event *xatu.DecoratedEvent) error {
+	payload := event.GetEthV2BeaconBlockVoluntaryExit()
+
+	if payload.GetSignature() == "" {
+		return fmt.Errorf("empty voluntary_exit_signature: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockVoluntaryExit()
+	if additional == nil {
+		return fmt.Errorf("nil eth_v2_beacon_block_voluntary_exit additional data: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil block identifier: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetVersion() == "" {
+		return fmt.Errorf("empty block_version: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_block_voluntary_exit_test.go
@@ -3,6 +3,8 @@ package canonical
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -19,15 +21,27 @@ func TestSnapshot_canonical_beacon_block_voluntary_exit(t *testing.T) {
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockVoluntaryExit{
 				EthV2BeaconBlockVoluntaryExit: &xatu.ClientMeta_AdditionalEthV2BeaconBlockVoluntaryExitData{
 					Block: &xatu.BlockIdentifier{
-						Epoch: testfixture.EpochAdditional(),
+						Slot:    testfixture.SlotEpochAdditional(),
+						Epoch:   testfixture.EpochAdditional(),
+						Version: "deneb",
+						Root:    "0x1111111111111111111111111111111111111111111111111111111111111111",
 					},
 				},
 			},
 		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockVoluntaryExit{
-			EthV2BeaconBlockVoluntaryExit: &ethv1.SignedVoluntaryExitV2{},
+			EthV2BeaconBlockVoluntaryExit: &ethv1.SignedVoluntaryExitV2{
+				Message: &ethv1.VoluntaryExitV2{
+					Epoch:          wrapperspb.UInt64(3),
+					ValidatorIndex: wrapperspb.UInt64(42),
+				},
+				Signature: "0x" + "ab" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			},
 		},
 	}, 1, map[string]any{
-		"meta_network_name": "mainnet",
+		"meta_network_name":                      "mainnet",
+		"block_version":                          "deneb",
+		"voluntary_exit_message_epoch":           uint32(3),
+		"voluntary_exit_message_validator_index": uint32(42),
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_committee.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_committee.go
@@ -51,11 +51,29 @@ func (b *canonicalBeaconCommitteeBatch) FlattenTo(event *xatu.DecoratedEvent) er
 		return fmt.Errorf("nil eth_v1_beacon_committee payload: %w", route.ErrInvalidEvent)
 	}
 
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendPayload(event)
 	b.appendAdditionalData(event)
 	b.rows++
+
+	return nil
+}
+
+func (b *canonicalBeaconCommitteeBatch) validate(event *xatu.DecoratedEvent) error {
+	committee := event.GetEthV1BeaconCommittee()
+
+	if committee.GetIndex() == nil {
+		return fmt.Errorf("nil Index: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta network name: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation.go
@@ -1,6 +1,7 @@
 package canonical
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -34,10 +35,99 @@ func (b *canonicalBeaconElaboratedAttestationBatch) FlattenTo(event *xatu.Decora
 		return nil
 	}
 
+	if event.GetEthV2BeaconBlockElaboratedAttestation() == nil {
+		return fmt.Errorf("nil eth_v2_beacon_block_elaborated_attestation payload: %w", route.ErrInvalidEvent)
+	}
+
+	if err := b.validate(event); err != nil {
+		return err
+	}
+
 	b.appendRuntime(event)
 	b.appendMetadata(event)
 	b.appendRow(event)
 	b.rows++
+
+	return nil
+}
+
+// validate rejects events missing any spec-required field that would otherwise be
+// silently zero-filled by appendRow/appendMetadata, corrupting canonical data.
+// Empty-valid fields (indexes, slot/epoch numbers, validators, committee_index,
+// reward-style values) are intentionally NOT guarded: value 0 / empty list / a
+// zero-hash checkpoint root are legitimate. Checkpoint/attestation roots are
+// guarded only against the empty-string absence sentinel, never against zero-hash.
+func (b *canonicalBeaconElaboratedAttestationBatch) validate(event *xatu.DecoratedEvent) error {
+	data := event.GetEthV2BeaconBlockElaboratedAttestation().GetData()
+	if data == nil {
+		return fmt.Errorf("nil AttestationData: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetBeaconBlockRoot() == "" {
+		return fmt.Errorf("empty beacon_block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetSource().GetRoot() == "" {
+		return fmt.Errorf("empty source_root: %w", route.ErrInvalidEvent)
+	}
+
+	if data.GetTarget().GetRoot() == "" {
+		return fmt.Errorf("empty target_root: %w", route.ErrInvalidEvent)
+	}
+
+	if err := b.validateAdditional(event); err != nil {
+		return err
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta_network_name: %w", route.ErrInvalidEvent)
+	}
+
+	return nil
+}
+
+// validateAdditional guards the xatu-derived block-identity and wall-clock columns.
+// These are partition / ORDER BY / shard keys: a zero/empty value corrupts placement,
+// so their absence must halt rather than store garbage. The slot/epoch numeric VALUES
+// stay allow-zero (genesis); only the derived roots and *_start_date_time must exist.
+func (b *canonicalBeaconElaboratedAttestationBatch) validateAdditional(event *xatu.DecoratedEvent) error {
+	additional := event.GetMeta().GetClient().GetEthV2BeaconBlockElaboratedAttestation()
+	if additional == nil {
+		return fmt.Errorf("nil elaborated_attestation additional data: %w", route.ErrInvalidEvent)
+	}
+
+	block := additional.GetBlock()
+	if block == nil {
+		return fmt.Errorf("nil additional Block: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetRoot() == "" {
+		return fmt.Errorf("empty block_root: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil block_slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if block.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil block_epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSource().GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil source_epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetTarget().GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil target_epoch_start_date_time: %w", route.ErrInvalidEvent)
+	}
 
 	return nil
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_elaborated_attestation_test.go
@@ -20,7 +20,19 @@ func TestSnapshot_canonical_beacon_elaborated_attestation(t *testing.T) {
 		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
 			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockElaboratedAttestation{
 				EthV2BeaconBlockElaboratedAttestation: &xatu.ClientMeta_AdditionalEthV2BeaconBlockElaboratedAttestationData{
+					Block: &xatu.BlockIdentifier{
+						Root:  "0x4444444444444444444444444444444444444444444444444444444444444444",
+						Slot:  testfixture.SlotEpochAdditional(),
+						Epoch: testfixture.EpochAdditional(),
+					},
+					Slot:  testfixture.SlotEpochAdditional(),
 					Epoch: testfixture.EpochAdditional(),
+					Source: &xatu.ClientMeta_AdditionalEthV1AttestationSourceV2Data{
+						Epoch: testfixture.EpochAdditional(),
+					},
+					Target: &xatu.ClientMeta_AdditionalEthV1AttestationTargetV2Data{
+						Epoch: testfixture.EpochAdditional(),
+					},
 				},
 			},
 		}),
@@ -30,9 +42,28 @@ func TestSnapshot_canonical_beacon_elaborated_attestation(t *testing.T) {
 					wrapperspb.UInt64(11),
 					wrapperspb.UInt64(22),
 				},
+				Data: &ethv1.AttestationDataV2{
+					Slot:            wrapperspb.UInt64(100),
+					Index:           wrapperspb.UInt64(0),
+					BeaconBlockRoot: "0x1111111111111111111111111111111111111111111111111111111111111111",
+					Source: &ethv1.CheckpointV2{
+						Epoch: wrapperspb.UInt64(2),
+						Root:  "0x2222222222222222222222222222222222222222222222222222222222222222",
+					},
+					Target: &ethv1.CheckpointV2{
+						Epoch: wrapperspb.UInt64(3),
+						Root:  "0x3333333333333333333333333333333333333333333333333333333333333333",
+					},
+				},
 			},
 		},
 	}, 1, map[string]any{
 		"meta_network_name": "mainnet",
+		"beacon_block_root": "0x1111111111111111111111111111111111111111111111111111111111111111",
+		"source_root":       "0x2222222222222222222222222222222222222222222222222222222222222222",
+		"target_root":       "0x3333333333333333333333333333333333333333333333333333333333333333",
+		"block_root":        "0x4444444444444444444444444444444444444444444444444444444444444444",
+		"committee_index":   "0",
+		"validators":        []uint32{11, 22},
 	})
 }

--- a/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty.go
@@ -70,6 +70,27 @@ func (b *canonicalBeaconProposerDutyBatch) validate(event *xatu.DecoratedEvent) 
 		return fmt.Errorf("nil ValidatorIndex: %w", route.ErrInvalidEvent)
 	}
 
+	if payload.GetPubkey() == "" {
+		return fmt.Errorf("empty Pubkey: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty meta network name: %w", route.ErrInvalidEvent)
+	}
+
+	additional := event.GetMeta().GetClient().GetEthV1ProposerDuty()
+	if additional == nil {
+		return fmt.Errorf("nil eth_v1_proposer_duty additional data: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetSlot().GetStartDateTime() == nil {
+		return fmt.Errorf("nil slot start date time: %w", route.ErrInvalidEvent)
+	}
+
+	if additional.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil epoch start date time: %w", route.ErrInvalidEvent)
+	}
+
 	return nil
 }
 

--- a/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty_test.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_proposer_duty_test.go
@@ -30,6 +30,7 @@ func TestSnapshot_canonical_beacon_proposer_duty(t *testing.T) {
 			EthV1ProposerDuty: &ethv1.ProposerDuty{
 				Slot:           wrapperspb.UInt64(100),
 				ValidatorIndex: wrapperspb.UInt64(77),
+				Pubkey:         "0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95",
 			},
 		},
 	}, 1, map[string]any{

--- a/pkg/clickhouse/route/canonical/canonical_beacon_state_finality_checkpoint.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_state_finality_checkpoint.go
@@ -60,6 +60,18 @@ func (b *canonicalBeaconStateFinalityCheckpointBatch) validate(event *xatu.Decor
 		return fmt.Errorf("nil Epoch: %w", route.ErrInvalidEvent)
 	}
 
+	if extra.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil EpochStartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if extra.GetStateId() == "" {
+		return fmt.Errorf("nil StateID: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("nil MetaNetworkName: %w", route.ErrInvalidEvent)
+	}
+
 	if payload.GetPreviousJustified() == nil {
 		return fmt.Errorf("nil PreviousJustified: %w", route.ErrInvalidEvent)
 	}

--- a/pkg/clickhouse/route/canonical/canonical_beacon_state_randao.go
+++ b/pkg/clickhouse/route/canonical/canonical_beacon_state_randao.go
@@ -77,9 +77,22 @@ func (b *canonicalBeaconStateRandaoBatch) FlattenTo(event *xatu.DecoratedEvent) 
 }
 
 func (b *canonicalBeaconStateRandaoBatch) validate(event *xatu.DecoratedEvent) error {
+	payload := event.GetEthV1BeaconStateRandao()
+	if payload.GetRandao() == "" {
+		return fmt.Errorf("empty Randao: %w", route.ErrInvalidEvent)
+	}
+
 	extra := event.GetMeta().GetClient().GetEthV1BeaconStateRandao()
 	if extra == nil || extra.GetEpoch() == nil || extra.GetEpoch().GetNumber() == nil {
 		return fmt.Errorf("nil Epoch: %w", route.ErrInvalidEvent)
+	}
+
+	if extra.GetEpoch().GetStartDateTime() == nil {
+		return fmt.Errorf("nil EpochStartDateTime: %w", route.ErrInvalidEvent)
+	}
+
+	if event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName() == "" {
+		return fmt.Errorf("empty MetaNetworkName: %w", route.ErrInvalidEvent)
 	}
 
 	return nil

--- a/pkg/clickhouse/route/routes_test.go
+++ b/pkg/clickhouse/route/routes_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethpandaops/xatu/pkg/clickhouse/route"
 	tabledefs "github.com/ethpandaops/xatu/pkg/clickhouse/route/all"
+	"github.com/ethpandaops/xatu/pkg/clickhouse/route/testfixture"
 	ethv1 "github.com/ethpandaops/xatu/pkg/proto/eth/v1"
 	libp2p "github.com/ethpandaops/xatu/pkg/proto/libp2p"
 	"github.com/ethpandaops/xatu/pkg/proto/xatu"
@@ -288,11 +289,43 @@ func TestElaboratedAttestationAliasesValidatorIndexesToValidators(t *testing.T) 
 			DateTime: timestamppb.Now(),
 			Id:       "elaborated-1",
 		},
+		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
+			AdditionalData: &xatu.ClientMeta_EthV2BeaconBlockElaboratedAttestation{
+				EthV2BeaconBlockElaboratedAttestation: &xatu.ClientMeta_AdditionalEthV2BeaconBlockElaboratedAttestationData{
+					Block: &xatu.BlockIdentifier{
+						Root:  "0x4444444444444444444444444444444444444444444444444444444444444444",
+						Slot:  testfixture.SlotEpochAdditional(),
+						Epoch: testfixture.EpochAdditional(),
+					},
+					Slot:  testfixture.SlotEpochAdditional(),
+					Epoch: testfixture.EpochAdditional(),
+					Source: &xatu.ClientMeta_AdditionalEthV1AttestationSourceV2Data{
+						Epoch: testfixture.EpochAdditional(),
+					},
+					Target: &xatu.ClientMeta_AdditionalEthV1AttestationTargetV2Data{
+						Epoch: testfixture.EpochAdditional(),
+					},
+				},
+			},
+		}),
 		Data: &xatu.DecoratedEvent_EthV2BeaconBlockElaboratedAttestation{
 			EthV2BeaconBlockElaboratedAttestation: &ethv1.ElaboratedAttestation{
 				ValidatorIndexes: []*wrapperspb.UInt64Value{
 					wrapperspb.UInt64(11),
 					wrapperspb.UInt64(22),
+				},
+				Data: &ethv1.AttestationDataV2{
+					Slot:            wrapperspb.UInt64(100),
+					Index:           wrapperspb.UInt64(0),
+					BeaconBlockRoot: "0x1111111111111111111111111111111111111111111111111111111111111111",
+					Source: &ethv1.CheckpointV2{
+						Epoch: wrapperspb.UInt64(2),
+						Root:  "0x2222222222222222222222222222222222222222222222222222222222222222",
+					},
+					Target: &ethv1.CheckpointV2{
+						Epoch: wrapperspb.UInt64(3),
+						Root:  "0x3333333333333333333333333333333333333333333333333333333333333333",
+					},
 				},
 			},
 		},

--- a/pkg/clickhouse/table_writer.go
+++ b/pkg/clickhouse/table_writer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,6 +46,14 @@ type chTableWriter struct {
 	insertQueryOK bool
 }
 
+// isCanonical reports whether this writer targets a canonical (cannon-derived,
+// backfilled) table. Canonical data is authoritative and gap-sensitive, so
+// invalid events halt rather than drop. Live/sentry tables are not prefixed
+// canonical_ and drop invalid events instead.
+func (tw *chTableWriter) isCanonical() bool {
+	return strings.HasPrefix(tw.baseTable, "canonical_")
+}
+
 func (tw *chTableWriter) flush(ctx context.Context, events []*xatu.DecoratedEvent) ([]*xatu.DecoratedEvent, error) {
 	if len(events) == 0 {
 		return nil, nil
@@ -80,11 +89,12 @@ func (tw *chTableWriter) flush(ctx context.Context, events []*xatu.DecoratedEven
 		if errors.Is(err, route.ErrInvalidEvent) {
 			tw.metrics.WriteErrors().WithLabelValues(tw.table).Inc()
 
-			invalidEvents = append(invalidEvents, event)
+			canonical := tw.isCanonical()
 
 			if ok, suppressed := tw.logSampler.Allow("invalid_event"); ok {
 				entry := tw.log.WithError(err).
-					WithField("event_name", event.GetEvent().GetName().String())
+					WithField("event_name", event.GetEvent().GetName().String()).
+					WithField("canonical", canonical)
 				if meta := event.GetMeta(); meta != nil && meta.GetClient() != nil {
 					entry = entry.WithField("client_name", meta.GetClient().GetName())
 				}
@@ -97,8 +107,26 @@ func (tw *chTableWriter) flush(ctx context.Context, events []*xatu.DecoratedEven
 					entry = entry.WithField("event_json", string(jsonBytes))
 				}
 
-				entry.Warn("Skipping invalid event")
+				if canonical {
+					entry.Error("Halting on invalid canonical event (refusing to advance past a gap)")
+				} else {
+					entry.Warn("Skipping invalid event")
+				}
 			}
+
+			// Canonical (cannon-backfilled) data is authoritative: dropping an
+			// invalid row leaves a permanent gap. Halt so the caller retries
+			// against complete upstream data rather than advancing past it.
+			if canonical {
+				return invalidEvents, &tableWriteError{
+					table: tw.baseTable,
+					cause: &invalidEventError{cause: err},
+				}
+			}
+
+			// Non-canonical (live/sentry) data is point-in-time and cannot be
+			// re-fetched — drop it.
+			invalidEvents = append(invalidEvents, event)
 
 			continue
 		}

--- a/pkg/clickhouse/writer_test.go
+++ b/pkg/clickhouse/writer_test.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -527,6 +528,52 @@ func (s *stubBatch) Rows() int { return s.rows }
 func (s *stubBatch) Input() proto.Input { return proto.Input{} }
 
 func (s *stubBatch) Reset() { s.rows = 0 }
+
+// invalidEventBatch always reports an event as invalid (route.ErrInvalidEvent).
+type invalidEventBatch struct{}
+
+func (b *invalidEventBatch) FlattenTo(_ *xatu.DecoratedEvent) error {
+	return fmt.Errorf("bad event: %w", route.ErrInvalidEvent)
+}
+func (b *invalidEventBatch) Rows() int          { return 0 }
+func (b *invalidEventBatch) Input() proto.Input { return proto.Input{} }
+func (b *invalidEventBatch) Reset()             {}
+
+func newInvalidEventTableWriter(table string) *chTableWriter {
+	return &chTableWriter{
+		log:        logrus.New().WithField("component", "test"),
+		table:      table,
+		baseTable:  table,
+		metrics:    sharedTestMetrics(),
+		logSampler: telemetry.NewLogSampler(time.Minute),
+		newBatch:   func() route.ColumnarBatch { return &invalidEventBatch{} },
+	}
+}
+
+func TestFlushCanonicalInvalidEventHaltsNonCanonicalDrops(t *testing.T) {
+	ev := &xatu.DecoratedEvent{
+		Event: &xatu.Event{Name: xatu.Event_BEACON_API_ETH_V2_BEACON_BLOCK_V2},
+	}
+
+	// Canonical: a dropped row is a permanent gap, so an invalid event must
+	// HALT (return an error) and must NOT land in the drop list.
+	tw := newInvalidEventTableWriter("canonical_beacon_block")
+	invalid, err := tw.flush(context.Background(), []*xatu.DecoratedEvent{ev})
+	require.Error(t, err)
+	assert.Empty(t, invalid, "canonical invalid event must not be dropped")
+
+	var iee *invalidEventError
+	assert.True(t, errors.As(err, &iee), "canonical halt should wrap invalidEventError")
+	assert.False(t, IsPermanentWriteError(err),
+		"canonical halt must be non-permanent so it retries/NAKs rather than dropping")
+
+	// Non-canonical (live/sentry): point-in-time data that cannot be re-fetched
+	// is DROPPED — no error, event lands in the invalid (drop) list.
+	tw2 := newInvalidEventTableWriter("beacon_api_eth_v1_events_head")
+	invalid2, err2 := tw2.flush(context.Background(), []*xatu.DecoratedEvent{ev})
+	require.NoError(t, err2, "non-canonical invalid event must drop, not halt")
+	assert.Len(t, invalid2, 1, "non-canonical invalid event should be in the drop list")
+}
 
 func TestTableConfigMergeSkipFlattenErrors(t *testing.T) {
 	t.Run("default inherits from defaults", func(t *testing.T) {

--- a/pkg/consumoor/config_test.go
+++ b/pkg/consumoor/config_test.go
@@ -152,8 +152,9 @@ func TestTableConfigForMergesInsertSettings(t *testing.T) {
 	assert.Equal(
 		t,
 		map[string]any{
-			"insert_quorum":         3,
-			"insert_quorum_timeout": 30000,
+			"insert_quorum":             3,
+			"insert_quorum_timeout":     30000,
+			distributedForegroundInsert: 1,
 		},
 		got.InsertSettings,
 	)
@@ -240,12 +241,14 @@ func TestKafkaConfigValidateSessionTimeout(t *testing.T) {
 	})
 }
 
+const distributedForegroundInsert = "distributed_foreground_insert"
+
 func TestTableConfigForAppliesCanonicalDefaults(t *testing.T) {
 	t.Run("adds auto quorum for canonical tables when unset", func(t *testing.T) {
 		cfg := &clickhouse.Config{}
 
 		got := cfg.TableConfigFor("canonical_beacon_block")
-		assert.Equal(t, map[string]any{"insert_quorum": "auto"}, got.InsertSettings)
+		assert.Equal(t, map[string]any{"insert_quorum": "auto", distributedForegroundInsert: 1}, got.InsertSettings)
 	})
 
 	t.Run("does not add quorum for non-canonical tables", func(t *testing.T) {
@@ -267,7 +270,7 @@ func TestTableConfigForAppliesCanonicalDefaults(t *testing.T) {
 		}
 
 		got := cfg.TableConfigFor("canonical_beacon_block")
-		assert.Equal(t, map[string]any{"insert_quorum": 3}, got.InsertSettings)
+		assert.Equal(t, map[string]any{"insert_quorum": 3, distributedForegroundInsert: 1}, got.InsertSettings)
 	})
 
 	t.Run("preserves explicit default quorum", func(t *testing.T) {
@@ -280,6 +283,6 @@ func TestTableConfigForAppliesCanonicalDefaults(t *testing.T) {
 		}
 
 		got := cfg.TableConfigFor("canonical_beacon_block")
-		assert.Equal(t, map[string]any{"insert_quorum": 2}, got.InsertSettings)
+		assert.Equal(t, map[string]any{"insert_quorum": 2, distributedForegroundInsert: 1}, got.InsertSettings)
 	})
 }


### PR DESCRIPTION
Makes canonical (cannon-backfilled) data strict: a dropped row is a permanent gap in history, so an invalid canonical event now HALTS the writer (cannon doesn't advance its checkpoint; consumoor NAKs for redelivery) instead of being silently dropped or zero-filled. Non-canonical (live/sentry) events are unchanged — they're point-in-time and still drop. The halt keys off the `canonical_` table prefix via a non-permanent `invalidEventError`.

Adds/extends route `validate()` on 16 canonical tables so every spec-required field is presence-checked (`error-if-absent`), driven by a field-by-field audit of each table against the beacon-API OpenAPI `required:` arrays and the consensus-specs SSZ containers. Empty-valid fields (validator index 0, genesis slot/epoch 0, zero/negative rewards, pre-finality ZERO_HASH checkpoint roots, empty lists) are deliberately left untouched so strictness never stalls on legitimate data. Supersedes #860 (this is the spec-verified version of that cleanup).

Also fixes two stale consumoor tests left red on master by b826b35a (canonical `distributed_foreground_insert` default). The validators table's lossy Nullable→NOT NULL flip + re-derive is handled in a separate follow-up PR.