### PR TITLE
server: release beacon block dedup mark when a sink write fails

### DIFF
--- a/pkg/server/service/event-ingester/event/beacon/eth/v2/beacon_block.go
+++ b/pkg/server/service/event-ingester/event/beacon/eth/v2/beacon_block.go
@@ -23,6 +23,10 @@ type BeaconBlock struct {
 	event *xatu.DecoratedEvent
 
 	cache store.Cache
+
+	// markedKey holds the cache key set during Filter so it can be released if the
+	// event fails to reach a durable sink.
+	markedKey string
 }
 
 func NewBeaconBlock(log observability.ContextualLogger, event *xatu.DecoratedEvent, cache store.Cache) *BeaconBlock {
@@ -121,7 +125,21 @@ func (b *BeaconBlock) Filter(ctx context.Context) bool {
 	}
 
 	// If the block is already in the cache, filter it out
-	return retrieved
+	if retrieved {
+		return true
+	}
+
+	// We just marked this block. Record the key so the pipeline can release it if the
+	// event fails to reach a durable sink.
+	b.markedKey = key
+
+	return false
+}
+
+// DedupKey returns the cache key marked during Filter, or an empty string if none was
+// marked.
+func (b *BeaconBlock) DedupKey() string {
+	return b.markedKey
 }
 
 func (b *BeaconBlock) AppendServerMeta(ctx context.Context, meta *xatu.ServerMeta) *xatu.ServerMeta {

--- a/pkg/server/service/event-ingester/event/beacon/eth/v2/beacon_block_v2.go
+++ b/pkg/server/service/event-ingester/event/beacon/eth/v2/beacon_block_v2.go
@@ -26,6 +26,10 @@ type BeaconBlockV2 struct {
 	// Typically non finalized blocks are ingested multiple times from the sentry.
 	// Finalized blocks are only ingested once from the cannon.
 	nonFinalizedCache store.Cache
+
+	// markedKey holds the cache key set during Filter so it can be released if the
+	// event fails to reach a durable sink.
+	markedKey string
 }
 
 func NewBeaconBlockV2(log observability.ContextualLogger, event *xatu.DecoratedEvent, cache store.Cache) *BeaconBlockV2 {
@@ -119,10 +123,22 @@ func (b *BeaconBlockV2) Filter(ctx context.Context) bool {
 		}
 
 		// If the block is already in the cache, filter it out
-		return retrieved
+		if retrieved {
+			return true
+		}
+
+		// We just marked this block. Record the key so the pipeline can release it if
+		// the event fails to reach a durable sink.
+		b.markedKey = key
 	}
 
 	return false
+}
+
+// DedupKey returns the cache key marked during Filter, or an empty string if none was
+// marked (for example a block that was finalized when requested).
+func (b *BeaconBlockV2) DedupKey() string {
+	return b.markedKey
 }
 
 func (b *BeaconBlockV2) AppendServerMeta(ctx context.Context, meta *xatu.ServerMeta) *xatu.ServerMeta {

--- a/pkg/server/service/event-ingester/event/event.go
+++ b/pkg/server/service/event-ingester/event/event.go
@@ -134,6 +134,16 @@ type Event interface {
 	AppendServerMeta(ctx context.Context, meta *xatu.ServerMeta) *xatu.ServerMeta
 }
 
+// DedupKeyer is implemented by events that mark themselves in the shared cache during
+// Filter to drop duplicates. It exposes the key that was marked so the pipeline can
+// release it when the event fails to reach a durable sink, otherwise a retry of the
+// same event would be dropped as a duplicate of a write that never landed.
+type DedupKeyer interface {
+	// DedupKey returns the cache key marked during Filter, or an empty string if the
+	// event did not mark one.
+	DedupKey() string
+}
+
 type EventRouter struct {
 	log           observability.ContextualLogger
 	cache         store.Cache

--- a/pkg/server/service/event-ingester/handler.go
+++ b/pkg/server/service/event-ingester/handler.go
@@ -45,7 +45,7 @@ func NewHandler(log observability.ContextualLogger, clockDrift *time.Duration, g
 }
 
 //nolint:gocyclo // Needs refactor
-func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, user *auth.User, group *auth.Group) ([]*xatu.DecoratedEvent, error) {
+func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, user *auth.User, group *auth.Group) ([]*xatu.DecoratedEvent, []string, error) {
 	groupName := "unknown"
 	if group != nil {
 		groupName = group.Name()
@@ -58,7 +58,7 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 
 	filteredEvents, err := h.filterEvents(ctx, events, user, group)
 	if err != nil {
-		return nil, fmt.Errorf("failed to filter events: %w", err)
+		return nil, nil, fmt.Errorf("failed to filter events: %w", err)
 	}
 
 	events = filteredEvents
@@ -67,7 +67,7 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 	if group != nil {
 		redactedEvents, err := group.ApplyRedacter(ctx, events)
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply group redacter: %w", err)
+			return nil, nil, fmt.Errorf("failed to apply group redacter: %w", err)
 		}
 
 		events = redactedEvents
@@ -82,12 +82,12 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 
 	p, ok := peer.FromContext(ctx)
 	if !ok {
-		return nil, errors.New("failed to get grpc peer")
+		return nil, nil, errors.New("failed to get grpc peer")
 	}
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, errors.New("failed to get metadata from context")
+		return nil, nil, errors.New("failed to get metadata from context")
 	}
 
 	var ipAddress string
@@ -155,6 +155,9 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 	}
 
 	handlerFilteredEvents := make([]*xatu.DecoratedEvent, 0)
+	// dedupKeys holds the cache keys marked by events that passed filtering, so the
+	// caller can release them if the events fail to reach a durable sink.
+	dedupKeys := make([]string, 0)
 	// Route the events to the correct handler
 	for _, event := range events {
 		if event == nil || event.Event == nil {
@@ -171,13 +174,13 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 		if err != nil {
 			h.log.WithError(err).WithField("event", eventName).WithContext(ctx).Warn("failed to create event handler")
 
-			return nil, fmt.Errorf("failed to create event for %s event handler: %w ", eventName, err)
+			return nil, nil, fmt.Errorf("failed to create event for %s event handler: %w ", eventName, err)
 		}
 
 		if err := e.Validate(ctx); err != nil {
 			h.log.WithError(err).WithField("event", eventName).WithContext(ctx).Warn("failed to validate event")
 
-			return nil, fmt.Errorf("%s event failed validation: %w", eventName, err)
+			return nil, nil, fmt.Errorf("%s event failed validation: %w", eventName, err)
 		}
 
 		if shouldFilter := e.Filter(ctx); shouldFilter {
@@ -213,6 +216,12 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 
 		event.Meta.Server = e.AppendServerMeta(ctx, &meta)
 
+		if dk, ok := e.(eventHandler.DedupKeyer); ok {
+			if key := dk.DedupKey(); key != "" {
+				dedupKeys = append(dedupKeys, key)
+			}
+		}
+
 		handlerFilteredEvents = append(handlerFilteredEvents, event)
 	}
 
@@ -222,13 +231,24 @@ func (h *Handler) Events(ctx context.Context, events []*xatu.DecoratedEvent, use
 	if group != nil {
 		redactedEvents, err := group.ApplyRedacter(ctx, filteredEvents)
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply group redacter: %w", err)
+			return nil, nil, fmt.Errorf("failed to apply group redacter: %w", err)
 		}
 
 		filteredEvents = redactedEvents
 	}
 
-	return filteredEvents, nil
+	return filteredEvents, dedupKeys, nil
+}
+
+// ReleaseDedupKeys removes the given deduplication keys from the cache. It is used when
+// events fail to reach a durable sink so a retry of the same events is not dropped as a
+// duplicate of a write that never landed.
+func (h *Handler) ReleaseDedupKeys(ctx context.Context, keys []string) {
+	for _, key := range keys {
+		if err := h.cache.Delete(ctx, key); err != nil {
+			h.log.WithError(err).WithField("key", key).WithContext(ctx).Warn("failed to release dedup key")
+		}
+	}
 }
 
 func (h *Handler) filterEvents(ctx context.Context, events []*xatu.DecoratedEvent, user *auth.User, group *auth.Group) ([]*xatu.DecoratedEvent, error) {

--- a/pkg/server/service/event-ingester/pipeline.go
+++ b/pkg/server/service/event-ingester/pipeline.go
@@ -108,7 +108,7 @@ func (p *Pipeline) ProcessAndSend(
 	group *auth.Group,
 	spanPrefix string,
 ) (uint64, error) {
-	filteredEvents, err := p.handler.Events(ctx, events, user, group)
+	filteredEvents, dedupKeys, err := p.handler.Events(ctx, events, user, group)
 	if err != nil {
 		return 0, fmt.Errorf("failed to process events: %w", err)
 	}
@@ -125,6 +125,11 @@ func (p *Pipeline) ProcessAndSend(
 		if err := sink.HandleNewDecoratedEvents(sinkCtx, filteredEvents); err != nil {
 			span.SetStatus(ocodes.Error, err.Error())
 			span.End()
+
+			// The events did not reach a durable sink. Release any dedup marks so a
+			// retry of this batch is not dropped as a duplicate of a write that never
+			// landed.
+			p.handler.ReleaseDedupKeys(ctx, dedupKeys)
 
 			return 0, fmt.Errorf("failed to send events to sink %s: %w", sink.Name(), err)
 		}

--- a/pkg/server/service/event-ingester/pipeline_test.go
+++ b/pkg/server/service/event-ingester/pipeline_test.go
@@ -1,0 +1,204 @@
+package eventingester
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/ethpandaops/go-eth2-client/spec"
+
+	"github.com/ethpandaops/xatu/pkg/output"
+	ethv2 "github.com/ethpandaops/xatu/pkg/proto/eth/v2"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+// testCache is an in-memory store.Cache used by the pipeline tests. It mirrors the
+// GetOrSet and Delete semantics the dedup logic relies on, without touching the global
+// prometheus registry.
+type testCache struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func newTestCache() *testCache { return &testCache{m: make(map[string]string)} }
+
+func (c *testCache) Start(context.Context) error { return nil }
+func (c *testCache) Stop(context.Context) error  { return nil }
+func (c *testCache) Type() string                { return "test" }
+
+func (c *testCache) Get(_ context.Context, key string) (*string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if v, ok := c.m[key]; ok {
+		return &v, nil
+	}
+
+	return nil, nil
+}
+
+func (c *testCache) GetOrSet(_ context.Context, key, value string, _ time.Duration) (*string, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if v, ok := c.m[key]; ok {
+		existing := v
+
+		return &existing, true, nil
+	}
+
+	c.m[key] = value
+	stored := value
+
+	return &stored, false, nil
+}
+
+func (c *testCache) GetAndDelete(_ context.Context, key string) (*string, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if v, ok := c.m[key]; ok {
+		delete(c.m, key)
+
+		return &v, true, nil
+	}
+
+	return nil, false, nil
+}
+
+func (c *testCache) Set(_ context.Context, key, value string, _ time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = value
+
+	return nil
+}
+
+func (c *testCache) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, key)
+
+	return nil
+}
+
+// mockSink is a minimal output.Sink used to observe writes and inject failures.
+type mockSink struct {
+	name     string
+	fail     bool
+	received int
+}
+
+func (m *mockSink) Start(context.Context) error { return nil }
+func (m *mockSink) Stop(context.Context) error  { return nil }
+func (m *mockSink) Type() string                { return "mock" }
+func (m *mockSink) Name() string                { return m.name }
+
+func (m *mockSink) HandleNewDecoratedEvent(context.Context, *xatu.DecoratedEvent) error {
+	return nil
+}
+
+func (m *mockSink) HandleNewDecoratedEvents(_ context.Context, events []*xatu.DecoratedEvent) error {
+	if m.fail {
+		return errors.New("sink failure")
+	}
+
+	m.received += len(events)
+
+	return nil
+}
+
+func ingesterTestContext() context.Context {
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1},
+	})
+
+	return metadata.NewIncomingContext(ctx, metadata.New(map[string]string{}))
+}
+
+func newBeaconBlockEvent(stateRoot string) *xatu.DecoratedEvent {
+	return &xatu.DecoratedEvent{
+		Event: &xatu.Event{Name: xatu.Event_BEACON_API_ETH_V2_BEACON_BLOCK},
+		Data: &xatu.DecoratedEvent_EthV2BeaconBlock{
+			EthV2BeaconBlock: &ethv2.EventBlock{
+				Message: &ethv2.EventBlock_BellatrixBlock{
+					BellatrixBlock: &ethv2.BeaconBlockBellatrix{StateRoot: stateRoot},
+				},
+			},
+		},
+		Meta: &xatu.Meta{
+			Client: &xatu.ClientMeta{
+				AdditionalData: &xatu.ClientMeta_EthV2BeaconBlock{
+					EthV2BeaconBlock: &xatu.ClientMeta_AdditionalEthV2BeaconBlockData{
+						Version: spec.DataVersionBellatrix.String(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestPipeline(t *testing.T, sinks ...output.Sink) *Pipeline {
+	t.Helper()
+
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	return &Pipeline{
+		log:     log,
+		handler: NewHandler(log, nil, nil, newTestCache(), ""),
+		sinks:   sinks,
+	}
+}
+
+const testStateRoot = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+// TestProcessAndSendReleasesDedupOnSinkFailure verifies that when a sink write fails,
+// the beacon-block dedup mark is released so the client's retry is not silently dropped
+// as a duplicate of a write that never landed.
+func TestProcessAndSendReleasesDedupOnSinkFailure(t *testing.T) {
+	ctx := ingesterTestContext()
+
+	failing := &mockSink{name: "sink", fail: true}
+	p := newTestPipeline(t, failing)
+
+	// First attempt: the sink fails. This marks the block during filtering and must
+	// release that mark on failure.
+	_, err := p.ProcessAndSend(ctx, []*xatu.DecoratedEvent{newBeaconBlockEvent(testStateRoot)}, nil, nil, "test")
+	require.Error(t, err)
+
+	// Retry with a healthy sink: the block must NOT be filtered out.
+	recording := &mockSink{name: "sink"}
+	p.sinks = []output.Sink{recording}
+
+	count, err := p.ProcessAndSend(ctx, []*xatu.DecoratedEvent{newBeaconBlockEvent(testStateRoot)}, nil, nil, "test")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), count, "retry after a sink failure must not be dropped as a duplicate")
+	require.Equal(t, 1, recording.received, "the block must reach the sink on retry")
+}
+
+// TestProcessAndSendDedupesAfterSuccessfulWrite confirms the dedup behaviour is retained:
+// once a block reaches the sink, a subsequent submission of the same block is dropped.
+func TestProcessAndSendDedupesAfterSuccessfulWrite(t *testing.T) {
+	ctx := ingesterTestContext()
+
+	recording := &mockSink{name: "sink"}
+	p := newTestPipeline(t, recording)
+
+	first, err := p.ProcessAndSend(ctx, []*xatu.DecoratedEvent{newBeaconBlockEvent(testStateRoot)}, nil, nil, "test")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), first)
+
+	second, err := p.ProcessAndSend(ctx, []*xatu.DecoratedEvent{newBeaconBlockEvent(testStateRoot)}, nil, nil, "test")
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), second, "a duplicate block after a successful write must be dropped")
+	require.Equal(t, 1, recording.received, "the sink must receive the block exactly once")
+}


### PR DESCRIPTION
Beacon block events are deduplicated by marking their state root in a shared cache during filtering. The mark was set before the events reached a sink, and it was never released if the sink write failed.

When a sink was unavailable the client retried the batch, but the retry found the mark already set and dropped the block as a duplicate. The block was therefore lost for the cache TTL despite never being durably written. Because the key is shared across sentries, every sentry reporting the same block during the outage window was dropped the same way.

This records the key marked during filtering, returns it from the handler, and releases it if any sink write fails, so a retry is processed normally. Duplicate handling on the success path is unchanged, and the only added cost is a re-processed batch on the failure path whose duplicates are absorbed by the ReplacingMergeTree tables downstream.

Scope is limited to the two event types that deduplicate against the cache via a new optional interface, so the other event handlers are untouched.

Tests: adds pipeline coverage for releasing the mark on sink failure so a retry is not dropped, plus a control confirming duplicates are still dropped after a successful write.