### PR TITLE
processor: export the final partial batch on shutdown

### DIFF
--- a/pkg/processor/batch.go
+++ b/pkg/processor/batch.go
@@ -209,6 +209,7 @@ type BatchItemProcessor[T any] struct {
 
 	timer         *time.Timer
 	stopWait      sync.WaitGroup
+	builderWait   sync.WaitGroup
 	stopOnce      sync.Once
 	stopCh        chan struct{}
 	stopWorkersCh chan struct{}
@@ -315,7 +316,11 @@ func (bvp *BatchItemProcessor[T]) Start(ctx context.Context) {
 		}(i)
 	}
 
+	bvp.builderWait.Add(1)
+
 	go func() {
+		defer bvp.builderWait.Done()
+
 		bvp.batchBuilder(ctx)
 		bvp.log.WithContext(ctx).Info("Batch builder exited")
 	}()
@@ -452,12 +457,26 @@ func (bvp *BatchItemProcessor[T]) Shutdown(ctx context.Context) error {
 		go func() {
 			bvp.log.WithContext(ctx).Info("Stopping processor")
 
+			// Stop accepting new items and stop the flush timer.
 			close(bvp.stopCh)
 
 			bvp.timer.Stop()
 
+			// Close the queue so the batch builder drains it and flushes its final
+			// partial batch to the workers.
 			bvp.drainQueue()
 
+			// Wait for the batch builder to finish flushing before draining the worker
+			// channel, otherwise its final partial batch would be lost.
+			bvp.builderWait.Wait()
+
+			// Wait for the workers to pick up every batch that was handed off.
+			for len(bvp.batchCh) > 0 {
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			// All batches have been handed to workers; stopping them now still lets any
+			// in-flight export finish before stopWait returns.
 			close(bvp.stopWorkersCh)
 
 			bvp.stopWait.Wait()
@@ -614,19 +633,11 @@ func (bvp *BatchItemProcessor[T]) worker(ctx context.Context, number int) {
 func (bvp *BatchItemProcessor[T]) drainQueue() {
 	bvp.log.Info("Draining queue: waiting for the batch builder to process remaining items")
 
-	// First wait for queue to be processed
+	// Wait for the queued items to be consumed by the batch builder, then close the
+	// queue so the builder flushes its final partial batch and exits.
 	for len(bvp.queue) > 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
-
-	bvp.log.Info("Draining queue: waiting for workers to finish processing batches")
-
-	// Then wait for any in-flight batches
-	for len(bvp.batchCh) > 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	bvp.log.Info("Draining queue: all items processed")
 
 	close(bvp.queue)
 }

--- a/pkg/processor/shutdown_flush_test.go
+++ b/pkg/processor/shutdown_flush_test.go
@@ -1,0 +1,68 @@
+package processor
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestShutdownFlushesFinalPartialBatch verifies that a graceful shutdown exports the
+// final partial batch held in the batch builder rather than dropping it. The batch size
+// and timeout are set so the items never flush on their own, so they sit in the builder
+// until shutdown.
+func TestShutdownFlushesFinalPartialBatch(t *testing.T) {
+	const (
+		trials      = 200
+		itemsPerRun = 3 // below MaxExportBatchSize, so never flushed by size
+	)
+
+	for _, workers := range []int{1, 4} {
+		workers := workers
+
+		t.Run("workers="+strconv.Itoa(workers), func(t *testing.T) {
+			lostItems := 0
+
+			for i := 0; i < trials; i++ {
+				be := testBatchExporter[TestItem]{}
+
+				bsp, err := NewBatchItemProcessor[TestItem](
+					&be, "processor", nullLogger(),
+					WithMaxExportBatchSize(1000),
+					WithBatchTimeout(1*time.Hour),
+					WithWorkers(workers),
+					WithShippingMethod(ShippingMethodAsync),
+				)
+				if err != nil {
+					t.Fatalf("constructor: %v", err)
+				}
+
+				bsp.Start(context.Background())
+
+				items := make([]*TestItem, itemsPerRun)
+				for j := range items {
+					items[j] = &TestItem{name: "x"}
+				}
+
+				if err := bsp.Write(context.Background(), items); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+
+				// Let the builder pull the items into its in-memory partial batch.
+				time.Sleep(2 * time.Millisecond)
+
+				if err := bsp.Shutdown(context.Background()); err != nil {
+					t.Fatalf("shutdown: %v", err)
+				}
+
+				if got := be.len(); got < itemsPerRun {
+					lostItems += itemsPerRun - got
+				}
+			}
+
+			if lostItems > 0 {
+				t.Fatalf("shutdown dropped %d items across %d trials; the final partial batch must be exported", lostItems, trials)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The batch builder holds accumulated items in an in-memory batch until they reach the export size or the flush timer fires. On shutdown the builder ran in a goroutine that was never waited on, and drainQueue only waited on the queue and the worker channel, not on that in-memory batch.

As a result close(stopWorkersCh) raced the builder: the builder could exit without flushing, or its final batch could sit in the worker channel while the workers stopped. Any batch smaller than the export size, which is the common case on a graceful restart, was silently dropped with no failure recorded.

This tracks the batch builder with its own wait group and reorders shutdown: close the queue, wait for the builder to flush its final batch, wait for the workers to pick up every handed-off batch, and only then stop the workers. In-flight exports still complete before Shutdown returns.

Tests: adds a shutdown test over one and four workers asserting the final partial batch is always exported. Ran the full processor suite repeatedly under the race detector.