### PR TITLE
fix(gloas): accept versioned wrapper on gloas SSE events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ethpandaops/beacon v0.69.1-0.20260514032911-81b9ef3395fd
 	github.com/ethpandaops/ethcore v0.0.0-20260514003726-f67d7a6e9f91
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.6-0.20260702064619-3508a16829bf
+	github.com/ethpandaops/go-eth2-client v0.1.6-0.20260703015600-af3297cb0c0d
 	github.com/failsafe-go/failsafe-go v0.9.6
 	github.com/ferranbt/fastssz v1.0.0
 	github.com/go-co-op/gocron/v2 v2.16.6

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/ethpandaops/ethereum-package-go v0.8.1 h1:VN5l8UXveyw7gp0Glj8BRzS/D5R
 github.com/ethpandaops/ethereum-package-go v0.8.1/go.mod h1:LQThCwlCeeNBTdXOFV+xSwudoced53x+o/Orya3Y+oo=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.6-0.20260702064619-3508a16829bf h1:VwXdhLyHd6q2+EZiTRbe01gVzrrnYCZcoot20/VOE1o=
-github.com/ethpandaops/go-eth2-client v0.1.6-0.20260702064619-3508a16829bf/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
+github.com/ethpandaops/go-eth2-client v0.1.6-0.20260703015600-af3297cb0c0d h1:oVn/pm1SOqW2nPfKGeYm4ZQYD9yYWjyYr76QSbC+Zj8=
+github.com/ethpandaops/go-eth2-client v0.1.6-0.20260703015600-af3297cb0c0d/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
 github.com/failsafe-go/failsafe-go v0.9.6 h1:vPSH2cry0Ee5cnR9wc9qshCDO6jdrMA9elBJNwyo4Uk=
 github.com/failsafe-go/failsafe-go v0.9.6/go.mod h1:IeRpglkcwzKagjDMh90ZhN2l4Ovt3+jemQBUbThag54=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=


### PR DESCRIPTION
Bumps go-eth2-client for the eventstream fix (ethpandaops/go-eth2-client#36): the beacon-API spec wraps `payload_attestation_message`, `execution_payload_bid` and `proposer_preferences` as `{"version", "data"}` — Lighthouse follows the spec, Prysm sends the bare object. Both shapes now decode.

Found live on glamsterdam-devnet-6: every Lighthouse PTC message failed with `invalid JSON: beacon block root missing` while Prysm's parsed fine.