### PR TITLE
processor: report dropped item when the queue is closed during shutdown

### DIFF
--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -631,25 +631,26 @@ func (bvp *BatchItemProcessor[T]) drainQueue() {
 	close(bvp.queue)
 }
 
-func recoverSendOnClosedChan() {
-	x := recover()
-
-	switch err := x.(type) {
-	case nil:
-		return
-	case runtime.Error:
-		if err.Error() == "send on closed channel" {
+func (bvp *BatchItemProcessor[T]) enqueueOrDrop(ctx context.Context, item *TraceableItem[T]) (err error) {
+	// The queue send below panics if the queue was closed during shutdown. Recover it
+	// and report the item as dropped, otherwise the caller would treat a lost item as
+	// successfully enqueued.
+	defer func() {
+		r := recover()
+		if r == nil {
 			return
 		}
-	}
 
-	panic(x)
-}
+		if re, ok := r.(runtime.Error); ok && re.Error() == "send on closed channel" {
+			bvp.metrics.IncItemsDroppedBy(bvp.name, float64(1))
 
-func (bvp *BatchItemProcessor[T]) enqueueOrDrop(ctx context.Context, item *TraceableItem[T]) error {
-	// This ensures the bvp.queue<- below does not panic as the
-	// processor shuts down.
-	defer recoverSendOnClosedChan()
+			err = errors.New("processor is shutting down")
+
+			return
+		}
+
+		panic(r)
+	}()
 
 	select {
 	case <-bvp.stopCh:

--- a/pkg/processor/enqueue_test.go
+++ b/pkg/processor/enqueue_test.go
@@ -1,0 +1,59 @@
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// TestEnqueueOrDropReportsDropOnClosedQueue verifies that enqueueOrDrop reports an error
+// and records a drop when the queue send panics on a closed channel during shutdown.
+// Previously the panic was recovered into an unnamed return value, so the function
+// returned nil and the caller treated a lost item as successfully enqueued.
+func TestEnqueueOrDropReportsDropOnClosedQueue(t *testing.T) {
+	metrics := NewMetrics("enqueue_closed_queue_test")
+
+	be := testBatchExporter[TestItem]{}
+	bvp, err := NewBatchItemProcessor[TestItem](&be, "processor", nullLogger(), WithMetrics(metrics))
+	if err != nil {
+		t.Fatalf("constructor: %v", err)
+	}
+
+	droppedBefore := droppedCount(t, metrics, "processor")
+
+	// Reproduce the shutdown state: the stopCh check has already passed and the queue is
+	// now closed, so the send inside enqueueOrDrop panics.
+	close(bvp.queue)
+
+	item := &TraceableItem[TestItem]{item: &TestItem{name: "x"}}
+
+	if err := bvp.enqueueOrDrop(context.Background(), item); err == nil {
+		t.Fatal("enqueueOrDrop returned nil after the queue was closed; a dropped item must be reported as an error")
+	}
+
+	if got, want := droppedCount(t, metrics, "processor"), droppedBefore+1; got != want {
+		t.Fatalf("items dropped counter = %v, want %v", got, want)
+	}
+}
+
+func droppedCount(t *testing.T, m *Metrics, processor string) float64 {
+	t.Helper()
+
+	c, err := m.itemsDropped.GetMetricWith(prometheus.Labels{"processor": processor})
+	if err != nil {
+		t.Fatalf("metric: %v", err)
+	}
+
+	metric := &dto.Metric{}
+	if err := c.Write(metric); err != nil {
+		t.Fatalf("metric write: %v", err)
+	}
+
+	if metric.Counter == nil || metric.Counter.Value == nil {
+		return 0
+	}
+
+	return *metric.Counter.Value
+}


### PR DESCRIPTION
enqueueOrDrop recovered the "send on closed channel" panic into an unnamed return value. When the queue was closed during shutdown, the send panicked, the panic was swallowed, and the function returned nil. The caller treated the lost item as successfully enqueued, with no drop recorded, so the item was silently lost.

This uses a named return so the recovery reports the item as dropped and increments the dropped counter, matching the queue-full path. The caller now sees the failure instead of silently losing the item. Panics that are not a closed-channel send are still re-raised.

Tests: adds coverage asserting that enqueueOrDrop returns an error and records a drop when the queue is closed.