### PR TITLE
fix(docker): pin cryo builder to rust 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,12 @@ RUN go build \
 # every build path (docker build, docker compose, `make docker`, and the
 # release cryo image) builds this Dockerfile, so bump it here to upgrade cryo
 # everywhere. Override with --build-arg CRYO_GIT_REF=<ref> for ad-hoc testing.
-FROM rust:1-bookworm AS cryo-builder
+# Rust is pinned because the cryo ref is: cryo's lockfile carries ethnum
+# 1.5.0, whose IntErrorKind transmute fails to compile (E0512) from rustc
+# 1.97.0. The floating rust:1 tag only bit when a new stable invalidated the
+# cryo-buildcache layer. Unpin (or bump) together with CRYO_GIT_REF once
+# cryo's lockfile moves to an ethnum that builds on current stable.
+FROM rust:1.96-bookworm AS cryo-builder
 ARG CRYO_GIT_REF=559b65455d7ef6b03e8e9e96a0e50fd4fe8a9c86
 RUN cargo install --git https://github.com/paradigmxyz/cryo --rev "${CRYO_GIT_REF}" --locked cryo_cli
 


### PR DESCRIPTION
Pins the cryo-builder stage to `rust:1.96-bookworm`. The floating `rust:1-bookworm` tag moved to 1.97.0 between the 2026-07-09 and 2026-07-12 release runs, invalidating the cryo-buildcache layer and recompiling cryo under a rustc that rejects the `IntErrorKind` transmute in ethnum 1.5.0 (`error[E0512]`), which cryo's `--locked` lockfile pins. The pin should move together with the next `CRYO_GIT_REF` bump once cryo's lockfile carries an ethnum that builds on current stable.

Same commit is on `release/glamsterdam-devnet-7` (dfbabda0). `release/glamsterdam-devnet-6` still has the floating tag — its next release tag will hit the same failure unless dfbabda0 is cherry-picked there (deliberately not pushed, since any push to that branch republishes the rolling image live devnet-6 sentries track).

https://claude.ai/code/session_019cbhUv62kwFTKQD5aM8FGC