### PR TITLE
feat: emit EL node records from mimicry sessions, add dial failure metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,12 @@ RUN go build \
 # every build path (docker build, docker compose, `make docker`, and the
 # release cryo image) builds this Dockerfile, so bump it here to upgrade cryo
 # everywhere. Override with --build-arg CRYO_GIT_REF=<ref> for ad-hoc testing.
-FROM rust:1-bookworm AS cryo-builder
+# Rust is pinned because the cryo ref is: cryo's lockfile carries ethnum
+# 1.5.0, whose IntErrorKind transmute fails to compile (E0512) from rustc
+# 1.97.0. The floating rust:1 tag only bit when a new stable invalidated the
+# cryo-buildcache layer. Unpin (or bump) together with CRYO_GIT_REF once
+# cryo's lockfile moves to an ethnum that builds on current stable.
+FROM rust:1.96-bookworm AS cryo-builder
 ARG CRYO_GIT_REF=559b65455d7ef6b03e8e9e96a0e50fd4fe8a9c86
 RUN cargo install --git https://github.com/paradigmxyz/cryo --rev "${CRYO_GIT_REF}" --locked cryo_cli
 

--- a/example_discovery.yaml
+++ b/example_discovery.yaml
@@ -50,8 +50,10 @@ p2p:
     restart: 2m
     # execution layer discovery settings (optional, defaults shown)
     # execution:
-    #   retryAttempts: 5    # max retry attempts for dialing a peer
-    #   retryDelay: 5s      # delay between retry attempts
+    #   retryAttempts: 1    # max retry attempts for dialing a peer; EL clients
+    #                       # throttle same-IP reconnects (30s-5m), so retries
+    #                       # spaced closer than that are rejected pre-handshake
+    #   retryDelay: 60s     # delay between retry attempts, when enabled
     #   dialTimeout: 15s    # timeout for dialing a peer
     #   bootstrapRpcUrl: "" # optional EL JSON-RPC. When set, discovery serves
     #                       # Status/headers/bodies/receipts from this endpoint
@@ -124,8 +126,8 @@ p2p:
   #   forkIdHashes: [0xf0afd0e3] # execution layer
   #   forkDigests: [0x09fb0a12] # consensus layer
   #   execution:  # optional
-  #     retryAttempts: 5
-  #     retryDelay: 5s
+  #     retryAttempts: 1
+  #     retryDelay: 60s
   #     dialTimeout: 15s
   #     bootstrapRpcUrl: "" # optional EL JSON-RPC for Status/headers/bodies/receipts
   #   consensus:  # optional

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ethpandaops/xatu
 
 go 1.26.2
 
+toolchain go1.26.5
+
 // release-xatu branch.
 
 // Match tysm's tablewriter version requirement
@@ -274,7 +276,7 @@ require (
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15 // indirect
 	github.com/prysmaticlabs/gohashtree v0.0.5-beta // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc // indirect
 	github.com/r3labs/sse/v2 v2.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -722,8 +722,8 @@ github.com/prysmaticlabs/protoc-gen-go-cast v0.0.0-20230228205207-28762a7b9294 h
 github.com/prysmaticlabs/protoc-gen-go-cast v0.0.0-20230228205207-28762a7b9294/go.mod h1:ZVEbRdnMkGhp/pu35zq4SXxtvUwWK0J1MATtekZpH2Y=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/quic-go/webtransport-go v0.10.0 h1:LqXXPOXuETY5Xe8ITdGisBzTYmUOy5eSj+9n4hLTjHI=
 github.com/quic-go/webtransport-go v0.10.0/go.mod h1:LeGIXr5BQKE3UsynwVBeQrU1TPrbh73MGoC6jd+V7ow=
 github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc h1:hK577yxEJ2f5s8w2iy2KimZmgrdAUZUNftE1ESmg2/Q=

--- a/pkg/discovery/p2p/config.go
+++ b/pkg/discovery/p2p/config.go
@@ -48,8 +48,8 @@ func (c *Config) GetNetworkIDs() []uint64 {
 // Returns a config with default values if not configured or on error.
 func (c *Config) GetExecutionConfig() *static.ExecutionConfig {
 	defaultConfig := &static.ExecutionConfig{
-		RetryAttempts: 5,
-		RetryDelay:    5 * time.Second,
+		RetryAttempts: 1,
+		RetryDelay:    60 * time.Second,
 		DialTimeout:   15 * time.Second,
 	}
 
@@ -86,11 +86,11 @@ func (c *Config) GetExecutionConfig() *static.ExecutionConfig {
 // applyExecutionDefaults applies default values for zero-valued fields.
 func (c *Config) applyExecutionDefaults(exec *static.ExecutionConfig) *static.ExecutionConfig {
 	if exec.RetryAttempts == 0 {
-		exec.RetryAttempts = 5
+		exec.RetryAttempts = 1
 	}
 
 	if exec.RetryDelay == 0 {
-		exec.RetryDelay = 5 * time.Second
+		exec.RetryDelay = 60 * time.Second
 	}
 
 	if exec.DialTimeout == 0 {

--- a/pkg/discovery/p2p/config_test.go
+++ b/pkg/discovery/p2p/config_test.go
@@ -1,0 +1,34 @@
+package p2p
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/xatu/pkg/discovery/p2p/static"
+)
+
+func TestGetExecutionConfigDefaults(t *testing.T) {
+	cfg := &Config{}
+
+	exec := cfg.GetExecutionConfig()
+
+	require.Equal(t, uint(1), exec.RetryAttempts)
+	require.Equal(t, 60*time.Second, exec.RetryDelay)
+	require.Equal(t, 15*time.Second, exec.DialTimeout)
+}
+
+func TestApplyExecutionDefaultsPreservesExplicitValues(t *testing.T) {
+	cfg := &Config{}
+
+	exec := cfg.applyExecutionDefaults(&static.ExecutionConfig{
+		RetryAttempts: 3,
+		RetryDelay:    5 * time.Second,
+		DialTimeout:   10 * time.Second,
+	})
+
+	require.Equal(t, uint(3), exec.RetryAttempts)
+	require.Equal(t, 5*time.Second, exec.RetryDelay)
+	require.Equal(t, 10*time.Second, exec.DialTimeout)
+}

--- a/pkg/discovery/p2p/execution_peer.go
+++ b/pkg/discovery/p2p/execution_peer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/ethpandaops/ethcore/pkg/execution/mimicry"
 
@@ -20,6 +21,8 @@ type ExecutionPeer struct {
 	client *mimicry.Client
 
 	hello *mimicry.Hello
+
+	disconnectReason atomic.Pointer[string]
 
 	handlerFunc func(ctx context.Context, status *xatu.ExecutionNodeStatus)
 }
@@ -106,6 +109,8 @@ func (p *ExecutionPeer) Start(ctx context.Context) (<-chan error, error) {
 			str = reason.Reason.String()
 		}
 
+		p.disconnectReason.Store(&str)
+
 		response <- errors.New("disconnected from peer (reason " + str + ")")
 
 		return nil
@@ -117,6 +122,16 @@ func (p *ExecutionPeer) Start(ctx context.Context) (<-chan error, error) {
 	}
 
 	return response, nil
+}
+
+// DisconnectReason returns the devp2p disconnect reason sent by the remote
+// peer, or an empty string if the session ended without one.
+func (p *ExecutionPeer) DisconnectReason() string {
+	if reason := p.disconnectReason.Load(); reason != nil {
+		return *reason
+	}
+
+	return ""
 }
 
 func (p *ExecutionPeer) Stop(ctx context.Context) error {

--- a/pkg/discovery/p2p/metrics.go
+++ b/pkg/discovery/p2p/metrics.go
@@ -4,6 +4,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 type Metrics struct {
 	dialedNodeRecordsTotal   *prometheus.CounterVec
+	dialFailuresTotal        *prometheus.CounterVec
 	activeDialingNodeRecords *prometheus.GaugeVec
 }
 
@@ -14,6 +15,11 @@ func NewMetrics(namespace string) *Metrics {
 			Name:      "dialed_node_records_total",
 			Help:      "Total number of dialed node records",
 		}, []string{"result", "layer"}),
+		dialFailuresTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "dial_failures_total",
+			Help:      "Total number of failed node record dials by reason",
+		}, []string{"layer", "reason"}),
 		activeDialingNodeRecords: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "active_dialing_node_records",
@@ -22,6 +28,7 @@ func NewMetrics(namespace string) *Metrics {
 	}
 
 	prometheus.MustRegister(m.dialedNodeRecordsTotal)
+	prometheus.MustRegister(m.dialFailuresTotal)
 	prometheus.MustRegister(m.activeDialingNodeRecords)
 
 	return m
@@ -29,6 +36,10 @@ func NewMetrics(namespace string) *Metrics {
 
 func (m *Metrics) AddDialedNodeRecod(count int, result, layer string) {
 	m.dialedNodeRecordsTotal.WithLabelValues(result, layer).Add(float64(count))
+}
+
+func (m *Metrics) AddDialFailure(count int, layer, reason string) {
+	m.dialFailuresTotal.WithLabelValues(layer, reason).Add(float64(count))
 }
 
 func (m *Metrics) SetActiveDialingNodeRecods(count int, layer string) {

--- a/pkg/discovery/p2p/static/config.go
+++ b/pkg/discovery/p2p/static/config.go
@@ -8,9 +8,13 @@ import (
 // ExecutionConfig holds configuration for execution layer node discovery dialing.
 type ExecutionConfig struct {
 	// RetryAttempts is the maximum number of retry attempts for dialing a peer.
-	RetryAttempts uint `yaml:"retryAttempts" default:"5"`
-	// RetryDelay is the delay between retry attempts.
-	RetryDelay time.Duration `yaml:"retryDelay" default:"5s"`
+	// Execution clients throttle repeat connections from the same IP (30s for
+	// geth/erigon/reth, 5m per /24 for nethermind), so rapid in-process retries
+	// are rejected before the handshake; rely on rediscovery instead.
+	RetryAttempts uint `yaml:"retryAttempts" default:"1"`
+	// RetryDelay is the delay between retry attempts, when retries are enabled.
+	// Must exceed the remote client's same-IP reconnect throttle to be useful.
+	RetryDelay time.Duration `yaml:"retryDelay" default:"60s"`
 	// DialTimeout is the timeout for dialing a peer.
 	DialTimeout time.Duration `yaml:"dialTimeout" default:"15s"`
 	// BootstrapRPCURL is an optional execution JSON-RPC endpoint used to build

--- a/pkg/discovery/p2p/status.go
+++ b/pkg/discovery/p2p/status.go
@@ -22,7 +22,13 @@ import (
 const (
 	topicExecutionStatus = "execution_status"
 	topicConsensusStatus = "consensus_status"
+
+	dialFailureTimeout  = "timeout"
+	dialFailureCanceled = "canceled"
+	dialFailureError    = "dial_error"
 )
+
+var errDialTimeout = errors.New(dialFailureTimeout)
 
 type Status struct {
 	config           *Config
@@ -168,6 +174,10 @@ func (s *Status) AddExecutionNodeRecords(ctx context.Context, nodeRecords []stri
 
 							s.metrics.AddDialedNodeRecod(1, status, "execution")
 
+							if !connected {
+								s.metrics.AddDialFailure(1, "execution", executionDialFailureReason(peer, response))
+							}
+
 							if err = peer.Stop(s.ctx); err != nil {
 								s.log.WithError(err).WithContext(ctx).Warn("failed to stop peer")
 							}
@@ -186,7 +196,7 @@ func (s *Status) AddExecutionNodeRecords(ctx context.Context, nodeRecords []stri
 					select {
 					case response = <-disconnect:
 					case <-timer.C:
-						response = errors.New("timeout")
+						response = errDialTimeout
 					case <-s.ctx.Done():
 						response = s.ctx.Err()
 					}
@@ -314,7 +324,7 @@ func (s *Status) AddConsensusNodeRecords(_ context.Context, nodeRecords []string
 			select {
 			case response = <-disconnect:
 			case <-timer.C:
-				response = errors.New("timeout")
+				response = errDialTimeout
 			case <-s.ctx.Done():
 				response = s.ctx.Err()
 			}
@@ -356,7 +366,7 @@ func (s *Status) OnExecutionStatus(ctx context.Context, handler func(ctx context
 		}
 
 		// exclude execution status for fork id hashes that are not in the list
-		if len(forkIdHashes) > 0 && !slices.Contains(forkIdHashes, fmt.Sprintf("0x%x", status.ForkId.Hash)) {
+		if len(forkIdHashes) > 0 && !slices.Contains(forkIdHashes, fmt.Sprintf("0x%x", status.GetForkId().GetHash())) {
 			s.log.WithField("fork_id_hash", fmt.Sprintf("0x%x", status.GetForkId().GetHash())).WithContext(ctx).Warn("skipping execution status for fork id hash")
 
 			return
@@ -370,4 +380,27 @@ func (s *Status) OnConsensusStatus(ctx context.Context, handler func(ctx context
 	s.broker.On(topicConsensusStatus, func(status *xatu.ConsensusNodeStatus) {
 		s.handleSubscriberError(handler(ctx, status), topicConsensusStatus)
 	})
+}
+
+// executionDialFailureReason maps a failed dial attempt to a bounded metric
+// label: the remote's devp2p disconnect reason when one was received,
+// otherwise a coarse local classification.
+func executionDialFailureReason(peer *ExecutionPeer, response error) string {
+	if reason := peer.DisconnectReason(); reason != "" {
+		return reason
+	}
+
+	if response == nil {
+		return dialFailureError
+	}
+
+	if errors.Is(response, context.Canceled) || errors.Is(response, context.DeadlineExceeded) {
+		return dialFailureCanceled
+	}
+
+	if errors.Is(response, errDialTimeout) {
+		return dialFailureTimeout
+	}
+
+	return dialFailureError
 }

--- a/pkg/discovery/p2p/status_test.go
+++ b/pkg/discovery/p2p/status_test.go
@@ -1,0 +1,56 @@
+package p2p
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionDialFailureReason(t *testing.T) {
+	tests := []struct {
+		name             string
+		disconnectReason string
+		response         error
+		want             string
+	}{
+		{
+			name:             "remote disconnect reason wins",
+			disconnectReason: "too many peers",
+			response:         errors.New("disconnected from peer (reason too many peers)"),
+			want:             "too many peers",
+		},
+		{
+			name:     "timeout",
+			response: errDialTimeout,
+			want:     dialFailureTimeout,
+		},
+		{
+			name:     "context canceled",
+			response: context.Canceled,
+			want:     dialFailureCanceled,
+		},
+		{
+			name:     "dial error",
+			response: errors.New("connection refused"),
+			want:     dialFailureError,
+		},
+		{
+			name: "no response",
+			want: dialFailureError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer := &ExecutionPeer{}
+
+			if tt.disconnectReason != "" {
+				peer.disconnectReason.Store(&tt.disconnectReason)
+			}
+
+			require.Equal(t, tt.want, executionDialFailureReason(peer, tt.response))
+		})
+	}
+}

--- a/pkg/discovery/p2p/xatu/config.go
+++ b/pkg/discovery/p2p/xatu/config.go
@@ -9,9 +9,13 @@ import (
 // ExecutionConfig holds configuration for execution layer node discovery dialing.
 type ExecutionConfig struct {
 	// RetryAttempts is the maximum number of retry attempts for dialing a peer.
-	RetryAttempts uint `yaml:"retryAttempts" default:"5"`
-	// RetryDelay is the delay between retry attempts.
-	RetryDelay time.Duration `yaml:"retryDelay" default:"5s"`
+	// Execution clients throttle repeat connections from the same IP (30s for
+	// geth/erigon/reth, 5m per /24 for nethermind), so rapid in-process retries
+	// are rejected before the handshake; rely on rediscovery instead.
+	RetryAttempts uint `yaml:"retryAttempts" default:"1"`
+	// RetryDelay is the delay between retry attempts, when retries are enabled.
+	// Must exceed the remote client's same-IP reconnect throttle to be useful.
+	RetryDelay time.Duration `yaml:"retryDelay" default:"60s"`
 	// DialTimeout is the timeout for dialing a peer.
 	DialTimeout time.Duration `yaml:"dialTimeout" default:"15s"`
 	// BootstrapRPCURL is an optional execution JSON-RPC endpoint used to build

--- a/pkg/mimicry/p2p/execution/event_node_record.go
+++ b/pkg/mimicry/p2p/execution/event_node_record.go
@@ -1,0 +1,58 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/ethpandaops/xatu/pkg/proto/noderecord"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+// createNodeRecordEvent converts the status captured during the eth handshake
+// into a NODE_RECORD_EXECUTION event, matching the shape emitted by the
+// discovery module so both feed the same pipeline.
+func (p *Peer) createNodeRecordEvent(ctx context.Context, status *xatu.ExecutionNodeStatus) (*xatu.DecoratedEvent, error) {
+	meta, err := p.createNewClientMeta(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+
+	capabilities := make([]string, 0, len(status.GetCapabilities()))
+	for _, capability := range status.GetCapabilities() {
+		capabilities = append(capabilities, fmt.Sprintf("%s/%d", capability.GetName(), capability.GetVersion()))
+	}
+
+	executionData := &noderecord.Execution{
+		Enr:             &wrapperspb.StringValue{Value: status.GetNodeRecord()},
+		Timestamp:       timestamppb.New(now),
+		Name:            &wrapperspb.StringValue{Value: status.GetName()},
+		Capabilities:    &wrapperspb.StringValue{Value: strings.Join(capabilities, ",")},
+		ProtocolVersion: &wrapperspb.StringValue{Value: fmt.Sprintf("%d", status.GetProtocolVersion())},
+		Head:            &wrapperspb.StringValue{Value: fmt.Sprintf("0x%x", status.GetHead())},
+		Genesis:         &wrapperspb.StringValue{Value: fmt.Sprintf("0x%x", status.GetGenesis())},
+		ForkIdHash:      &wrapperspb.StringValue{Value: fmt.Sprintf("0x%x", status.GetForkId().GetHash())},
+		ForkIdNext:      &wrapperspb.StringValue{Value: fmt.Sprintf("%d", status.GetForkId().GetNext())},
+	}
+
+	return &xatu.DecoratedEvent{
+		Event: &xatu.Event{
+			Name:     xatu.Event_NODE_RECORD_EXECUTION,
+			DateTime: timestamppb.New(now),
+			Id:       uuid.New().String(),
+		},
+		Meta: &xatu.Meta{
+			Client: meta,
+		},
+		Data: &xatu.DecoratedEvent_NodeRecordExecution{
+			NodeRecordExecution: executionData,
+		},
+	}, nil
+}

--- a/pkg/mimicry/p2p/execution/event_node_record_test.go
+++ b/pkg/mimicry/p2p/execution/event_node_record_test.go
@@ -1,0 +1,60 @@
+package execution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/xatu/pkg/mimicry/p2p/handler"
+	"github.com/ethpandaops/xatu/pkg/networks"
+	"github.com/ethpandaops/xatu/pkg/proto/xatu"
+)
+
+func TestCreateNodeRecordEvent(t *testing.T) {
+	p := &Peer{
+		handlers: &handler.Peer{
+			CreateNewClientMeta: func(_ context.Context) (*xatu.ClientMeta, error) {
+				return &xatu.ClientMeta{Name: "test-mimicry"}, nil
+			},
+		},
+		network: &networks.Network{Name: networks.NetworkNameMainnet, ID: 1},
+		forkID:  &xatu.ForkID{Hash: "0xf0afd0e3", Next: "0"},
+	}
+
+	status := &xatu.ExecutionNodeStatus{
+		NodeRecord:      "enr:-test",
+		Name:            "Geth/v1.16.0-stable/linux-amd64/go1.24.0",
+		NetworkId:       1,
+		ProtocolVersion: 5,
+		Capabilities: []*xatu.ExecutionNodeStatus_Capability{
+			{Name: "eth", Version: 68},
+			{Name: "snap", Version: 1},
+		},
+		Head:    []byte{0xab, 0xcd},
+		Genesis: []byte{0x12, 0x34},
+		ForkId: &xatu.ExecutionNodeStatus_ForkID{
+			Hash: []byte{0xf0, 0xaf, 0xd0, 0xe3},
+			Next: 0,
+		},
+	}
+
+	event, err := p.createNodeRecordEvent(context.Background(), status)
+	require.NoError(t, err)
+
+	require.Equal(t, xatu.Event_NODE_RECORD_EXECUTION, event.GetEvent().GetName())
+	require.NotEmpty(t, event.GetEvent().GetId())
+	require.Equal(t, "test-mimicry", event.GetMeta().GetClient().GetName())
+	require.Equal(t, "mainnet", event.GetMeta().GetClient().GetEthereum().GetNetwork().GetName())
+
+	data := event.GetNodeRecordExecution()
+	require.NotNil(t, data)
+	require.Equal(t, "enr:-test", data.GetEnr().GetValue())
+	require.Equal(t, "Geth/v1.16.0-stable/linux-amd64/go1.24.0", data.GetName().GetValue())
+	require.Equal(t, "eth/68,snap/1", data.GetCapabilities().GetValue())
+	require.Equal(t, "5", data.GetProtocolVersion().GetValue())
+	require.Equal(t, "0xabcd", data.GetHead().GetValue())
+	require.Equal(t, "0x1234", data.GetGenesis().GetValue())
+	require.Equal(t, "0xf0afd0e3", data.GetForkIdHash().GetValue())
+	require.Equal(t, "0", data.GetForkIdNext().GetValue())
+}

--- a/pkg/mimicry/p2p/execution/execution.go
+++ b/pkg/mimicry/p2p/execution/execution.go
@@ -209,29 +209,29 @@ func (p *Peer) Start(ctx context.Context) (<-chan error, error) {
 	})
 
 	p.client.OnStatus(ctx, func(ctx context.Context, status mimicry.Status) error {
+		s := &xatu.ExecutionNodeStatus{NodeRecord: p.nodeRecord}
+
+		s.Name = p.name
+		s.ProtocolVersion = p.protocolVersion
+
+		if p.capabilities != nil {
+			for _, cap := range *p.capabilities {
+				s.Capabilities = append(s.Capabilities, &xatu.ExecutionNodeStatus_Capability{
+					Name:    cap.Name,
+					Version: uint32(cap.Version), //nolint:gosec // devp2p capability versions are small protocol numbers.
+				})
+			}
+		}
+
+		s.NetworkId = status.GetNetworkID()
+		s.Head = status.GetHead()
+		s.Genesis = status.GetGenesis()
+		s.ForkId = &xatu.ExecutionNodeStatus_ForkID{
+			Hash: status.GetForkIDHash(),
+			Next: status.GetForkIDNext(),
+		}
+
 		if p.handlers.ExecutionStatus != nil {
-			s := &xatu.ExecutionNodeStatus{NodeRecord: p.nodeRecord}
-
-			s.Name = p.name
-			s.ProtocolVersion = p.protocolVersion
-
-			if p.capabilities != nil {
-				for _, cap := range *p.capabilities {
-					s.Capabilities = append(s.Capabilities, &xatu.ExecutionNodeStatus_Capability{
-						Name:    cap.Name,
-						Version: uint32(cap.Version),
-					})
-				}
-			}
-
-			s.NetworkId = status.GetNetworkID()
-			s.Head = status.GetHead()
-			s.Genesis = status.GetGenesis()
-			s.ForkId = &xatu.ExecutionNodeStatus_ForkID{
-				Hash: status.GetForkIDHash(),
-				Next: status.GetForkIDNext(),
-			}
-
 			if serr := p.handlers.ExecutionStatus(ctx, s); serr != nil {
 				p.log.WithError(serr).WithContext(ctx).Error("failed to handle execution status")
 			}
@@ -272,6 +272,15 @@ func (p *Peer) Start(ctx context.Context) (<-chan error, error) {
 			"fork_id_hash": "0x" + fmt.Sprintf("%x", status.GetForkIDHash()),
 			"fork_id_next": fmt.Sprintf("%d", status.GetForkIDNext()),
 		}).WithContext(ctx).Debug("got client status")
+
+		if p.handlers.DecoratedEvent != nil {
+			nodeRecordEvent, nrErr := p.createNodeRecordEvent(ctx, s)
+			if nrErr != nil {
+				p.log.WithError(nrErr).WithContext(ctx).Error("failed to create node record event")
+			} else if nrErr := p.handlers.DecoratedEvent(ctx, nodeRecordEvent); nrErr != nil {
+				p.log.WithError(nrErr).WithContext(ctx).Error("failed to publish node record event")
+			}
+		}
 
 		p.markConnectedMetric()
 


### PR DESCRIPTION
Mimicry now emits a `NODE_RECORD_EXECUTION` event for every execution peer it completes an eth handshake with, using the same event shape as discovery. Previously these statuses only went to the coordinator gRPC API and the ClickHouse emission was a `// TODO`, so mimicry's live sessions (~370 connected mainnet peers right now) never appeared in `node_record_execution`.

Discovery changes: a new `xatu_discovery_dial_failures_total{layer, reason}` metric records the remote's devp2p disconnect reason for failed dials, and the execution dial defaults drop from 5 retries at 5s to a single attempt (60s delay when retries are configured). EL clients throttle repeat connections from the same IP (30s for geth/erigon/reth, 5 minutes per /24 for nethermind), so retries spaced closer than that are rejected before the handshake and just burn dial slots.

Verified end-to-end by running mimicry with a static coordinator against 15 recently-seen mainnet ENRs: 7 peers completed handshakes and each produced a full `NODE_RECORD_EXECUTION` event (client name, capabilities, fork id, head) with correct mainnet client meta.

https://claude.ai/code/session_012bukTEk683JovCbksWyFp8