### PR TITLE
feat: event meta mutations for relay and consumer pipelines

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -89,6 +89,30 @@ var ServerOverrides = []ServerOverride{
 			overrides.MetricsAddr.Value = val
 		},
 	}),
+	createServerOverride(ServerOverrideConfig{
+		FlagName:    "server-event-ingester-meta-network-name-value",
+		EnvName:     "SERVER_EVENT_INGESTER_META_NETWORK_NAME_VALUE",
+		Description: "replaces the meta network name on all ingested events",
+		OverrideFunc: func(val string, overrides *server.Override) {
+			overrides.EventIngesterMetaNetworkName.Value = val
+		},
+	}),
+	createServerOverride(ServerOverrideConfig{
+		FlagName:    "server-event-ingester-meta-network-name-prefix",
+		EnvName:     "SERVER_EVENT_INGESTER_META_NETWORK_NAME_PREFIX",
+		Description: "prepends a prefix to the meta network name on all ingested events",
+		OverrideFunc: func(val string, overrides *server.Override) {
+			overrides.EventIngesterMetaNetworkName.Prefix = val
+		},
+	}),
+	createServerOverride(ServerOverrideConfig{
+		FlagName:    "server-event-ingester-meta-network-name-suffix",
+		EnvName:     "SERVER_EVENT_INGESTER_META_NETWORK_NAME_SUFFIX",
+		Description: "appends a suffix to the meta network name on all ingested events",
+		OverrideFunc: func(val string, overrides *server.Override) {
+			overrides.EventIngesterMetaNetworkName.Suffix = val
+		},
+	}),
 }
 
 // serverCmd represents the server command

--- a/docs/server.md
+++ b/docs/server.md
@@ -212,6 +212,33 @@ The coordinator service is responsible for;
 
 The event ingester service is responsible for receiving events from clients (sentries) via gRPC, validating and then forwarding them to sinks.
 
+#### Mutations
+
+The event ingester can mutate every ingested event before it is handed to the outputs. This is useful when the server runs as a relay: a small server instance whose only output is a `xatu` sink pointing at an upstream server, re-namespacing events as they pass through. A common case is multiple networks that share a genesis (forked or copied devnets) — every client derives the same network name, so the relay in front of each copy rewrites the name to keep the copies distinguishable downstream.
+
+```yaml
+services:
+  eventIngester:
+    enabled: true
+    mutations:
+      metaNetworkName:
+        # Replace the network name outright...
+        value: "my-network"
+        # ...or decorate the client-asserted name instead.
+        # `value` is mutually exclusive with `prefix`/`suffix`.
+        # prefix: "relay/"
+        # suffix: "--copy-1"
+    outputs:
+    - name: upstream
+      type: xatu
+      config:
+        address: upstream-server:8080
+```
+
+Events that carry no network metadata are left untouched. The same settings are available as CLI flags (`--server-event-ingester-meta-network-name-value`, `-prefix`, `-suffix`) and environment variables (`SERVER_EVENT_INGESTER_META_NETWORK_NAME_VALUE`, `_PREFIX`, `_SUFFIX`), which take precedence over the config file.
+
+The [consumoor](./consumoor-runbook.md) supports the same `mutations` config, applied before events are written to ClickHouse — useful for enforcing a canonical network name on everything a given pipeline persists.
+
 ## HTTP Ingester
 
 The HTTP ingester provides an HTTP endpoint for receiving events, as an alternative to the gRPC event ingester. This is useful for clients that cannot use gRPC, such as [Vector](https://vector.dev)-based log collectors like [Sentry Logs](./sentry-logs.md).

--- a/example_consumoor.yaml
+++ b/example_consumoor.yaml
@@ -89,6 +89,16 @@ clickhouse:
 #   - BEACON_API_ETH_V1_DEBUG_FORK_CHOICE
 #   - BEACON_API_ETH_V1_DEBUG_FORK_CHOICE_V2
 
+# Optional: mutations applied to every decoded event before it is routed and
+# written to ClickHouse. Useful for enforcing a canonical network name on
+# everything this consumer persists, regardless of what producers asserted.
+# `value` is mutually exclusive with `prefix`/`suffix`.
+# mutations:
+#   metaNetworkName:
+#     value: "my-devnet"
+#     # prefix: "relay/"
+#     # suffix: "--copy-1"
+
 tracing:
   enabled: false
   endpoint: localhost:4318

--- a/example_server.yaml
+++ b/example_server.yaml
@@ -76,6 +76,18 @@ services:
     #             eventNames:
     #             - BEACON_API_ETH_V1_EVENTS_ATTESTATION
     #             - BEACON_API_ETH_V1_EVENTS_BLOCK
+    # Mutations are applied to every ingested event before it is handed to
+    # the outputs. Useful when this server runs as a relay that re-namespaces
+    # events before forwarding them upstream, e.g. networks that share a
+    # genesis and would otherwise derive identical network names.
+    # `value` is mutually exclusive with `prefix`/`suffix`.
+    # Also settable via --server-event-ingester-meta-network-name-{value,prefix,suffix}
+    # or SERVER_EVENT_INGESTER_META_NETWORK_NAME_{VALUE,PREFIX,SUFFIX}.
+    # mutations:
+    #   metaNetworkName:
+    #     value: "my-network"
+    #     # prefix: "relay/"
+    #     # suffix: "--copy-1"
     outputs:
     - name: stdout
       type: stdout

--- a/pkg/consumoor/config.go
+++ b/pkg/consumoor/config.go
@@ -29,6 +29,11 @@ type Config struct {
 	// DisabledEvents is a list of event names to drop without processing.
 	DisabledEvents []string `yaml:"disabledEvents"`
 
+	// Mutations are applied to every decoded event before it is routed and
+	// written to ClickHouse. Useful for enforcing a canonical network name
+	// on everything this consumer persists.
+	Mutations xatu.EventMutatorConfig `yaml:"mutations"`
+
 	// Tracing configuration
 	Tracing observability.TracingConfig `yaml:"tracing"`
 }
@@ -49,6 +54,10 @@ func (c *Config) Validate() error {
 
 	if _, err := c.DisabledEventEnums(); err != nil {
 		return err
+	}
+
+	if err := c.Mutations.Validate(); err != nil {
+		return fmt.Errorf("invalid mutations config: %w", err)
 	}
 
 	if err := c.Tracing.Validate(); err != nil {

--- a/pkg/consumoor/consumoor.go
+++ b/pkg/consumoor/consumoor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethpandaops/xatu/pkg/clickhouse/telemetry"
 	"github.com/ethpandaops/xatu/pkg/consumoor/source"
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
 // topicStream pairs a discovered Kafka topic with its dedicated Benthos stream.
@@ -47,6 +48,7 @@ type Consumoor struct {
 
 	metrics    *telemetry.Metrics
 	router     *router.Engine
+	mutator    xatu.EventMutator
 	writer     source.Writer
 	streams    []topicStream
 	lagMonitor *source.LagMonitor
@@ -96,6 +98,11 @@ func New(
 	}
 
 	rtr := router.New(log, registeredRoutes, disabledEvents, metrics)
+
+	mutator, err := xatu.NewEventMutator(&config.Mutations)
+	if err != nil {
+		return nil, fmt.Errorf("creating event mutator: %w", err)
+	}
 
 	// Register columnar batch factories from routes on the writer so
 	// each table gets zero-reflection inserts.
@@ -155,6 +162,7 @@ func New(
 				BaseDelay:   config.ClickHouse.ChGo.GroupRetryBaseDelay,
 				MaxDelay:    config.ClickHouse.ChGo.GroupRetryMaxDelay,
 			},
+			mutator,
 		)
 		if sErr != nil {
 			return nil, fmt.Errorf(
@@ -194,6 +202,7 @@ func New(
 		config:       config,
 		metrics:      metrics,
 		router:       rtr,
+		mutator:      mutator,
 		writer:       writer,
 		streams:      streams,
 		activeTopics: activeTopics,
@@ -521,6 +530,7 @@ func (c *Consumoor) startTopicStream(
 			BaseDelay:   c.config.ClickHouse.ChGo.GroupRetryBaseDelay,
 			MaxDelay:    c.config.ClickHouse.ChGo.GroupRetryMaxDelay,
 		},
+		c.mutator,
 	)
 	if err != nil {
 		c.log.WithError(err).

--- a/pkg/consumoor/source/benthos.go
+++ b/pkg/consumoor/source/benthos.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethpandaops/xatu/pkg/clickhouse/router"
 	"github.com/ethpandaops/xatu/pkg/clickhouse/telemetry"
 	"github.com/ethpandaops/xatu/pkg/observability"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 )
 
 const benthosOutputType = "xatu_clickhouse"
@@ -42,6 +43,7 @@ func NewBenthosStream(
 	writer Writer,
 	ownsWriter bool,
 	groupRetry GroupRetryConfig,
+	mutator xatu.EventMutator,
 ) (*service.Stream, error) {
 	if kafkaConfig == nil {
 		return nil, fmt.Errorf("nil kafka config")
@@ -77,6 +79,7 @@ func NewBenthosStream(
 				log:                   log.WithField("component", "benthos_clickhouse_output"),
 				encoding:              kafkaConfig.Encoding,
 				router:                routeEngine,
+				mutator:               mutator,
 				writer:                writer,
 				metrics:               metrics,
 				rejectSink:            rejectSink,

--- a/pkg/consumoor/source/benthos_test.go
+++ b/pkg/consumoor/source/benthos_test.go
@@ -364,6 +364,76 @@ func TestWriteBatchBatchModeTransientWriteFailureFailsImpactedMessages(t *testin
 	assert.Equal(t, []int{1}, failedIndexesFromBatchError(t, msgs, err))
 }
 
+// networkNameCapturingWriter records the network name of every flushed event.
+// Names are copied at flush time because events are returned to the VT pool
+// once WriteBatch returns.
+type networkNameCapturingWriter struct {
+	testWriter
+
+	networkNames []string
+}
+
+func (w *networkNameCapturingWriter) FlushTableEvents(ctx context.Context, tableEvents map[string][]*xatu.DecoratedEvent) *clickhouse.FlushResult {
+	for _, events := range tableEvents {
+		for _, event := range events {
+			w.networkNames = append(w.networkNames, event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName())
+		}
+	}
+
+	return w.testWriter.FlushTableEvents(ctx, tableEvents)
+}
+
+func TestWriteBatchAppliesMutationsBeforeWrite(t *testing.T) {
+	writer := &networkNameCapturingWriter{}
+
+	mutator, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{
+		MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Suffix: "--copy-1"},
+	})
+	require.NoError(t, err)
+
+	output := &xatuClickHouseOutput{
+		log:      logrus.New(),
+		encoding: "json",
+		router: newRouter(t, []route.Route{
+			testRoute{
+				eventName: xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD,
+				table:     "beacon_head",
+			},
+		}),
+		mutator:    mutator,
+		writer:     writer,
+		metrics:    newTestMetrics(),
+		logSampler: telemetry.NewLogSampler(time.Minute),
+		rejectSink: &testRejectSink{},
+	}
+
+	event := &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Id:       "evt-1",
+			Name:     xatu.Event_BEACON_API_ETH_V1_EVENTS_HEAD,
+			DateTime: timestamppb.New(time.Unix(1_700_000_000, 0)),
+		},
+		Meta: &xatu.Meta{
+			Client: &xatu.ClientMeta{
+				Ethereum: &xatu.ClientMeta_Ethereum{
+					Network: &xatu.ClientMeta_Ethereum_Network{Name: "devnet-1", Id: 12345},
+				},
+			},
+		},
+	}
+
+	raw, err := protojson.Marshal(event)
+	require.NoError(t, err)
+
+	msgs := service.MessageBatch{
+		newKafkaMessage(raw, "topic-a", 0, 1),
+	}
+
+	require.NoError(t, output.WriteBatch(context.Background(), msgs))
+	assert.Equal(t, 1, writer.writes["beacon_head"])
+	assert.Equal(t, []string{"devnet-1--copy-1"}, writer.networkNames)
+}
+
 func TestWriteBatchRejectSinkFailureMakesMessageRetry(t *testing.T) {
 	output := &xatuClickHouseOutput{
 		log:        logrus.New(),

--- a/pkg/consumoor/source/output.go
+++ b/pkg/consumoor/source/output.go
@@ -49,6 +49,7 @@ type xatuClickHouseOutput struct {
 	log              observability.ContextualLogger
 	encoding         string
 	router           *router.Engine
+	mutator          xatu.EventMutator
 	writer           Writer
 	metrics          *telemetry.Metrics
 	rejectSink       rejectSink
@@ -208,6 +209,10 @@ func (o *xatuClickHouseOutput) WriteBatch(
 		}
 
 		pooledEvents = append(pooledEvents, event)
+
+		if o.mutator != nil {
+			o.mutator.Mutate(event)
+		}
 
 		outcome := o.router.Route(event)
 

--- a/pkg/proto/xatu/mutator.go
+++ b/pkg/proto/xatu/mutator.go
@@ -1,0 +1,111 @@
+package xatu
+
+import (
+	"fmt"
+)
+
+// EventMutator mutates decorated events in place before they are forwarded
+// or persisted. Implementations must be safe for concurrent use.
+type EventMutator interface {
+	// IsEnabled returns true when at least one mutation is configured.
+	IsEnabled() bool
+	// Mutate applies the configured mutations to the event in place.
+	Mutate(event *DecoratedEvent)
+}
+
+// EventMutatorConfig holds configuration for mutating decorated events.
+type EventMutatorConfig struct {
+	// MetaNetworkName rewrites the client-asserted network name
+	// (meta.client.ethereum.network.name).
+	MetaNetworkName MetaNetworkNameMutationConfig `yaml:"metaNetworkName"`
+}
+
+// MetaNetworkNameMutationConfig rewrites the client-asserted network name.
+// Useful for pipelines that need to re-namespace events, e.g. relays in
+// front of networks that share a genesis (and therefore derive identical
+// network names), or consumers that enforce a canonical name for everything
+// they persist. Value is mutually exclusive with Prefix/Suffix.
+type MetaNetworkNameMutationConfig struct {
+	// Value replaces the network name outright.
+	Value string `yaml:"value"`
+	// Prefix is prepended to the existing network name.
+	Prefix string `yaml:"prefix"`
+	// Suffix is appended to the existing network name.
+	Suffix string `yaml:"suffix"`
+}
+
+type eventMutator struct {
+	config *EventMutatorConfig
+}
+
+// NewEventMutator creates a new EventMutator from the given config.
+func NewEventMutator(config *EventMutatorConfig) (EventMutator, error) {
+	if config == nil {
+		config = &EventMutatorConfig{}
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid event mutator config: %w", err)
+	}
+
+	return &eventMutator{config: config}, nil
+}
+
+// Validate checks the configuration for errors.
+func (c *EventMutatorConfig) Validate() error {
+	return c.MetaNetworkName.Validate()
+}
+
+// Enabled returns true when at least one mutation is configured.
+func (c *EventMutatorConfig) Enabled() bool {
+	return c.MetaNetworkName.enabled()
+}
+
+// Validate checks the configuration for errors.
+func (c *MetaNetworkNameMutationConfig) Validate() error {
+	if c.Value != "" && (c.Prefix != "" || c.Suffix != "") {
+		return fmt.Errorf("metaNetworkName.value is mutually exclusive with prefix/suffix")
+	}
+
+	return nil
+}
+
+func (c *MetaNetworkNameMutationConfig) enabled() bool {
+	return c.Value != "" || c.Prefix != "" || c.Suffix != ""
+}
+
+func (m *eventMutator) IsEnabled() bool {
+	return m.config.Enabled()
+}
+
+func (m *eventMutator) Mutate(event *DecoratedEvent) {
+	if !m.IsEnabled() || event == nil {
+		return
+	}
+
+	m.mutateMetaNetworkName(event)
+}
+
+// mutateMetaNetworkName rewrites meta.client.ethereum.network.name. Events
+// that carry no network metadata are left untouched: fabricating the
+// structure would assert a network the client never claimed, and
+// prefixing/suffixing an empty name would produce a bare affix.
+func (m *eventMutator) mutateMetaNetworkName(event *DecoratedEvent) {
+	cfg := m.config.MetaNetworkName
+	if !cfg.enabled() {
+		return
+	}
+
+	network := event.GetMeta().GetClient().GetEthereum().GetNetwork()
+	if network == nil || network.GetName() == "" {
+		return
+	}
+
+	if cfg.Value != "" {
+		network.Name = cfg.Value
+
+		return
+	}
+
+	network.Name = cfg.Prefix + network.GetName() + cfg.Suffix
+}

--- a/pkg/proto/xatu/mutator_test.go
+++ b/pkg/proto/xatu/mutator_test.go
@@ -1,0 +1,196 @@
+package xatu_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+const (
+	testMutatedNetworkName = "my-network"
+	testNetworkNameSuffix  = "--abc123"
+)
+
+func newNetworkEvent(name string, id uint64) *xatu.DecoratedEvent {
+	return &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Name: xatu.Event_BEACON_API_ETH_V1_EVENTS_BLOCK,
+		},
+		Meta: &xatu.Meta{
+			Client: &xatu.ClientMeta{
+				Ethereum: &xatu.ClientMeta_Ethereum{
+					Network: &xatu.ClientMeta_Ethereum_Network{
+						Name: name,
+						Id:   id,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEventMutatorConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  xatu.EventMutatorConfig
+		wantErr bool
+	}{
+		{
+			name:   "empty config is valid",
+			config: xatu.EventMutatorConfig{},
+		},
+		{
+			name: "value only",
+			config: xatu.EventMutatorConfig{
+				MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Value: testMutatedNetworkName},
+			},
+		},
+		{
+			name: "prefix and suffix",
+			config: xatu.EventMutatorConfig{
+				MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Prefix: "pre-", Suffix: "-post"},
+			},
+		},
+		{
+			name: "value with suffix is invalid",
+			config: xatu.EventMutatorConfig{
+				MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Value: testMutatedNetworkName, Suffix: "-post"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "value with prefix is invalid",
+			config: xatu.EventMutatorConfig{
+				MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Value: testMutatedNetworkName, Prefix: "pre-"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEventMutator_IsEnabled(t *testing.T) {
+	disabled, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{})
+	require.NoError(t, err)
+	assert.False(t, disabled.IsEnabled())
+
+	enabled, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{
+		MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Suffix: "-a"},
+	})
+	require.NoError(t, err)
+	assert.True(t, enabled.IsEnabled())
+}
+
+func TestEventMutator_Mutate_MetaNetworkName(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   xatu.MetaNetworkNameMutationConfig
+		event    *xatu.DecoratedEvent
+		wantName string
+	}{
+		{
+			name:     "value replaces name",
+			config:   xatu.MetaNetworkNameMutationConfig{Value: testMutatedNetworkName},
+			event:    newNetworkEvent("devnet-1", 12345),
+			wantName: testMutatedNetworkName,
+		},
+		{
+			name:     "suffix appends to name",
+			config:   xatu.MetaNetworkNameMutationConfig{Suffix: testNetworkNameSuffix},
+			event:    newNetworkEvent("devnet-1", 12345),
+			wantName: "devnet-1--abc123",
+		},
+		{
+			name:     "prefix prepends to name",
+			config:   xatu.MetaNetworkNameMutationConfig{Prefix: "relay/"},
+			event:    newNetworkEvent("devnet-1", 12345),
+			wantName: "relay/devnet-1",
+		},
+		{
+			name:     "prefix and suffix combine",
+			config:   xatu.MetaNetworkNameMutationConfig{Prefix: "relay/", Suffix: testNetworkNameSuffix},
+			event:    newNetworkEvent("devnet-1", 12345),
+			wantName: "relay/devnet-1--abc123",
+		},
+		{
+			name:     "empty name is left untouched",
+			config:   xatu.MetaNetworkNameMutationConfig{Suffix: testNetworkNameSuffix},
+			event:    newNetworkEvent("", 12345),
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutator, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{MetaNetworkName: tt.config})
+			require.NoError(t, err)
+
+			mutator.Mutate(tt.event)
+
+			assert.Equal(t, tt.wantName, tt.event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName())
+			assert.Equal(t, uint64(12345), tt.event.GetMeta().GetClient().GetEthereum().GetNetwork().GetId())
+		})
+	}
+}
+
+func TestEventMutator_Mutate_MissingMetadata(t *testing.T) {
+	mutator, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{
+		MetaNetworkName: xatu.MetaNetworkNameMutationConfig{Value: testMutatedNetworkName},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		event *xatu.DecoratedEvent
+	}{
+		{name: "nil event", event: nil},
+		{name: "no meta", event: &xatu.DecoratedEvent{Event: &xatu.Event{}}},
+		{
+			name: "no ethereum meta",
+			event: &xatu.DecoratedEvent{
+				Event: &xatu.Event{},
+				Meta:  &xatu.Meta{Client: &xatu.ClientMeta{}},
+			},
+		},
+		{
+			name: "no network meta",
+			event: &xatu.DecoratedEvent{
+				Event: &xatu.Event{},
+				Meta: &xatu.Meta{
+					Client: &xatu.ClientMeta{Ethereum: &xatu.ClientMeta_Ethereum{}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Must not panic, and must not fabricate network metadata.
+			mutator.Mutate(tt.event)
+			assert.Nil(t, tt.event.GetMeta().GetClient().GetEthereum().GetNetwork())
+		})
+	}
+}
+
+func TestEventMutator_Mutate_Disabled(t *testing.T) {
+	mutator, err := xatu.NewEventMutator(&xatu.EventMutatorConfig{})
+	require.NoError(t, err)
+
+	event := newNetworkEvent("devnet-1", 12345)
+	mutator.Mutate(event)
+
+	assert.Equal(t, "devnet-1", event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName())
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -135,5 +135,26 @@ func (c *Config) ApplyOverrides(o *Override, log observability.ContextualLogger)
 		c.MetricsAddr = o.MetricsAddr.Value
 	}
 
+	networkNameOverride := o.EventIngesterMetaNetworkName
+	if networkNameOverride.Value != "" || networkNameOverride.Prefix != "" || networkNameOverride.Suffix != "" {
+		log.Info("Overriding event ingester meta network name mutation")
+
+		if networkNameOverride.Value != "" {
+			c.Services.EventIngester.Mutations.MetaNetworkName.Value = networkNameOverride.Value
+		}
+
+		if networkNameOverride.Prefix != "" {
+			c.Services.EventIngester.Mutations.MetaNetworkName.Prefix = networkNameOverride.Prefix
+		}
+
+		if networkNameOverride.Suffix != "" {
+			c.Services.EventIngester.Mutations.MetaNetworkName.Suffix = networkNameOverride.Suffix
+		}
+
+		if err := c.Services.EventIngester.Mutations.Validate(); err != nil {
+			return fmt.Errorf("invalid event ingester meta network name override: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/server/overrides.go
+++ b/pkg/server/overrides.go
@@ -16,4 +16,11 @@ type Override struct {
 		Enabled    bool
 		AuthSecret string
 	}
+	// EventIngesterMetaNetworkName rewrites the client-asserted network name
+	// on every ingested event.
+	EventIngesterMetaNetworkName struct {
+		Value  string
+		Prefix string
+		Suffix string
+	}
 }

--- a/pkg/server/service/event-ingester/config.go
+++ b/pkg/server/service/event-ingester/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethpandaops/xatu/pkg/output"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
 	"github.com/ethpandaops/xatu/pkg/server/service/event-ingester/auth"
 )
 
@@ -15,6 +16,10 @@ type Config struct {
 	Authorization auth.AuthorizationConfig `yaml:"authorization"`
 	// ClientNameSalt is the salt to use for computing client names
 	ClientNameSalt string `yaml:"clientNameSalt"`
+	// Mutations are applied to every ingested event before it is handed to
+	// the outputs. Useful when the server runs as a relay that needs to
+	// re-namespace events before forwarding them upstream.
+	Mutations xatu.EventMutatorConfig `yaml:"mutations"`
 }
 
 func (c *Config) Validate() error {
@@ -32,6 +37,10 @@ func (c *Config) Validate() error {
 
 	if c.ClientNameSalt == "" {
 		return fmt.Errorf("clientNameSalt is required")
+	}
+
+	if err := c.Mutations.Validate(); err != nil {
+		return fmt.Errorf("mutations config is invalid: %w", err)
 	}
 
 	return nil

--- a/pkg/server/service/event-ingester/handler.go
+++ b/pkg/server/service/event-ingester/handler.go
@@ -27,12 +27,13 @@ type Handler struct {
 	geoipProvider  geoip.Provider
 	cache          store.Cache
 	clientNameSalt string
+	mutator        xatu.EventMutator
 	metrics        *Metrics
 
 	eventRouter *eventHandler.EventRouter
 }
 
-func NewHandler(log observability.ContextualLogger, clockDrift *time.Duration, geoipProvider geoip.Provider, cache store.Cache, clientNameSalt string) *Handler {
+func NewHandler(log observability.ContextualLogger, clockDrift *time.Duration, geoipProvider geoip.Provider, cache store.Cache, clientNameSalt string, mutator xatu.EventMutator) *Handler {
 	return &Handler{
 		log:            log,
 		clockDrift:     clockDrift,
@@ -41,6 +42,7 @@ func NewHandler(log observability.ContextualLogger, clockDrift *time.Duration, g
 		metrics:        NewMetrics("xatu_server_event_ingester"),
 		eventRouter:    eventHandler.NewEventRouter(log, cache, geoipProvider),
 		clientNameSalt: clientNameSalt,
+		mutator:        mutator,
 	}
 }
 
@@ -209,6 +211,10 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 
 		if user != nil {
 			meta.Client.User = username
+		}
+
+		if h.mutator != nil {
+			h.mutator.Mutate(event)
 		}
 
 		event.Meta.Server = e.AppendServerMeta(ctx, &meta)

--- a/pkg/server/service/event-ingester/pipeline.go
+++ b/pkg/server/service/event-ingester/pipeline.go
@@ -41,11 +41,16 @@ func NewPipeline(
 		return nil, fmt.Errorf("failed to create authorization: %w", err)
 	}
 
+	mutator, err := xatu.NewEventMutator(&config.Mutations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create event mutator: %w", err)
+	}
+
 	p := &Pipeline{
 		log:     log.WithField("component", "pipeline"),
 		config:  config,
 		auth:    a,
-		handler: NewHandler(log, clockDrift, geoipProvider, cache, config.ClientNameSalt),
+		handler: NewHandler(log, clockDrift, geoipProvider, cache, config.ClientNameSalt, mutator),
 	}
 
 	sinks, err := p.createSinks()


### PR DESCRIPTION
Adds a `mutations` config that rewrites the client-asserted `meta_network_name` (replace, prefix, or suffix) at the two pipeline entry points: the server's event ingester (gRPC and HTTP) and consumoor's decode path before events are routed to ClickHouse. A small server instance can now run as a re-namespacing relay in front of an upstream server, which keeps copies of networks that share a genesis distinguishable instead of collapsing into the same rows in the canonical ClickHouse tables. A consumoor can use the same config to enforce a canonical network name on everything it persists. The ingester settings are also exposed as CLI flags and env vars, and events without network metadata are left untouched.

https://claude.ai/code/session_01TRDn7uePxZtbXYLVKpkJ5Z