### PR TITLE
ci: publish a bare rolling tag per release branch

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -23,11 +23,13 @@ jobs:
           # Strip the 'refs/tags/' prefix
           TAG_NAME=${GITHUB_REF#refs/tags/}
 
-          # Extract suffix from tag name after the last '-' (e.g., 'dencun' from 'v1.0.0-dencun')
-          RELEASE_SUFFIX=${TAG_NAME##*-}
-
-          # Check if the suffix is still a version pattern (e.g., 'v0.0.44'), in which case there's no suffix
-          if [[ $RELEASE_SUFFIX =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # A release-branch tag is a semver core followed by everything after the
+          # FIRST '-' (e.g. 'glamsterdam-devnet-7' from '0.0.1-glamsterdam-devnet-7',
+          # 'dencun' from 'v1.0.0-dencun'). Anchoring on the semver core keeps
+          # multi-word suffixes intact and leaves plain 'vX.Y.Z' tags unsuffixed.
+          if [[ $TAG_NAME =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-(.+)$ ]]; then
+            RELEASE_SUFFIX="${BASH_REMATCH[1]}"
+          else
             RELEASE_SUFFIX=""
           fi
 
@@ -128,6 +130,6 @@ jobs:
             GIT_COMMIT=${{ env.CRYO_GIT_COMMIT }}
           tags: |
             ethpandaops/xatu:${{ env.CRYO_IMAGE_VERSION }}-cryo
-            ethpandaops/xatu:${{ env.RELEASE_SUFFIX && format('{0}-cryo-latest', env.RELEASE_SUFFIX) || 'cryo-latest' }}
+            ethpandaops/xatu:${{ env.RELEASE_SUFFIX && format('{0}-cryo', env.RELEASE_SUFFIX) || 'cryo-latest' }}
           cache-from: type=registry,ref=ethpandaops/xatu:cryo-buildcache
           cache-to: type=registry,ref=ethpandaops/xatu:cryo-buildcache,mode=max,ignore-error=true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,7 +78,7 @@ dockers:
     dockerfile: goreleaser-scratch.Dockerfile
     image_templates:
       - "ethpandaops/{{ .ProjectName }}:{{ .Version }}-amd64"
-      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-amd64"
+      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}{{ else }}latest{{ end }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--provenance=false"
@@ -93,7 +93,7 @@ dockers:
     dockerfile: goreleaser-scratch.Dockerfile
     image_templates:
       - "ethpandaops/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-arm64v8"
+      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}{{ else }}latest{{ end }}-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--provenance=false"
@@ -109,7 +109,7 @@ dockers:
     dockerfile: goreleaser-debian.Dockerfile
     image_templates:
       - "ethpandaops/{{ .ProjectName }}:{{ .Version }}-debian-amd64"
-      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}debian-latest-amd64"
+      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-debian{{ else }}debian-latest{{ end }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--provenance=false"
@@ -124,7 +124,7 @@ dockers:
     dockerfile: goreleaser-debian.Dockerfile
     image_templates:
       - "ethpandaops/{{ .ProjectName }}:{{ .Version }}-debian-arm64v8"
-      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}debian-latest-arm64v8"
+      - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-debian{{ else }}debian-latest{{ end }}-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--provenance=false"
@@ -142,10 +142,10 @@ docker_manifests:
   - name_template: ethpandaops/{{ .ProjectName }}:{{ .Version }}-arm64
     image_templates:
       - ethpandaops/{{ .ProjectName }}:{{ .Version }}-arm64v8
-  - name_template: ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest
+  - name_template: ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}{{ else }}latest{{ end }}
     image_templates:
-      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-amd64
-      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-arm64v8
+      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}{{ else }}latest{{ end }}-amd64
+      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}{{ else }}latest{{ end }}-arm64v8
 
   ## Debian
   - name_template: ethpandaops/{{ .ProjectName }}:{{ .Version }}-debian
@@ -155,7 +155,7 @@ docker_manifests:
   - name_template: ethpandaops/{{ .ProjectName }}:{{ .Version }}-debian-arm64
     image_templates:
       - ethpandaops/{{ .ProjectName }}:{{ .Version }}-debian-arm64v8
-  - name_template: ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}debian-latest
+  - name_template: ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-debian{{ else }}debian-latest{{ end }}
     image_templates:
-      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}debian-latest-amd64
-      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}debian-latest-arm64v8
+      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-debian{{ else }}debian-latest{{ end }}-amd64
+      - ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-debian{{ else }}debian-latest{{ end }}-arm64v8


### PR DESCRIPTION
Release branches publish an immutable `X.Y.Z-<suffix>` tag plus a rolling tag. Two bugs in how the rolling tag was derived:

- The suffix was taken from the tag after the **last** dash, so a multi-word suffix collapsed to its final segment. `0.0.1-glamsterdam-devnet-7` yielded `7`, and the rolling tags became `7-latest` / `7-debian-latest` — which would collide across fork families (`fusaka-devnet-7`, `bal-devnet-7`).
- The guard that recognises an unsuffixed tag required a leading `v`, so an unprefixed `0.0.44` produced the literal suffix `0.0.44`.

Both are fixed by anchoring on the semver core and taking everything after the first dash only when the tag is `[v]X.Y.Z-<suffix>`.

The rolling tag is now the bare suffix rather than `<suffix>-latest`, so a release branch publishes `ethpandaops/xatu:glamsterdam-devnet-7` and `:glamsterdam-devnet-7-debian`. That matches the tag every client image already uses (`ethpandaops/lighthouse:glamsterdam-devnet-6`), which lets a devnet's nodes track xatu by devnet name and lets watchtower/keel roll them. Unsuffixed tags keep publishing `latest`, `debian-latest` and `cryo-latest` unchanged.

Nothing consumes the old `<suffix>-latest` tags today (checked across the org).

This unblocks a per-devnet xatu release branch (`release/glamsterdam-devnet-N`), so breaking schema changes between devnets can land without disturbing the devnet already running.

https://claude.ai/code/session_01J2RzFzqWHvyHbEmVWJscZf