### PR TITLE
fix(clickhouse): signed propagation_slot_start_diff for pre-slot ePBS events

### DIFF
--- a/deploy/migrations/clickhouse/xatu/008_gloas_epbs_propagation_signed.down.sql
+++ b/deploy/migrations/clickhouse/xatu/008_gloas_epbs_propagation_signed.down.sql
@@ -1,0 +1,82 @@
+-- Reverse of 008: restore the vestigial `version` column and revert
+-- propagation_slot_start_diff to UInt32.
+
+---------------------------------------------------------------------
+-- Section 2 reverse: re-add `version` column (all four ePBS gossip tables)
+---------------------------------------------------------------------
+
+ALTER TABLE libp2p_gossipsub_execution_payload_envelope_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+ALTER TABLE libp2p_gossipsub_execution_payload_envelope ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+
+ALTER TABLE libp2p_gossipsub_execution_payload_bid_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+ALTER TABLE libp2p_gossipsub_execution_payload_bid ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+
+ALTER TABLE libp2p_gossipsub_payload_attestation_message_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+ALTER TABLE libp2p_gossipsub_payload_attestation_message ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+
+ALTER TABLE libp2p_gossipsub_proposer_preferences_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+ALTER TABLE libp2p_gossipsub_proposer_preferences ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS version UInt32 DEFAULT 4294967295 - propagation_slot_start_diff
+        COMMENT 'Version for dedup: prefer lowest propagation time'
+        CODEC(DoubleDelta, ZSTD(1)) AFTER updated_date_time;
+
+---------------------------------------------------------------------
+-- Section 1 reverse: propagation_slot_start_diff back to UInt32
+---------------------------------------------------------------------
+
+ALTER TABLE beacon_api_eth_v1_events_execution_payload_bid_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms'
+        CODEC(ZSTD(1));
+ALTER TABLE beacon_api_eth_v1_events_execution_payload_bid ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms'
+        CODEC(ZSTD(1));
+
+ALTER TABLE beacon_api_eth_v1_events_proposer_preferences_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms'
+        CODEC(ZSTD(1));
+ALTER TABLE beacon_api_eth_v1_events_proposer_preferences ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_execution_payload_bid_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Propagation delay from slot start in ms'
+        CODEC(ZSTD(1));
+ALTER TABLE libp2p_gossipsub_execution_payload_bid ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Propagation delay from slot start in ms'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_proposer_preferences_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Propagation delay from slot start in ms'
+        CODEC(ZSTD(1));
+ALTER TABLE libp2p_gossipsub_proposer_preferences ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff UInt32
+        COMMENT 'Propagation delay from slot start in ms'
+        CODEC(ZSTD(1));

--- a/deploy/migrations/clickhouse/xatu/008_gloas_epbs_propagation_signed.up.sql
+++ b/deploy/migrations/clickhouse/xatu/008_gloas_epbs_propagation_signed.up.sql
@@ -1,0 +1,84 @@
+-- EIP-7732 ePBS gossip-table corrections.
+--
+-- Section 1: make propagation_slot_start_diff signed.
+--   Builder bids and proposer preferences are broadcast BEFORE their slot begins,
+--   so (event_time - slot_start) is negative. The column was UInt32, which stored
+--   the negative value as a ~4.29e9 underflow. Change it to Int32 on the two
+--   pre-slot event tables (SSE + gossip). The UInt32 -> Int32 conversion is a
+--   wrapping cast in ClickHouse, so existing underflowed rows are corrected to
+--   their true negative value in place (e.g. 4294966896 -> -400).
+--
+-- Section 2: drop the vestigial `version` column.
+--   The four ePBS gossip tables carry a `version UInt32 DEFAULT
+--   4294967295 - propagation_slot_start_diff` column commented "for dedup", but no
+--   table's ReplacingMergeTree uses it -- every engine keys on updated_date_time.
+--   The same column was already removed from the pre-Gloas gossip tables
+--   (29466e46) and unintentionally reintroduced here. Drop it.
+
+---------------------------------------------------------------------
+-- Section 1: signed propagation_slot_start_diff (bid + proposer_preferences)
+---------------------------------------------------------------------
+
+ALTER TABLE beacon_api_eth_v1_events_execution_payload_bid_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE beacon_api_eth_v1_events_execution_payload_bid ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE beacon_api_eth_v1_events_proposer_preferences_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE beacon_api_eth_v1_events_proposer_preferences ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Difference between event_date_time and slot_start_date_time in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_execution_payload_bid_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Propagation delay from slot start in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_execution_payload_bid ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Propagation delay from slot start in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_proposer_preferences_local ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Propagation delay from slot start in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+ALTER TABLE libp2p_gossipsub_proposer_preferences ON CLUSTER '{cluster}'
+    MODIFY COLUMN propagation_slot_start_diff Int32
+        COMMENT 'Propagation delay from slot start in ms (negative if observed before slot start)'
+        CODEC(ZSTD(1));
+
+---------------------------------------------------------------------
+-- Section 2: drop vestigial `version` column (all four ePBS gossip tables)
+---------------------------------------------------------------------
+
+ALTER TABLE libp2p_gossipsub_execution_payload_envelope ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+ALTER TABLE libp2p_gossipsub_execution_payload_envelope_local ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+
+ALTER TABLE libp2p_gossipsub_execution_payload_bid ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+ALTER TABLE libp2p_gossipsub_execution_payload_bid_local ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+
+ALTER TABLE libp2p_gossipsub_payload_attestation_message ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+ALTER TABLE libp2p_gossipsub_payload_attestation_message_local ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+
+ALTER TABLE libp2p_gossipsub_proposer_preferences ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;
+ALTER TABLE libp2p_gossipsub_proposer_preferences_local ON CLUSTER '{cluster}'
+    DROP COLUMN IF EXISTS version;

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid.gen.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid.gen.go
@@ -17,7 +17,7 @@ type beaconApiEthV1EventsExecutionPayloadBidBatch struct {
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
-	PropagationSlotStartDiff                  proto.ColUInt32
+	PropagationSlotStartDiff                  proto.ColInt32
 	Epoch                                     proto.ColUInt32
 	EpochStartDateTime                        proto.ColDateTime
 	BuilderIndex                              proto.ColUInt64

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid.go
@@ -115,7 +115,10 @@ func (b *beaconApiEthV1EventsExecutionPayloadBidBatch) appendAdditionalData(
 
 	b.Slot.Append(uint32(additional.Slot)) //nolint:gosec // slot fits uint32
 	b.SlotStartDateTime.Append(time.Unix(additional.SlotStartDateTime, 0))
-	b.PropagationSlotStartDiff.Append(uint32(additional.PropagationSlotStartDiff)) //nolint:gosec // propagation diff fits uint32
-	b.Epoch.Append(uint32(additional.Epoch))                                       //nolint:gosec // epoch fits uint32
+	// Signed: bids propagate before slot start, so the diff can be negative. It is
+	// carried through the proto as a two's-complement uint64; reinterpret to int32.
+	//nolint:gosec // intentional two's-complement reinterpret of a signed ms diff
+	b.PropagationSlotStartDiff.Append(int32(int64(additional.PropagationSlotStartDiff)))
+	b.Epoch.Append(uint32(additional.Epoch)) //nolint:gosec // epoch fits uint32
 	b.EpochStartDateTime.Append(time.Unix(additional.EpochStartDateTime, 0))
 }

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid_test.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_execution_payload_bid_test.go
@@ -83,3 +83,47 @@ func TestSnapshot_beacon_api_eth_v1_events_execution_payload_bid(t *testing.T) {
 		colBlobKzgCommitmentCount:     uint32(3),
 	})
 }
+
+// Bids are broadcast before their slot begins, so the propagation delay is
+// negative. It travels through the proto as a two's-complement uint64 and must
+// land as a signed Int32, not a ~4.29e9 underflow.
+func TestSnapshot_beacon_api_eth_v1_events_execution_payload_bid_preSlot(t *testing.T) {
+	if len(beaconApiEthV1EventsExecutionPayloadBidEventNames) == 0 {
+		t.Skip("no event names registered for beacon_api_eth_v1_events_execution_payload_bid")
+	}
+
+	const colPropagationSlotStartDiff = "propagation_slot_start_diff"
+
+	preSlotMs := int64(-400)
+
+	testfixture.AssertSnapshot(t, newbeaconApiEthV1EventsExecutionPayloadBidBatch(), &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Name:     beaconApiEthV1EventsExecutionPayloadBidEventNames[0],
+			DateTime: testfixture.TS(),
+			Id:       testfixture.SnapshotID,
+		},
+		Meta: testfixture.MetaWithAdditional(&xatu.ClientMeta{
+			AdditionalData: &xatu.ClientMeta_EthV1EventsExecutionPayloadBid{
+				EthV1EventsExecutionPayloadBid: &xatu.ClientMeta_AdditionalEthV1EventsExecutionPayloadBidData{
+					Slot:  testfixture.SlotEpochAdditional(),
+					Epoch: testfixture.EpochAdditional(),
+					Propagation: &xatu.PropagationV2{
+						SlotStartDiff: wrapperspb.UInt64(uint64(preSlotMs)),
+					},
+				},
+			},
+		}),
+		Data: &xatu.DecoratedEvent_EthV1EventsExecutionPayloadBid{
+			EthV1EventsExecutionPayloadBid: &ethv1.SignedExecutionPayloadBid{
+				Message: &ethv1.ExecutionPayloadBid{
+					BlockHash:    repeatHex("2b", 32),
+					BuilderIndex: wrapperspb.UInt64(2),
+					Slot:         wrapperspb.UInt64(48752),
+				},
+				Signature: repeatHex("51", 96),
+			},
+		},
+	}, 1, map[string]any{
+		colPropagationSlotStartDiff: int32(preSlotMs),
+	})
+}

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_proposer_preferences.gen.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_proposer_preferences.gen.go
@@ -17,7 +17,7 @@ type beaconApiEthV1EventsProposerPreferencesBatch struct {
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
-	PropagationSlotStartDiff                  proto.ColUInt32
+	PropagationSlotStartDiff                  proto.ColInt32
 	Epoch                                     proto.ColUInt32
 	EpochStartDateTime                        proto.ColDateTime
 	ValidatorIndex                            proto.ColUInt32

--- a/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_proposer_preferences.go
+++ b/pkg/clickhouse/route/beacon/beacon_api_eth_v1_events_proposer_preferences.go
@@ -97,7 +97,11 @@ func (b *beaconApiEthV1EventsProposerPreferencesBatch) appendAdditionalData(
 
 	b.Slot.Append(uint32(additional.Slot)) //nolint:gosec // slot fits uint32
 	b.SlotStartDateTime.Append(time.Unix(additional.SlotStartDateTime, 0))
-	b.PropagationSlotStartDiff.Append(uint32(additional.PropagationSlotStartDiff)) //nolint:gosec // propagation diff fits uint32
-	b.Epoch.Append(uint32(additional.Epoch))                                       //nolint:gosec // epoch fits uint32
+	// Signed: proposer preferences propagate before slot start, so the diff can be
+	// negative. It is carried through the proto as a two's-complement uint64;
+	// reinterpret to int32.
+	//nolint:gosec // intentional two's-complement reinterpret of a signed ms diff
+	b.PropagationSlotStartDiff.Append(int32(int64(additional.PropagationSlotStartDiff)))
+	b.Epoch.Append(uint32(additional.Epoch)) //nolint:gosec // epoch fits uint32
 	b.EpochStartDateTime.Append(time.Unix(additional.EpochStartDateTime, 0))
 }

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_bid.gen.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_bid.gen.go
@@ -14,7 +14,6 @@ const libp2pGossipsubExecutionPayloadBidTableName route.TableName = "libp2p_goss
 
 type libp2pGossipsubExecutionPayloadBidBatch struct {
 	UpdatedDateTime                           proto.ColDateTime
-	Version                                   proto.ColUInt32
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
@@ -24,7 +23,7 @@ type libp2pGossipsubExecutionPayloadBidBatch struct {
 	WallclockSlotStartDateTime                proto.ColDateTime
 	WallclockEpoch                            proto.ColUInt32
 	WallclockEpochStartDateTime               proto.ColDateTime
-	PropagationSlotStartDiff                  proto.ColUInt32
+	PropagationSlotStartDiff                  proto.ColInt32
 	BuilderIndex                              proto.ColUInt64
 	BlockHash                                 route.SafeColFixedStr
 	ParentBlockHash                           route.SafeColFixedStr
@@ -119,7 +118,6 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) appendMetadata(event *xatu.Dec
 func (b *libp2pGossipsubExecutionPayloadBidBatch) Input() proto.Input {
 	return proto.Input{
 		{Name: "updated_date_time", Data: &b.UpdatedDateTime},
-		{Name: "version", Data: &b.Version},
 		{Name: "event_date_time", Data: &b.EventDateTime},
 		{Name: "slot", Data: &b.Slot},
 		{Name: "slot_start_date_time", Data: &b.SlotStartDateTime},
@@ -166,7 +164,6 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) Input() proto.Input {
 
 func (b *libp2pGossipsubExecutionPayloadBidBatch) Reset() {
 	b.UpdatedDateTime.Reset()
-	b.Version.Reset()
 	b.EventDateTime.Reset()
 	b.Slot.Reset()
 	b.SlotStartDateTime.Reset()
@@ -216,9 +213,8 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) Snapshot() []map[string]any {
 	out := make([]map[string]any, n)
 
 	for i := 0; i < n; i++ {
-		row := make(map[string]any, 43)
+		row := make(map[string]any, 42)
 		row["updated_date_time"] = b.UpdatedDateTime.Row(i).Unix()
-		row["version"] = b.Version.Row(i)
 		row["event_date_time"] = b.EventDateTime.Row(i).UnixMilli()
 		row["slot"] = b.Slot.Row(i)
 		row["slot_start_date_time"] = b.SlotStartDateTime.Row(i).Unix()

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_bid.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_bid.go
@@ -114,7 +114,6 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) appendClientAdditionalData(
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -137,7 +136,6 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) appendClientAdditionalData(
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -150,8 +148,6 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) appendClientAdditionalData(
 	}
 
 	// Extract slot/epoch/wallclock/propagation fields.
-	var propagationSlotStartDiff uint32
-
 	setGossipsubSlotEpochFields(additional, func(f gossipsubSlotEpochResult) {
 		b.Slot.Append(f.Slot)
 		b.SlotStartDateTime.Append(time.Unix(f.SlotStartDateTime, 0))
@@ -161,12 +157,10 @@ func (b *libp2pGossipsubExecutionPayloadBidBatch) appendClientAdditionalData(
 		b.WallclockSlotStartDateTime.Append(time.Unix(f.WallclockSlotStartDateTime, 0))
 		b.WallclockEpoch.Append(f.WallclockEpoch)
 		b.WallclockEpochStartDateTime.Append(time.Unix(f.WallclockEpochStartDateTime, 0))
-		b.PropagationSlotStartDiff.Append(f.PropagationSlotStartDiff)
-		propagationSlotStartDiff = f.PropagationSlotStartDiff
+		// Signed: bids propagate before slot start, so the diff can be negative.
+		//nolint:gosec // intentional two's-complement reinterpret of a signed ms diff
+		b.PropagationSlotStartDiff.Append(int32(f.PropagationSlotStartDiff))
 	})
-
-	// Compute version for ReplacingMergeTree dedup.
-	b.Version.Append(4294967295 - propagationSlotStartDiff)
 
 	// Extract message fields.
 	b.MessageID.Append(wrappedStringValue(additional.GetMessageId()))

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_envelope.gen.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_envelope.gen.go
@@ -14,7 +14,6 @@ const libp2pGossipsubExecutionPayloadEnvelopeTableName route.TableName = "libp2p
 
 type libp2pGossipsubExecutionPayloadEnvelopeBatch struct {
 	UpdatedDateTime                           proto.ColDateTime
-	Version                                   proto.ColUInt32
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
@@ -113,7 +112,6 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) appendMetadata(event *xat
 func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) Input() proto.Input {
 	return proto.Input{
 		{Name: "updated_date_time", Data: &b.UpdatedDateTime},
-		{Name: "version", Data: &b.Version},
 		{Name: "event_date_time", Data: &b.EventDateTime},
 		{Name: "slot", Data: &b.Slot},
 		{Name: "slot_start_date_time", Data: &b.SlotStartDateTime},
@@ -155,7 +153,6 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) Input() proto.Input {
 
 func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) Reset() {
 	b.UpdatedDateTime.Reset()
-	b.Version.Reset()
 	b.EventDateTime.Reset()
 	b.Slot.Reset()
 	b.SlotStartDateTime.Reset()
@@ -200,9 +197,8 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) Snapshot() []map[string]a
 	out := make([]map[string]any, n)
 
 	for i := 0; i < n; i++ {
-		row := make(map[string]any, 38)
+		row := make(map[string]any, 37)
 		row["updated_date_time"] = b.UpdatedDateTime.Row(i).Unix()
-		row["version"] = b.Version.Row(i)
 		row["event_date_time"] = b.EventDateTime.Row(i).UnixMilli()
 		row["slot"] = b.Slot.Row(i)
 		row["slot_start_date_time"] = b.SlotStartDateTime.Row(i).Unix()

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_envelope.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_execution_payload_envelope.go
@@ -93,7 +93,6 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) appendClientAdditionalDat
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -116,7 +115,6 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) appendClientAdditionalDat
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -129,8 +127,6 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) appendClientAdditionalDat
 	}
 
 	// Extract slot/epoch/wallclock/propagation fields.
-	var propagationSlotStartDiff uint32
-
 	setGossipsubSlotEpochFields(additional, func(f gossipsubSlotEpochResult) {
 		b.Slot.Append(f.Slot)
 		b.SlotStartDateTime.Append(time.Unix(f.SlotStartDateTime, 0))
@@ -141,11 +137,7 @@ func (b *libp2pGossipsubExecutionPayloadEnvelopeBatch) appendClientAdditionalDat
 		b.WallclockEpoch.Append(f.WallclockEpoch)
 		b.WallclockEpochStartDateTime.Append(time.Unix(f.WallclockEpochStartDateTime, 0))
 		b.PropagationSlotStartDiff.Append(f.PropagationSlotStartDiff)
-		propagationSlotStartDiff = f.PropagationSlotStartDiff
 	})
-
-	// Compute version for ReplacingMergeTree dedup.
-	b.Version.Append(4294967295 - propagationSlotStartDiff)
 
 	// Extract message fields.
 	b.MessageID.Append(wrappedStringValue(additional.GetMessageId()))

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_payload_attestation_message.gen.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_payload_attestation_message.gen.go
@@ -14,7 +14,6 @@ const libp2pGossipsubPayloadAttestationMessageTableName route.TableName = "libp2
 
 type libp2pGossipsubPayloadAttestationMessageBatch struct {
 	UpdatedDateTime                           proto.ColDateTime
-	Version                                   proto.ColUInt32
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
@@ -113,7 +112,6 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) appendMetadata(event *xa
 func (b *libp2pGossipsubPayloadAttestationMessageBatch) Input() proto.Input {
 	return proto.Input{
 		{Name: "updated_date_time", Data: &b.UpdatedDateTime},
-		{Name: "version", Data: &b.Version},
 		{Name: "event_date_time", Data: &b.EventDateTime},
 		{Name: "slot", Data: &b.Slot},
 		{Name: "slot_start_date_time", Data: &b.SlotStartDateTime},
@@ -156,7 +154,6 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) Input() proto.Input {
 
 func (b *libp2pGossipsubPayloadAttestationMessageBatch) Reset() {
 	b.UpdatedDateTime.Reset()
-	b.Version.Reset()
 	b.EventDateTime.Reset()
 	b.Slot.Reset()
 	b.SlotStartDateTime.Reset()
@@ -202,9 +199,8 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) Snapshot() []map[string]
 	out := make([]map[string]any, n)
 
 	for i := 0; i < n; i++ {
-		row := make(map[string]any, 39)
+		row := make(map[string]any, 38)
 		row["updated_date_time"] = b.UpdatedDateTime.Row(i).Unix()
-		row["version"] = b.Version.Row(i)
 		row["event_date_time"] = b.EventDateTime.Row(i).UnixMilli()
 		row["slot"] = b.Slot.Row(i)
 		row["slot_start_date_time"] = b.SlotStartDateTime.Row(i).Unix()

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_payload_attestation_message.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_payload_attestation_message.go
@@ -104,7 +104,6 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) appendClientAdditionalDa
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -127,7 +126,6 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) appendClientAdditionalDa
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -140,8 +138,6 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) appendClientAdditionalDa
 	}
 
 	// Extract slot/epoch/wallclock/propagation fields.
-	var propagationSlotStartDiff uint32
-
 	setGossipsubSlotEpochFields(additional, func(f gossipsubSlotEpochResult) {
 		b.Slot.Append(f.Slot)
 		b.SlotStartDateTime.Append(time.Unix(f.SlotStartDateTime, 0))
@@ -152,11 +148,7 @@ func (b *libp2pGossipsubPayloadAttestationMessageBatch) appendClientAdditionalDa
 		b.WallclockEpoch.Append(f.WallclockEpoch)
 		b.WallclockEpochStartDateTime.Append(time.Unix(f.WallclockEpochStartDateTime, 0))
 		b.PropagationSlotStartDiff.Append(f.PropagationSlotStartDiff)
-		propagationSlotStartDiff = f.PropagationSlotStartDiff
 	})
-
-	// Compute version for ReplacingMergeTree dedup.
-	b.Version.Append(4294967295 - propagationSlotStartDiff)
 
 	// Extract message fields.
 	b.MessageID.Append(wrappedStringValue(additional.GetMessageId()))

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_proposer_preferences.gen.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_proposer_preferences.gen.go
@@ -14,7 +14,6 @@ const libp2pGossipsubProposerPreferencesTableName route.TableName = "libp2p_goss
 
 type libp2pGossipsubProposerPreferencesBatch struct {
 	UpdatedDateTime                           proto.ColDateTime
-	Version                                   proto.ColUInt32
 	EventDateTime                             proto.ColDateTime64
 	Slot                                      proto.ColUInt32
 	SlotStartDateTime                         proto.ColDateTime
@@ -24,7 +23,7 @@ type libp2pGossipsubProposerPreferencesBatch struct {
 	WallclockSlotStartDateTime                proto.ColDateTime
 	WallclockEpoch                            proto.ColUInt32
 	WallclockEpochStartDateTime               proto.ColDateTime
-	PropagationSlotStartDiff                  proto.ColUInt32
+	PropagationSlotStartDiff                  proto.ColInt32
 	ValidatorIndex                            proto.ColUInt32
 	FeeRecipient                              route.SafeColFixedStr
 	TargetGasLimit                            proto.ColUInt64
@@ -112,7 +111,6 @@ func (b *libp2pGossipsubProposerPreferencesBatch) appendMetadata(event *xatu.Dec
 func (b *libp2pGossipsubProposerPreferencesBatch) Input() proto.Input {
 	return proto.Input{
 		{Name: "updated_date_time", Data: &b.UpdatedDateTime},
-		{Name: "version", Data: &b.Version},
 		{Name: "event_date_time", Data: &b.EventDateTime},
 		{Name: "slot", Data: &b.Slot},
 		{Name: "slot_start_date_time", Data: &b.SlotStartDateTime},
@@ -154,7 +152,6 @@ func (b *libp2pGossipsubProposerPreferencesBatch) Input() proto.Input {
 
 func (b *libp2pGossipsubProposerPreferencesBatch) Reset() {
 	b.UpdatedDateTime.Reset()
-	b.Version.Reset()
 	b.EventDateTime.Reset()
 	b.Slot.Reset()
 	b.SlotStartDateTime.Reset()
@@ -199,9 +196,8 @@ func (b *libp2pGossipsubProposerPreferencesBatch) Snapshot() []map[string]any {
 	out := make([]map[string]any, n)
 
 	for i := 0; i < n; i++ {
-		row := make(map[string]any, 38)
+		row := make(map[string]any, 37)
 		row["updated_date_time"] = b.UpdatedDateTime.Row(i).Unix()
-		row["version"] = b.Version.Row(i)
 		row["event_date_time"] = b.EventDateTime.Row(i).UnixMilli()
 		row["slot"] = b.Slot.Row(i)
 		row["slot_start_date_time"] = b.SlotStartDateTime.Row(i).Unix()

--- a/pkg/clickhouse/route/libp2p/libp2p_gossipsub_proposer_preferences.go
+++ b/pkg/clickhouse/route/libp2p/libp2p_gossipsub_proposer_preferences.go
@@ -94,7 +94,6 @@ func (b *libp2pGossipsubProposerPreferencesBatch) appendClientAdditionalData(
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -117,7 +116,6 @@ func (b *libp2pGossipsubProposerPreferencesBatch) appendClientAdditionalData(
 		b.WallclockEpoch.Append(0)
 		b.WallclockEpochStartDateTime.Append(time.Time{})
 		b.PropagationSlotStartDiff.Append(0)
-		b.Version.Append(4294967295)
 		b.MessageID.Append("")
 		b.MessageSize.Append(0)
 		b.TopicLayer.Append("")
@@ -130,8 +128,6 @@ func (b *libp2pGossipsubProposerPreferencesBatch) appendClientAdditionalData(
 	}
 
 	// Extract slot/epoch/wallclock/propagation fields.
-	var propagationSlotStartDiff uint32
-
 	setGossipsubSlotEpochFields(additional, func(f gossipsubSlotEpochResult) {
 		b.Slot.Append(f.Slot)
 		b.SlotStartDateTime.Append(time.Unix(f.SlotStartDateTime, 0))
@@ -141,12 +137,10 @@ func (b *libp2pGossipsubProposerPreferencesBatch) appendClientAdditionalData(
 		b.WallclockSlotStartDateTime.Append(time.Unix(f.WallclockSlotStartDateTime, 0))
 		b.WallclockEpoch.Append(f.WallclockEpoch)
 		b.WallclockEpochStartDateTime.Append(time.Unix(f.WallclockEpochStartDateTime, 0))
-		b.PropagationSlotStartDiff.Append(f.PropagationSlotStartDiff)
-		propagationSlotStartDiff = f.PropagationSlotStartDiff
+		// Signed: proposer preferences propagate before slot start, so the diff can be negative.
+		//nolint:gosec // intentional two's-complement reinterpret of a signed ms diff
+		b.PropagationSlotStartDiff.Append(int32(f.PropagationSlotStartDiff))
 	})
-
-	// Compute version for ReplacingMergeTree dedup.
-	b.Version.Append(4294967295 - propagationSlotStartDiff)
 
 	// Extract message fields.
 	b.MessageID.Append(wrappedStringValue(additional.GetMessageId()))


### PR DESCRIPTION
Gloas bids and proposer preferences are broadcast before their slot starts, so their `propagation_slot_start_diff` is negative — but the column was `UInt32`, storing those as a ~4.29e9 underflow (~99–100% of rows on glamsterdam-devnet-6 over the weekend). Migration 008 changes the column to `Int32` on the four pre-slot event tables; ClickHouse's wrapping `UInt32→Int32` cast corrects the existing rows in place, and the route mappers reinterpret the two's-complement value at the ClickHouse boundary (the shared `uint64` proto field is left untouched). Verified by regenerating `.gen.go` against a real ClickHouse, migration syntax/lint gates, and a new test asserting a pre-slot bid stores `int32(-400)`.

Breaking: also drops the vestigial `version` column from the four ePBS gossip tables — it was labelled "for dedup" but no engine uses it (they key on `updated_date_time`), and the same column was already removed from the pre-Gloas tables once (`29466e46`) before being reintroduced here. Safe now since these tables are new and not yet publicized.